### PR TITLE
docs: fix import wrap style

### DIFF
--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -1,6 +1,6 @@
 import { EditOutlined, GithubOutlined, HistoryOutlined } from '@ant-design/icons';
 import type { GetProp } from 'antd';
-import { Descriptions, Space, Tooltip, Typography, theme } from 'antd';
+import { Descriptions, Flex, Tooltip, Typography, theme } from 'antd';
 import { createStyles, css } from 'antd-style';
 import kebabCase from 'lodash/kebabCase';
 import React from 'react';
@@ -50,6 +50,7 @@ const useStyle = createStyles(({ token }) => ({
     transition: all ${token.motionDurationSlow} !important;
     font-family: ${token.codeFamily};
     color: ${token.colorTextSecondary} !important;
+    white-space: nowrap;
     &:hover {
       background: ${token.controlItemBgHover};
     }
@@ -166,7 +167,7 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
                   title={copied ? locale.copied : locale.copy}
                   onOpenChange={onOpenChange}
                 >
-                  <Typography.Text className={styles.code} onClick={onCopy}>
+                  <Typography.Text className={styles.code} ellipsis onClick={onCopy}>
                     {importList}
                   </Typography.Text>
                 </Tooltip>
@@ -185,7 +186,7 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
           filename && {
             label: locale.docs,
             children: (
-              <Space size="middle">
+              <Flex gap={16}>
                 <Typography.Link
                   className={styles.code}
                   href={`${branchUrl}${filename}`}
@@ -200,7 +201,7 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
                     <span>{locale.changelog}</span>
                   </Typography.Link>
                 </ComponentChangelog>
-              </Space>
+              </Flex>
             ),
           },
           isVersionNumber(version) && {

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -1,4 +1,4 @@
-import { Col, Flex, Space, Typography } from 'antd';
+import { Col, Flex, Typography } from 'antd';
 import classNames from 'classnames';
 import { FormattedMessage, useRouteMeta } from 'dumi';
 import React, { useContext, useLayoutEffect, useMemo, useState } from 'react';
@@ -54,22 +54,20 @@ const Content: React.FC<React.PropsWithChildren> = ({ children }) => {
         </InViewSuspense>
         <article className={classNames(styles.articleWrapper, { rtl: isRTL })}>
           {meta.frontmatter?.title ? (
-            <Flex justify="space-between">
-              <Typography.Title style={{ fontSize: 32, position: 'relative' }}>
-                <Space>
-                  <span>{meta.frontmatter?.title}</span>
-                  <span>{meta.frontmatter?.subtitle}</span>
-                  {!pathname.startsWith('/components/overview') && (
-                    <InViewSuspense fallback={null}>
-                      <EditButton
-                        title={<FormattedMessage id="app.content.edit-page" />}
-                        filename={meta.frontmatter.filename}
-                      />
-                    </InViewSuspense>
-                  )}
-                </Space>
-              </Typography.Title>
-            </Flex>
+            <Typography.Title style={{ fontSize: 32, position: 'relative' }}>
+              <Flex gap={8} wrap>
+                <span>{meta.frontmatter?.title}</span>
+                <span>{meta.frontmatter?.subtitle}</span>
+                {!pathname.startsWith('/components/overview') && (
+                  <InViewSuspense fallback={null}>
+                    <EditButton
+                      title={<FormattedMessage id="app.content.edit-page" />}
+                      filename={meta.frontmatter.filename}
+                    />
+                  </InViewSuspense>
+                )}
+              </Flex>
+            </Typography.Title>
           ) : null}
           <InViewSuspense fallback={null}>
             <DocMeta />


### PR DESCRIPTION
fix https://github.com/ant-design/x/issues/260

<img width="637" alt="图片" src="https://github.com/user-attachments/assets/6f659ec0-2278-49d2-99e4-04661ab8d12a">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了 `ComponentMeta` 和 `Content` 组件的布局，使用 `Flex` 组件替代了 `Space` 组件，提供更灵活的元素排列。
	- 在 `ComponentMeta` 组件中，添加了文本截断功能，以防止导入列表溢出。
- **样式**
	- 简化了标题部分的结构，确保视觉输出保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->