### PR TITLE
docs: Improve document syntax

### DIFF
--- a/components/x-provider/index.en-US.md
+++ b/components/x-provider/index.en-US.md
@@ -18,17 +18,17 @@ The `XProvider` extends the `ConfigProvider` from `antd` and provides global con
 
 If you are already using `ConfigProvider` from `antd`, please make the following changes to your code:
 
-```tsx
+```diff
 - import { ConfigProvider } from 'antd';
 + import { XProvider } from '@ant-design/x';
 
-- <ConfigProvider>
-- // ...
-- </ConfigProvider>
-
-+ <XProvider>
-+ // ...
-+ </XProvider>
+  const App = () => (
+-   <ConfigProvider>
++   <XProvider>
+      <YourApp />
+-   </ConfigProvider>
++   </XProvider>
+  );
 ```
 
 ## Examples

--- a/components/x-provider/index.zh-CN.md
+++ b/components/x-provider/index.zh-CN.md
@@ -19,17 +19,17 @@ demo:
 
 如果您已经使用 `antd` 的 `ConfigProvider`，请对您的代码做如下变更：
 
-```tsx
+```diff
 - import { ConfigProvider } from 'antd';
 + import { XProvider } from '@ant-design/x';
 
-- <ConfigProvider {...configProps}>
-- // ...
-- </ConfigProvider>
-
-+ <XProvider {...configProps}>
-+ // ...
-+ </XProvider>
+  const App = () => (
+-   <ConfigProvider>
++   <XProvider>
+      <YourApp />
+-   </ConfigProvider>
++   </XProvider>
+  );
 ```
 
 ## 代码演示


### PR DESCRIPTION

使用 [```diff`] 改进文档语法~

### before
<img width="943" alt="image" src="https://github.com/user-attachments/assets/8bb589a7-fb10-45fa-a40b-be429db0d133">

### after
<img width="898" alt="image" src="https://github.com/user-attachments/assets/5cb52ab9-1c9d-4b00-8441-d7a856e91bf4">


<!-- 混入我的第一个 PR -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `XProvider` 组件的文档，替换了 `antd` 的 `ConfigProvider`，并提供了新的使用示例。
	- 文档中增加了如何使用 `XProvider` 组件的代码片段，展示了其在应用中的包装方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->