### PR TITLE
docs: fix attachments docs

### DIFF
--- a/components/attachments/index.en-US.md
+++ b/components/attachments/index.en-US.md
@@ -61,13 +61,13 @@ interface PlaceholderType {
 ### Attachments.FileCard Props
 
 | Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | prefixCls | The prefix of the style class name | string | - | - |
 | className | Style class name | string | - | - |
 | style | Style Object | React.CSSProperties | - | - |
 | item | Attachment, same as Upload `UploadFile` | Attachment | - | - |
 | onRemove | A callback function, will be executed when removing file button is clicked, remove event will be prevented when the return value is false or a Promise which resolve(false) or reject | (item: Attachment) => boolean \| Promise | - | - |
-| imageProps | Image config, same as [Image](https://ant.design/components/image) |  | ImageProps | - | - |
+| imageProps | Image config, same as [Image](https://ant.design/components/image) | ImageProps | - | - |
 
 ## Semantic DOM
 

--- a/components/attachments/index.en-US.md
+++ b/components/attachments/index.en-US.md
@@ -66,8 +66,8 @@ interface PlaceholderType {
 | className | Style class name | string | - | - |
 | style | Style Object | React.CSSProperties | - | - |
 | item | Attachment, same as Upload `UploadFile` | Attachment | - | - |
-| onRemove | A callback function, will be executed when removing file button is clicked, remove event will be prevented when the return value is false or a Promise which resolve(false) or reject | (item: Attachment) => boolean | Promise | - | - |
-| imageProps | Image config, same as [Image](https://ant.design/components/image) | ImageProps | - | - |
+| onRemove | A callback function, will be executed when removing file button is clicked, remove event will be prevented when the return value is false or a Promise which resolve(false) or reject | (item: Attachment) => boolean \| Promise | - | - |
+| imageProps | Image config, same as [Image](https://ant.design/components/image) |  | ImageProps | - | - |
 
 ## Semantic DOM
 

--- a/components/attachments/index.zh-CN.md
+++ b/components/attachments/index.zh-CN.md
@@ -64,12 +64,12 @@ interface PlaceholderType {
 ### Attachments.FileCard Props
 
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | prefixCls | 样式类名的前缀 | string | - | - |
 | className | 样式类名 | string | - | - |
 | style | 样式对象 | React.CSSProperties | - | - |
 | item | 附件，同 Upload `UploadFile` | Attachment | - | - |
-| onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | (item: Attachment) => boolean | Promise | - | - |
+| onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | (item: Attachment) => boolean \| Promise | - | - |
 | imageProps | 图片属性，同 antd [Image](https://ant.design/components/image) 属性 | ImageProps | - | - |
 
 ## Semantic DOM


### PR DESCRIPTION
修复文档格式冲突导致的api表格渲染错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - 更新了附件卡片文档，明确说明移除操作的回调函数支持返回同步（布尔值）或异步（Promise）结果。
  - 简化了附件图片属性的说明，去除了多余的类型提示，提高了文档清晰度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->