### PR TITLE
feat: refine useTypedEffect

### DIFF
--- a/components/bubble/hooks/useTypedEffect.ts
+++ b/components/bubble/hooks/useTypedEffect.ts
@@ -15,19 +15,21 @@ const useTypedEffect = (
   typingStep: number,
   typingInterval: number,
 ): [typedContent: React.ReactNode | object, isTyping: boolean] => {
-  const [prevContent, setPrevContent] = React.useState<React.ReactNode | object>('');
+
+  const prevContentRef = React.useRef<React.ReactNode | object>();
+
   const [typingIndex, setTypingIndex] = React.useState<number>(1);
 
   const mergedTypingEnabled = typingEnabled && isString(content);
 
   // Reset typing index when content changed
   useLayoutEffect(() => {
-    setPrevContent(content);
     if (!mergedTypingEnabled && isString(content)) {
       setTypingIndex(content.length);
-    } else if (isString(content) && isString(prevContent) && content.indexOf(prevContent) !== 0) {
+    } else if (isString(content) && isString(prevContentRef.current) && content.indexOf(prevContentRef.current) !== 0) {
       setTypingIndex(1);
     }
+    prevContentRef.current = content;
   }, [content]);
 
   // Start typing

--- a/components/bubble/hooks/useTypedEffect.ts
+++ b/components/bubble/hooks/useTypedEffect.ts
@@ -16,7 +16,7 @@ const useTypedEffect = (
   typingInterval: number,
 ): [typedContent: React.ReactNode | object, isTyping: boolean] => {
 
-  const prevContentRef = React.useRef<React.ReactNode | object>();
+  const prevContentRef = React.useRef<React.ReactNode | object>('');
 
   const [typingIndex, setTypingIndex] = React.useState<number>(1);
 


### PR DESCRIPTION
使用ref代替state，useEffect中的依赖更清晰一些

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
	- 优化了 `useTypedEffect` 钩子的性能，通过使用 ref 替代状态变量来跟踪先前的内容。
	- 改进了内容处理的方式，减少不必要的重新渲染。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->