### PR TITLE
chore: replace github-contributors-lists plugin

### DIFF
--- a/.dumi/theme/slots/Content/ContributorAvatar.tsx
+++ b/.dumi/theme/slots/Content/ContributorAvatar.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import type { AvatarListItem } from '@qixian.cs/github-contributors-list/dist/AvatarList';
 import { Avatar, Skeleton, Tooltip } from 'antd';
+import type { AvatarListItem } from 'github-contributors-lists';
+import React from 'react';
 
 const AvatarPlaceholder: React.FC<{ num?: number }> = ({ num = 3 }) => (
   <li>

--- a/.dumi/theme/slots/Content/Contributors.tsx
+++ b/.dumi/theme/slots/Content/Contributors.tsx
@@ -1,7 +1,7 @@
-import ContributorsList from '@qixian.cs/github-contributors-list';
 import { createStyles } from 'antd-style';
 import classNames from 'classnames';
 import { useIntl } from 'dumi';
+import ContributorsList from 'github-contributors-lists';
 import React, { useContext } from 'react';
 
 import SiteContext from '../SiteContext';

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@microflash/rehype-figure": "^2.1.1",
     "@npmcli/run-script": "^9.0.1",
     "@octokit/rest": "^21.0.2",
-    "@qixian.cs/github-contributors-list": "^2.0.2",
+    "github-contributors-lists": "^1.0.3",
     "@rc-component/father-plugin": "1.2.0-alpha.0",
     "@rc-component/trigger": "^2.2.3",
     "@size-limit/file": "^11.1.5",


### PR DESCRIPTION
文档中贡献者头像无法显示，原因可能是 主分支为 main，antd 的是 master 分支所以不会有问题，虽然当时也 pr 加上了 main分支的设置，但是好像也会有这样子问题。所以当时换了个api 接口开发了个插件，[web3.ant.design](https://web3.ant.design/)目前的的贡献者头像就是用这个插件(https://github.com/thinkasany/contributors-list)



before：
![image](https://github.com/user-attachments/assets/26329445-197d-4c75-8eaa-ebd6e9da2675)

after：
![image](https://github.com/user-attachments/assets/484477af-026f-4f65-8f3a-2b9836dfee38)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了贡献者头像和贡献者列表组件的导入路径，提升了组件的灵活性和可维护性。

- **Bug 修复**
	- 改进了 `ContributorAvatar` 组件的解构逻辑，确保在未提供 `item` 时不会抛出错误。

- **文档**
	- 更新了 `package.json` 中的依赖项，替换为更通用的 `github-contributors-lists` 包。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->