### PR TITLE
chore: create size-limit.yml

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: bun
-          build_script: dist
+          build_script: compile
         env:
           NODE_OPTIONS: --max_old_space_size=4096
           PRODUCTION_ONLY: 1

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -24,7 +24,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: bun
           build_script: compile
-        env:
-          NODE_OPTIONS: --max_old_space_size=4096
-          PRODUCTION_ONLY: 1
-          CI_JOB_NUMBER: 1

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,0 +1,30 @@
+name: 📦 Size Limit
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  size:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: size-limit
+        uses: ant-design/size-limit-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          package_manager: bun
+          build_script: dist
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          PRODUCTION_ONLY: 1
+          CI_JOB_NUMBER: 1

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   },
   "size-limit": [
     {
-      "path": "./dist/antd-x.min.js",
+      "path": "./dist/antdx.min.js",
       "limit": "350 KiB"
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了新的 GitHub Actions 工作流 `size-limit`，用于在拉取请求时执行大小限制检查。
  - 更新了 `size-limit` 配置中最小化 JavaScript 文件的路径，从 `"./dist/antd-x.min.js"` 更改为 `"./dist/antdx.min.js"`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->