### PR TITLE
fix: Theme invalidates when using antd/lib

### DIFF
--- a/components/_util/import-from-antd.ts
+++ b/components/_util/import-from-antd.ts
@@ -1,0 +1,3 @@
+export { useToken as useAntdToken } from 'antd/es/theme/internal';
+export type { AliasToken, SeedToken } from 'antd/es/theme/internal';
+

--- a/components/theme/cssinjs-utils.ts
+++ b/components/theme/cssinjs-utils.ts
@@ -1,3 +1,7 @@
+
+
+import type { CSSInterpolation } from '@ant-design/cssinjs';
+import type { AnyObject } from '../_util/type';
 import type {
   GlobalToken as GlobalTokenTypeUtil,
   OverrideTokenMap as OverrideTokenTypeUtil,
@@ -6,37 +10,24 @@ import type {
   GenStyleFn as GenStyleFnTypeUtil,
   TokenMapKey,
 } from '@ant-design/cssinjs-utils';
-
+import type { AliasToken } from '../_util/import-from-antd';
 import type { ComponentTokenMap } from './components';
-import type { AnyObject } from '../_util/type';
-import type { CSSInterpolation } from '@ant-design/cssinjs';
 
 /** Final token which contains the components level override */
-export type GlobalToken = GlobalTokenTypeUtil<ComponentTokenMap, AnyObject>;
+export type GlobalToken = GlobalTokenTypeUtil<ComponentTokenMap, AliasToken>;
 
-export type OverrideToken = OverrideTokenTypeUtil<ComponentTokenMap, AnyObject>;
+export type OverrideToken = OverrideTokenTypeUtil<ComponentTokenMap, AliasToken>;
 
 export type OverrideComponent = TokenMapKey<ComponentTokenMap>;
 
-export type FullToken<C extends TokenMapKey<ComponentTokenMap>> = FullTokenTypeUtil<
-  ComponentTokenMap,
-  AnyObject,
-  C
->;
+export type FullToken<C extends TokenMapKey<ComponentTokenMap>> = FullTokenTypeUtil<ComponentTokenMap, AliasToken, C>;
 
-export type GetDefaultToken<C extends TokenMapKey<ComponentTokenMap>> = GetDefaultTokenTypeUtil<
-  ComponentTokenMap,
-  AnyObject,
-  C
->;
+export type GetDefaultToken<C extends TokenMapKey<ComponentTokenMap>> = GetDefaultTokenTypeUtil<ComponentTokenMap, AliasToken, C>;
 
-export type GenStyleFn<C extends TokenMapKey<ComponentTokenMap>> = GenStyleFnTypeUtil<
-  ComponentTokenMap,
-  AnyObject,
-  C
->;
+export type GenStyleFn<C extends TokenMapKey<ComponentTokenMap>> = GenStyleFnTypeUtil<ComponentTokenMap, AliasToken, C>;
 
 export type GenerateStyle<
-  ComponentToken extends AnyObject = AnyObject,
+  ComponentToken extends AnyObject = AliasToken,
   ReturnType = CSSInterpolation,
 > = (token: ComponentToken) => ReturnType;
+

--- a/components/theme/genStyleUtils.ts
+++ b/components/theme/genStyleUtils.ts
@@ -1,8 +1,7 @@
 import { genStyleUtils } from '@ant-design/cssinjs-utils';
 import type { ComponentTokenMap } from './components';
-
-import useAntdToken from 'antd/es/theme/useToken';
-import type { AliasToken, SeedToken } from 'antd/es/theme/internal';
+import { useAntdToken } from '../_util/import-from-antd';
+import type { AliasToken, SeedToken } from '../_util/import-from-antd';
 import useConfigContext from '../config-provider/useConfigContext';
 
 export const { genStyleHooks, genComponentStyleHook, genSubStyleComponent } = genStyleUtils<

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,17 @@ function externalCssinjs(config) {
   config.resolve.alias['@ant-design/cssinjs'] = path.resolve(__dirname, 'alias/cssinjs');
 }
 
+function addAntdAlias(config) {
+  config.resolve = config.resolve || {};
+  config.resolve.alias = config.resolve.alias || {};
+
+  if (process.env.ESBUILD || process.env.CSB_REPO) {
+    config.resolve.alias['antd/es/theme/internal'] = path.resolve(__dirname, 'node_modules/antd/es/theme/internal');
+  } else {
+    config.resolve.alias['antd/es/theme/internal'] = path.resolve(__dirname, 'node_modules/antd/lib/theme/internal');
+  }
+}
+
 let webpackConfig = getWebpackConfig(false);
 
 // Used for `size-limit` ci which only need to check min files
@@ -46,6 +57,7 @@ if (process.env.RUN_ENV === 'PRODUCTION') {
     addLocales(config);
     externalDayjs(config);
     externalCssinjs(config);
+    addAntdAlias(config);
 
     // Reduce non-minified dist files size
     config.optimization.usedExports = true;


### PR DESCRIPTION
fix: Theme invalidates when using antd/lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the import path for the `useAntdToken` function to enhance performance and reduce bundle size.
	- Introduced a new utility for streamlined imports from Ant Design, improving modularity and naming consistency.
	- Enhanced type definitions across various components for better type safety and clarity.
	- Modified Webpack configuration to support flexible module resolution based on the build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->