### PR TITLE
docs: add link of Next.js docs

### DIFF
--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -50,7 +50,7 @@ const Home = () => (
 export default Home;
 ```
 
-You should now see the Bubble component from `@ant-design/x` on your page. You can proceed to use other components to develop your application. For other development processes, you can refer to the [official Next.js documentation](https://nextjs.org/).
+You should now see the Bubble component from `@ant-design/x` on your page. You can proceed to use other components to develop your application. For other development processes, you can refer to the [official Next.js documentation](https://nextjs.org/docs).
 
 You may notice that the `@ant-design/x` component does not have styles on the first screen. Below, we'll address how to handle SSR (Server-Side Rendering) styles for Next.js.
 

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -46,7 +46,7 @@ const Home = () => (
 export default Home;
 ```
 
-好了，现在你应该能看到页面上已经有了 `@ant-design/x` 的气泡组件，接下来就可以继续选用其他组件开发应用了。其他开发流程你可以参考 Next.js 的[官方文档](https://nextjs.org/)。
+好了，现在你应该能看到页面上已经有了 `@ant-design/x` 的气泡组件，接下来就可以继续选用其他组件开发应用了。其他开发流程你可以参考 Next.js 的[官方文档](https://nextjs.org/docs)。
 
 细心的朋友可以发现这时引入的 @ant-design/x 组件在首屏并没有样式，下面就需要根据 Next.js 的模式来选择不同的 SSR 样式处理方式。
 


### PR DESCRIPTION
添加了 nextjs 文档的直接链接

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档更新**
	- 更新了《在 Next.js 中使用》文档，以反映 `@ant-design/x` 组件库在 Next.js 应用中的使用变化。
	- 明确了安装说明，强调使用 `yarn`、`pnpm` 或 `bun` 等包管理器。
	- 更新了导入 `@ant-design/x` 的说明，并添加了指向官方 Next.js 文档的链接。
	- 添加了关于使用 App Router 和 Pages Router 的新章节，提供了更详细的集成步骤和示例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->