### PR TITLE
fix: peerdep antd version needs to be greater than 5.20.3 because of …

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "webpack-bundle-analyzer": "^4.10.2"
   },
   "peerDependencies": {
-    "antd": ">=5.0.0",
+    "antd": "^5.20.3",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },


### PR DESCRIPTION
link [https://github.com/ant-design/x/issues/596](url)
fix antd version error
peerdep antd version needs to be greater than 5.20.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 调整了依赖项的版本要求，确保在引入非破坏性更新时提供更精准的版本管理，进一步提升系统的稳定性与兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->