### PR TITLE
docs(attachments): fix description of overflow demo

### DIFF
--- a/components/attachments/demo/overflow.md
+++ b/components/attachments/demo/overflow.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-修改占位信息。
+控制附件超出区域长度时的展示方式。
 
 ## en-US
 
-Modify placeholder information.
+Controls the layout of attachments when they exceed the area.


### PR DESCRIPTION

The description is repeated.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c780cf65-b658-454f-a8d9-9707e40a2e95" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
	- 更新了附件溢出布局的演示文档
	- 为中英文文档添加了更详细的布局控制说明

<!-- end of auto-generated comment: release notes by coderabbit.ai -->