### PR TITLE
fix: has cssVar config

### DIFF
--- a/components/theme/genStyleUtils.ts
+++ b/components/theme/genStyleUtils.ts
@@ -3,7 +3,6 @@ import { genStyleUtils } from '@ant-design/cssinjs-utils';
 import { useXProviderContext } from '../x-provider';
 import { useInternalToken } from './useToken';
 
-import { unitless } from 'antd/es/theme/useToken';
 import type { ComponentTokenMap } from './components';
 import type { AliasToken, SeedToken } from './cssinjs-utils';
 


### PR DESCRIPTION
follow up #163

前个 PR 删掉了 css var 的配置使用 antd 默认数据，但是 useGlobalCache 里的 cssVar 并未透出。重新聚合一下。

和 #163  放一起，相当于：
1. 默认不开启 cssVar 防止 XProvider 有无产生的样式内容不同
2. 将 cssVar 配置挪入 useGlobalCache 实现 cssVar 配置填充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了主题令牌管理的功能，增强了CSS变量的配置选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->