### PR TITLE
docs(attachments): add file-card props description

### DIFF
--- a/components/attachments/index.en-US.md
+++ b/components/attachments/index.en-US.md
@@ -57,6 +57,16 @@ interface PlaceholderType {
 | nativeElement | Get the native node    | HTMLElement          | -       |
 | upload        | Manually upload a file | (file: File) => void | -       |
 
+### Attachments.FileCard Props
+
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| prefixCls | The prefix of the style class name | string | - | - |
+| className | Style class name | string | - | - |
+| style | Style Object | React.CSSProperties | - | - |
+| item | Attachment, same as Upload `UploadFile` | Attachment | - | - |
+| onRemove | Callback function when attachment is removed | (item: Attachment) => void | - | - |
+
 ## Semantic DOM
 
 <code src="./demo/_semantic.tsx" simplify="true"></code>

--- a/components/attachments/index.zh-CN.md
+++ b/components/attachments/index.zh-CN.md
@@ -60,6 +60,16 @@ interface PlaceholderType {
 | nativeElement | 获取原生节点     | HTMLElement          | -    |
 | upload        | 手工调用上传文件 | (file: File) => void | -    |
 
+### Attachments.FileCard Props
+
+| 属性      | 说明                         | 类型                       | 默认值 | 版本 |
+| --------- | ---------------------------- | -------------------------- | ------ | ---- |
+| prefixCls | 样式类名的前缀               | string                     | -      | -    |
+| className | 样式类名                     | string                     | -      | -    |
+| style     | 样式对象                     | React.CSSProperties        | -      | -    |
+| item      | 附件，同 Upload `UploadFile` | Attachment                 | -      | -    |
+| onRemove  | 附件移除时的回调函数         | (item: Attachment) => void | -      | -    |
+
 ## Semantic DOM
 
 <code src="./demo/_semantic.tsx" simplify="true"></code>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 在附件组件的文档中新增了“文件卡属性”说明，提供更灵活的配置选项。
  - 新增的属性包括样式前缀、自定义类名、内联样式设置、文件数据接收以及附件移除事件回调。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->