### PR TITLE
test: add test case for useSpeech

### DIFF
--- a/components/sender/__tests__/index.test.tsx
+++ b/components/sender/__tests__/index.test.tsx
@@ -138,4 +138,34 @@ describe('Sender Component', () => {
     const { container } = render(<Sender readOnly />);
     expect(container.querySelector('textarea')).toHaveAttribute('readonly');
   });
+
+  describe('allowSpeech', () => {
+    it('allowSpeech prop enables speech input', () => {
+      const { container } = render(<Sender allowSpeech />);
+      const speechButton = container.querySelector('.ant-sender-actions-btn');
+      expect(speechButton).toBeInTheDocument();
+    });
+
+    it('custom speech input using allowSpeech prop', () => {
+      const onRecordingChange = jest.fn();
+      const { container } = render(
+        <Sender
+          allowSpeech={{
+            recording: false,
+            onRecordingChange,
+          }}
+        />,
+      );
+      const speechButton = container.querySelector('.ant-sender-actions-btn');
+      fireEvent.click(speechButton!);
+      expect(onRecordingChange).toHaveBeenCalledWith(true);
+    });
+
+    it('speech button functionality', () => {
+      const { container } = render(<Sender allowSpeech />);
+      const speechButton = container.querySelector('.ant-sender-actions-btn');
+      fireEvent.click(speechButton!);
+      expect(container.querySelector('.ant-sender-actions-btn')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ant-design/x/pull/388?shareId=88711f0a-3277-4d26-928a-9f5a6548066d).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为 `Sender` 组件添加了语音输入功能的测试套件。
  
- **测试**
  - 增加了三个测试来验证 `allowSpeech` 属性的功能，包括语音按钮的渲染、语音输入的行为以及按钮的存在性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->