### PR TITLE
perf: Update browser targets

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -19,22 +19,13 @@ class CodecovWebpackPlugin {
 
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
-  targets: {
-    chrome: 80,
-  },
   esm: {
     input: 'components/',
     ignores: ['**/demo/**', '**/__tests__/**'],
-    targets: {
-      chrome: 80,
-    },
   },
   cjs: {
     input: 'components/',
     ignores: ['**/demo/**', '**/__tests__/**'],
-    targets: {
-      chrome: 80,
-    },
   },
   umd: {
     entry: 'components/index.ts',
@@ -42,6 +33,9 @@ export default defineConfig({
     output: {
       path: 'dist/',
       filename: 'antdx',
+    },
+    targets: {
+      chrome: 80,
     },
     sourcemap: true,
     generateUnminified: true,

--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -19,6 +19,9 @@ class CodecovWebpackPlugin {
 
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
+  targets: {
+    chrome: 80,
+  },
   esm: {
     input: 'components/',
     ignores: ['**/demo/**', '**/__tests__/**'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "noImplicitAny": true,
-    "target": "es2020",
+    "target": "ESNext",
     "lib": ["dom", "es2020"],
     "skipLibCheck": true,
     "stripInternal": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "noImplicitAny": true,
-    "target": "ESNext",
+    "target": "es2020",
     "lib": ["dom", "es2020"],
     "skipLibCheck": true,
     "stripInternal": true,


### PR DESCRIPTION
UMD 没必要兼容到 IE11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 在UMD配置中添加了针对Chrome 80的目标属性。
- **变更**
  - 从ESM和CJS配置中移除了针对Chrome 80的目标属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->