### PR TITLE
fix: Sender.Header can not focus

### DIFF
--- a/components/sender/__tests__/index.test.tsx
+++ b/components/sender/__tests__/index.test.tsx
@@ -109,4 +109,28 @@ describe('Sender Component', () => {
       expect(onSubmit).toHaveBeenCalledWith('bamboo');
     });
   });
+
+  it('Sender.Header can be focus', () => {
+    const { container } = render(
+      <Sender
+        header={
+          <Sender.Header open>
+            <input className="target" />
+          </Sender.Header>
+        }
+      />,
+    );
+
+    const inputEle = container.querySelector<HTMLInputElement>('.target')!;
+    inputEle.focus();
+    expect(document.activeElement).toEqual(inputEle);
+
+    // Click on the header
+    fireEvent.mouseDown(container.querySelector('.ant-sender-header')!);
+    expect(document.activeElement).toEqual(inputEle);
+
+    // Click on the content
+    fireEvent.mouseDown(container.querySelector('.ant-sender-content')!);
+    expect(document.activeElement).toEqual(container.querySelector('textarea'));
+  });
 });

--- a/components/sender/index.tsx
+++ b/components/sender/index.tsx
@@ -211,7 +211,7 @@ function Sender(props: SenderProps, ref: React.Ref<HTMLDivElement>) {
   };
 
   // ============================ Focus =============================
-  const onInternalMouseDown: React.MouseEventHandler<HTMLDivElement> = (e) => {
+  const onContentMouseDown: React.MouseEventHandler<HTMLDivElement> = (e) => {
     // If input focused but click on the container,
     // input will lose focus.
     // We call `preventDefault` to prevent this behavior
@@ -250,14 +250,13 @@ function Sender(props: SenderProps, ref: React.Ref<HTMLDivElement>) {
       ref={mergedContainerRef}
       className={mergedCls}
       style={{ ...contextConfig.style, ...style }}
-      onMouseDown={onInternalMouseDown}
     >
       {/* Header */}
       {header && (
         <SendHeaderContext.Provider value={{ prefixCls }}>{header}</SendHeaderContext.Provider>
       )}
 
-      <div className={`${prefixCls}-content`}>
+      <div className={`${prefixCls}-content`} onMouseDown={onContentMouseDown}>
         {/* Prefix */}
         {prefix && (
           <div


### PR DESCRIPTION
content 点击会强制聚焦到 TextArea 上，导致 Header 不能点，调整一下逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了`Sender`组件的焦点管理，确保在与头部和内容区域交互时，输入框能够正确接收焦点。

- **测试**
  - 为`Sender.Header`组件新增了测试用例，验证输入框的焦点行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->