### PR TITLE
docs(attachments): fix typo

### DIFF
--- a/components/attachments/index.en-US.md
+++ b/components/attachments/index.en-US.md
@@ -3,7 +3,7 @@ category: Components
 group:
   title: Express
   order: 2
-title: Attachment
+title: Attachments
 description: Display the collection of attachment information.
 cover: https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*5l2oSKBXatAAAAAAAAAAAAAADgCCAQ/original
 coverDark: https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*N8QHQJhgfbEAAAAAAAAAAAAADgCCAQ/original
@@ -13,7 +13,7 @@ demo:
 
 ## When To Use
 
-The Prompts component is used to display a predefined set of questions or suggestion that are relevant to the current context.
+The Attachments component is used in scenarios where a set of attachment information needs to be displayed.
 
 ## Examples
 
@@ -26,7 +26,7 @@ The Prompts component is used to display a predefined set of questions or sugges
 
 ## API
 
-### AttachmentProps
+### AttachmentsProps
 
 For more properties, see [Upload](https://ant.design/components/upload).
 
@@ -63,4 +63,4 @@ interface PlaceholderType {
 
 ## Design Token
 
-<ComponentTokenTable component="Prompts"></ComponentTokenTable>
+<ComponentTokenTable component="Attachments"></ComponentTokenTable>

--- a/components/attachments/index.zh-CN.md
+++ b/components/attachments/index.zh-CN.md
@@ -3,7 +3,7 @@ category: Components
 group:
   title: 表达
   order: 2
-title: Attachment
+title: Attachments
 subtitle: 输入附件
 description: 用于展示一组附件信息集合。
 cover: https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*5l2oSKBXatAAAAAAAAAAAAAADgCCAQ/original
@@ -14,7 +14,7 @@ demo:
 
 ## 何时使用
 
-Attachment 组件用于需要展示一组附件信息集合的场景。
+Attachments 组件用于需要展示一组附件信息集合的场景。
 
 ## 代码演示
 
@@ -29,7 +29,7 @@ Attachment 组件用于需要展示一组附件信息集合的场景。
 
 通用属性参考：[通用属性](/docs/react/common-props)。
 
-### AttachmentProps
+### AttachmentsProps
 
 继承 antd [Upload](https://ant.design/components/upload) 属性。
 
@@ -66,4 +66,4 @@ interface PlaceholderType {
 
 ## 主题变量（Design Token）
 
-<ComponentTokenTable component="Prompts"></ComponentTokenTable>
+<ComponentTokenTable component="Attachments"></ComponentTokenTable>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
  - 将组件名称从“Attachment”统一更改为“Attachments”，提高了命名的一致性和清晰度。
  - 更新了组件描述、属性标题以及设计令牌的引用，确保所有语言版本（包括英文和中文）同步调整并准确反映最新信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->