### PR TITLE
docs(sender): add onPasteFile callback

### DIFF
--- a/components/sender/index.en-US.md
+++ b/components/sender/index.en-US.md
@@ -52,6 +52,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | onSubmit | Callback when click send button | (message: string) => void | - | - |
 | onChange | Callback when input value changes | (value: string, event?: React.FormEvent<`HTMLTextAreaElement`> \| React.ChangeEvent<`HTMLTextAreaElement`> ) => void | - | - |
 | onCancel | Callback when click cancel button | () => void | - | - |
+| onPasteFile | Callback when paste file | (file: File) => void | - | - |
 
 ```typescript | pure
 type SpeechConfig = {

--- a/components/sender/index.zh-CN.md
+++ b/components/sender/index.zh-CN.md
@@ -53,6 +53,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*cOfrS4fVkOMAAA
 | onSubmit | 点击发送按钮的回调 | (message: string) => void | - | - |
 | onChange | 输入框值改变的回调 | (value: string, event?: React.FormEvent<`HTMLTextAreaElement`> \| React.ChangeEvent<`HTMLTextAreaElement`> ) => void | - | - |
 | onCancel | 点击取消按钮的回调 | () => void | - | - |
+| onPasteFile | 黏贴文件的回调 | (file: File) => void | - | - |
 
 ```typescript | pure
 type SpeechConfig = {


### PR DESCRIPTION
Sender 组件文档 [粘贴图片](https://ant-design-x.antgroup.com/components/sender-cn#sender-demo-paste-image) Demo 中使用了 `onPasteFile` 回调，但缺少该回调的说明，故补上

另外
发现缺少 `onPaste` 回调的说明，在一些场景下可能需要该回调，例如：

用户在输入框粘贴一段网址，希望能够解析地址。

![image](https://github.com/user-attachments/assets/7b00f83c-41cd-4d35-946a-e5bf7e3bf76b)

![image](https://github.com/user-attachments/assets/93a6496c-e66b-44eb-bc3c-41d35e120581)

是否可以将 `onPaste` 回调暴露给组件使用者？

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为发送组件添加了文件粘贴事件处理能力
	- 新增 `onPasteFile` 属性，支持在组件中处理文件粘贴操作

<!-- end of auto-generated comment: release notes by coderabbit.ai -->