### PR TITLE
docs: correct join us url

### DIFF
--- a/.dumi/theme/slots/Footer/index.tsx
+++ b/.dumi/theme/slots/Footer/index.tsx
@@ -243,12 +243,12 @@ const Footer: React.FC = () => {
       col2.items.push({
         icon: <UsergroupAddOutlined />,
         title: <FormattedMessage id="app.footer.work_with_us" />,
-        url: getLink('/docs/resources', {
+        url: `https://ant.design${getLink('/docs/resources', {
           cn: '加入我们',
           en: 'JoinUs',
-        }),
-        LinkComponent: Link,
-      } as unknown as (typeof col2)['items'][number]);
+        })}`,
+        openExternal: true,
+      });
     }
 
     const col3 = {


### PR DESCRIPTION
修正 Footer 中『加入我们』的超链接，目前是 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化了页脚“加入我们”项的链接生成方式，确保在中文环境下正确显示目标链接，并自动在外部浏览器中打开页面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->