### PR TITLE
 fix: Attachments FileList scroll button is not shown

### DIFF
--- a/components/attachments/FileList/index.tsx
+++ b/components/attachments/FileList/index.tsx
@@ -77,7 +77,7 @@ export default function FileList(props: FileListProps) {
 
   React.useEffect(() => {
     checkPing();
-  }, [overflow]);
+  }, [overflow, items]);
 
   const onScrollOffset = (offset: -1 | 1) => {
     const containerEle = containerRef.current;

--- a/components/attachments/FileList/index.tsx
+++ b/components/attachments/FileList/index.tsx
@@ -77,7 +77,7 @@ export default function FileList(props: FileListProps) {
 
   React.useEffect(() => {
     checkPing();
-  }, [overflow, items]);
+  }, [overflow, items.length]);
 
   const onScrollOffset = (offset: -1 | 1) => {
     const containerEle = containerRef.current;


### PR DESCRIPTION
## 问题描述

添加文件后，滚动按钮没有正确地显示出来
![image](https://github.com/user-attachments/assets/09a659e2-13ab-484f-ade0-695bdd414297)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- 优化了附件列表的更新响应逻辑，使界面能在文件项变更时更及时地刷新显示，从而提升整体用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->