### PR TITLE
docs: fix playground style and enhance user experience

### DIFF
--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -390,11 +390,13 @@ createRoot(document.getElementById('container')).render(<Demo />);
       {!simplify && (
         <section className="code-box-meta markdown">
           <div className="code-box-title">
-            <Tooltip title={originDebug ? <FormattedMessage id="app.demo.debug" /> : ''}>
-              <a href={`#${asset.id}`} ref={anchorRef}>
-                {localizedTitle}
-              </a>
-            </Tooltip>
+            {localizedTitle && (
+              <Tooltip title={originDebug ? <FormattedMessage id="app.demo.debug" /> : ''}>
+                <a href={`#${asset.id}`} ref={anchorRef}>
+                  {localizedTitle}
+                </a>
+              </Tooltip>
+            )}
             <EditButton
               title={<FormattedMessage id="app.content.edit-demo" />}
               filename={filename}

--- a/.dumi/theme/common/EditButton.tsx
+++ b/.dumi/theme/common/EditButton.tsx
@@ -21,6 +21,8 @@ const useStyle = createStyles(({ token, css }) => {
         display: inline-block;
         text-decoration: none;
         vertical-align: middle;
+        pointer-events: auto;
+        z-index: 999;
         margin-inline-start: ${token.marginXS}px;
         ${iconCls} {
           display: block;

--- a/.dumi/theme/common/styles/Demo.tsx
+++ b/.dumi/theme/common/styles/Demo.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { css, Global } from '@emotion/react';
+import { Global, css } from '@emotion/react';
 import { useTheme } from 'antd-style';
+import React from 'react';
 
 const GlobalDemoStyles: React.FC = () => {
   const token = useTheme();
@@ -74,6 +74,7 @@ const GlobalDemoStyles: React.FC = () => {
           &-title {
             position: absolute;
             top: -14px;
+            height: auto;
             padding: 1px 8px;
             color: #777;
             background: ${token.colorBgContainer};
@@ -291,8 +292,8 @@ const GlobalDemoStyles: React.FC = () => {
           }
 
           &-codesandbox {
-            width: 16px;
-            height: 16px;
+            width: 14px;
+            height: 14px;
             overflow: hidden;
             border: 0;
             cursor: pointer;


### PR DESCRIPTION
fix: #254

修复：文档演示页左下角编辑按钮的hover状态得到了修复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `CodePreviewer` 组件的工具提示逻辑，确保仅在存在有效标题时显示链接。
	- 修改了 `EditButton` 组件的样式，使按钮可交互并在视觉上更突出。

- **样式**
	- 调整了 `Demo.tsx` 组件的样式，改变了 `.code-box-title` 和 `.code-sandbox` 的尺寸属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->