### PR TITLE
fix: Sender with `actions` missing SpeechButton

### DIFF
--- a/components/sender/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/sender/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1039,7 +1039,6 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
           class="ant-sender-actions-list"
         >
           <button
-            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-sender-actions-btn"
             style="border-radius: 12px;"
             type="button"
@@ -1081,7 +1080,6 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
             >
               <div
                 class="ant-tooltip-inner"
-                id="test-id"
                 role="tooltip"
               >
                 Send ↵
@@ -1108,7 +1106,6 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
           class="ant-sender-actions-list"
         >
           <button
-            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-text ant-btn-icon-only ant-sender-actions-btn"
             type="button"
           >
@@ -1152,7 +1149,6 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
             >
               <div
                 class="ant-tooltip-inner"
-                id="test-id"
                 role="tooltip"
               >
                 Send ↵

--- a/components/sender/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/sender/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -70,6 +70,44 @@ exports[`renders components/sender/demo/actions.tsx extend context correctly 1`]
             class="ant-space-item"
           >
             <button
+              class="ant-btn ant-btn-text ant-btn-color-primary ant-btn-variant-text ant-btn-icon-only ant-sender-actions-btn ant-sender-actions-btn-disabled"
+              type="button"
+            >
+              <span
+                class="ant-btn-icon"
+              >
+                <span
+                  aria-label="audio-muted"
+                  class="anticon anticon-audio-muted"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="audio-muted"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <defs>
+                      <style />
+                    </defs>
+                    <path
+                      d="M682 455V311l-76 76v68c-.1 50.7-42 92.1-94 92a95.8 95.8 0 01-52-15l-54 55c29.1 22.4 65.9 36 106 36 93.8 0 170-75.1 170-168z"
+                    />
+                    <path
+                      d="M833 446h-60c-4.4 0-8 3.6-8 8 0 140.3-113.7 254-254 254-63 0-120.7-23-165-61l-54 54a334.01 334.01 0 00179 81v102H326c-13.9 0-24.9 14.3-25 32v36c.1 4.4 2.9 8 6 8h408c3.2 0 6-3.6 6-8v-36c0-17.7-11-32-25-32H547V782c165.3-17.9 294-157.9 294-328 0-4.4-3.6-8-8-8zm13.1-377.7l-43.5-41.9a8 8 0 00-11.2.1l-129 129C634.3 101.2 577 64 511 64c-93.9 0-170 75.3-170 168v224c0 6.7.4 13.3 1.2 19.8l-68 68A252.33 252.33 0 01258 454c-.2-4.4-3.8-8-8-8h-60c-4.4 0-8 3.6-8 8 0 53 12.5 103 34.6 147.4l-137 137a8.03 8.03 0 000 11.3l42.7 42.7c3.1 3.1 8.2 3.1 11.3 0L846.2 79.8l.1-.1c3.1-3.2 3-8.3-.2-11.4zM417 401V232c0-50.6 41.9-92 94-92 46 0 84.1 32.3 92.3 74.7L417 401z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-space-item"
+          >
+            <button
               class="ant-btn ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-sender-actions-btn"
               type="button"
             >
@@ -1001,6 +1039,7 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
           class="ant-sender-actions-list"
         >
           <button
+            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-sender-actions-btn"
             style="border-radius: 12px;"
             type="button"
@@ -1042,6 +1081,7 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
             >
               <div
                 class="ant-tooltip-inner"
+                id="test-id"
                 role="tooltip"
               >
                 Send ↵
@@ -1068,6 +1108,7 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
           class="ant-sender-actions-list"
         >
           <button
+            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-text ant-btn-icon-only ant-sender-actions-btn"
             type="button"
           >
@@ -1111,6 +1152,7 @@ exports[`renders components/sender/demo/send-style.tsx extend context correctly 
             >
               <div
                 class="ant-tooltip-inner"
+                id="test-id"
                 role="tooltip"
               >
                 Send ↵

--- a/components/sender/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/sender/__tests__/__snapshots__/demo.test.ts.snap
@@ -69,6 +69,44 @@ exports[`renders components/sender/demo/actions.tsx correctly 1`] = `
             class="ant-space-item"
           >
             <button
+              class="ant-btn ant-btn-text ant-btn-color-primary ant-btn-variant-text ant-btn-icon-only ant-sender-actions-btn ant-sender-actions-btn-disabled"
+              type="button"
+            >
+              <span
+                class="ant-btn-icon"
+              >
+                <span
+                  aria-label="audio-muted"
+                  class="anticon anticon-audio-muted"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="audio-muted"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <defs>
+                      <style />
+                    </defs>
+                    <path
+                      d="M682 455V311l-76 76v68c-.1 50.7-42 92.1-94 92a95.8 95.8 0 01-52-15l-54 55c29.1 22.4 65.9 36 106 36 93.8 0 170-75.1 170-168z"
+                    />
+                    <path
+                      d="M833 446h-60c-4.4 0-8 3.6-8 8 0 140.3-113.7 254-254 254-63 0-120.7-23-165-61l-54 54a334.01 334.01 0 00179 81v102H326c-13.9 0-24.9 14.3-25 32v36c.1 4.4 2.9 8 6 8h408c3.2 0 6-3.6 6-8v-36c0-17.7-11-32-25-32H547V782c165.3-17.9 294-157.9 294-328 0-4.4-3.6-8-8-8zm13.1-377.7l-43.5-41.9a8 8 0 00-11.2.1l-129 129C634.3 101.2 577 64 511 64c-93.9 0-170 75.3-170 168v224c0 6.7.4 13.3 1.2 19.8l-68 68A252.33 252.33 0 01258 454c-.2-4.4-3.8-8-8-8h-60c-4.4 0-8 3.6-8 8 0 53 12.5 103 34.6 147.4l-137 137a8.03 8.03 0 000 11.3l42.7 42.7c3.1 3.1 8.2 3.1 11.3 0L846.2 79.8l.1-.1c3.1-3.2 3-8.3-.2-11.4zM417 401V232c0-50.6 41.9-92 94-92 46 0 84.1 32.3 92.3 74.7L417 401z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-space-item"
+          >
+            <button
               class="ant-btn ant-btn-circle ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-sender-actions-btn"
               type="button"
             >
@@ -931,6 +969,7 @@ exports[`renders components/sender/demo/send-style.tsx correctly 1`] = `
           class="ant-sender-actions-list"
         >
           <button
+            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-sender-actions-btn"
             style="border-radius:12px"
             type="button"
@@ -978,6 +1017,7 @@ exports[`renders components/sender/demo/send-style.tsx correctly 1`] = `
           class="ant-sender-actions-list"
         >
           <button
+            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-text ant-btn-icon-only ant-sender-actions-btn"
             type="button"
           >

--- a/components/sender/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/sender/__tests__/__snapshots__/demo.test.ts.snap
@@ -969,7 +969,6 @@ exports[`renders components/sender/demo/send-style.tsx correctly 1`] = `
           class="ant-sender-actions-list"
         >
           <button
-            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-sender-actions-btn"
             style="border-radius:12px"
             type="button"
@@ -1017,7 +1016,6 @@ exports[`renders components/sender/demo/send-style.tsx correctly 1`] = `
           class="ant-sender-actions-list"
         >
           <button
-            aria-describedby="test-id"
             class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-text ant-btn-icon-only ant-sender-actions-btn"
             type="button"
           >

--- a/components/sender/demo/actions.tsx
+++ b/components/sender/demo/actions.tsx
@@ -35,7 +35,7 @@ const Demo: React.FC = () => {
         setLoading(false);
       }}
       actions={(_, info) => {
-        const { SendButton, LoadingButton, ClearButton } = info.components;
+        const { SendButton, LoadingButton, ClearButton, SpeechButton } = info.components;
 
         return (
           <Space size="small">
@@ -43,6 +43,7 @@ const Demo: React.FC = () => {
               <small>`Shift + Enter` to submit</small>
             </Typography.Text>
             <ClearButton />
+            <SpeechButton />
             {loading ? (
               <LoadingButton type="default" icon={<Spin size="small" />} disabled />
             ) : (

--- a/components/sender/index.tsx
+++ b/components/sender/index.tsx
@@ -33,6 +33,7 @@ export type ActionsRender = (
       SendButton: React.ComponentType<ButtonProps>;
       ClearButton: React.ComponentType<ButtonProps>;
       LoadingButton: React.ComponentType<ButtonProps>;
+      SpeechButton: React.ComponentType<ButtonProps>;
     };
   },
 ) => React.ReactNode;
@@ -270,6 +271,7 @@ const ForwardSender = React.forwardRef<SenderRef, SenderProps>((props, ref) => {
         SendButton,
         ClearButton,
         LoadingButton,
+        SpeechButton,
       },
     });
   } else if (actions) {


### PR DESCRIPTION
修复 Sender 的 `actions` 缺少 SpeechButton 组件的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 在发送界面中新增了语音按钮，与现有的操作按钮一起显示，方便用户使用语音输入功能。
  - 语音功能在特定条件下启用，增强了交互体验，用户可在消息发送过程中选择语音输入。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->