### PR TITLE
feat: add petercat assistant

### DIFF
--- a/.dumi/theme/common/PeterCat.tsx
+++ b/.dumi/theme/common/PeterCat.tsx
@@ -1,0 +1,17 @@
+import { Assistant } from '@petercatai/assistant';
+import React from 'react';
+import '@petercatai/assistant/style';
+
+const PeterCat: React.FC = () => {
+  return (
+    <Assistant
+      showBubble={true}
+      isVisible={false}
+      bottom={48}
+      token="e3092c32-9ed9-44c2-ad0c-7251e382c2df"
+      apiDomain="https://api.petercat.ai"
+    />
+  );
+};
+
+export default PeterCat;

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -29,6 +29,7 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
       icon={<ThemeIcon />}
       aria-label="Theme Switcher"
       badge={{ dot: true }}
+      style={{ bottom: 120 }}
     >
       <Link
         to={getLocalizedPathname('/theme-editor', isZhCN(pathname), search)}

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -18,9 +18,12 @@ import { DarkContext } from '../../hooks/useDark';
 import useLayoutState from '../../hooks/useLayoutState';
 import useLocation from '../../hooks/useLocation';
 import SiteThemeProvider from '../SiteThemeProvider';
+import PeterCat from '../common/PeterCat';
 import type { ThemeName } from '../common/ThemeSwitch';
 import type { SiteContextProps } from '../slots/SiteContext';
 import SiteContext from '../slots/SiteContext';
+
+import '@petercatai/assistant/style';
 
 const ThemeSwitch = React.lazy(() => import('../common/ThemeSwitch'));
 
@@ -203,6 +206,7 @@ const GlobalLayout: React.FC = () => {
             value={theme}
             onChange={(nextTheme) => updateSiteConfig({ theme: nextTheme })}
           />
+          <PeterCat />
         </Suspense>
       </App>
     );

--- a/package.json
+++ b/package.json
@@ -91,13 +91,13 @@
     "@ant-design/fast-color": "^2.0.6",
     "@ant-design/icons": "^5.4.0",
     "@babel/runtime": "^7.25.6",
-    "@petercatai/assistant": "^2.0.2",
     "classnames": "^2.5.1",
     "rc-motion": "^2.9.2",
     "rc-util": "^5.43.0"
   },
   "devDependencies": {
     "@ant-design/tools": "^18.0.2",
+    "@petercatai/assistant": "^2.0.2",
     "@antv/gpt-vis": "^0.3.0",
     "@biomejs/biome": "^1.9.0",
     "@codecov/webpack-plugin": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@ant-design/fast-color": "^2.0.6",
     "@ant-design/icons": "^5.4.0",
     "@babel/runtime": "^7.25.6",
+    "@petercatai/assistant": "^2.0.2",
     "classnames": "^2.5.1",
     "rc-motion": "^2.9.2",
     "rc-util": "^5.43.0"


### PR DESCRIPTION
给 ant-design/x 挂一个基于ant-design/x 封装的 PeterCat 机器人
![image](https://github.com/user-attachments/assets/9b875dfa-3c28-47ca-a4f4-bf2d909f3d7b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了新的 `PeterCat` 组件，集成了助手功能。
  - 更新了 `GlobalLayout` 以包含 `PeterCat` 组件，并增强了主题管理功能。

- **样式调整**
  - 修改了 `ThemeSwitch` 组件的按钮组位置。

- **依赖更新**
  - 添加了新的依赖项 `@petercatai/assistant`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->