### PR TITLE
fix(thought-chain): 非受控模式无法工作

### DIFF
--- a/components/thought-chain/__tests__/index.test.tsx
+++ b/components/thought-chain/__tests__/index.test.tsx
@@ -111,4 +111,23 @@ describe('ThoughtChain Component', () => {
 
     expect(expandBodyElements).toHaveLength(1);
   });
+
+  it('ThoughtChain component work with uncontrolled mode', () => {
+    const App = () => {
+      return <ThoughtChain items={items} collapsible />;
+    };
+
+    const { container } = render(<App />);
+    const element = container.querySelectorAll<HTMLDivElement>(
+      '.ant-thought-chain-item-header-box',
+    )[0];
+
+    fireEvent.click(element as Element);
+
+    const expandBodyElements = container.querySelectorAll<HTMLDivElement>(
+      '.ant-thought-chain-item .ant-thought-chain-item-content',
+    );
+
+    expect(expandBodyElements).toHaveLength(1);
+  });
 });

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -53,12 +53,19 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
   }, [collapsible]);
 
   // ============================ ExpandedKeys ============================
+  const collapsibleIsTrue = collapsible === true;
   const [mergedExpandedKeys, setMergedExpandedKeys] = useMergedState<
     RequiredCollapsibleOptions['expandedKeys']
-  >([], {
-    value: customizeExpandedKeys,
-    onChange: customizeOnExpand,
-  });
+  >(
+    customizeExpandedKeys,
+    collapsibleIsTrue
+      ? undefined
+      : {
+          defaultValue: customizeExpandedKeys,
+          value: customizeExpandedKeys,
+          onChange: customizeOnExpand,
+        },
+  );
 
   // ============================ Event ============================
   const onItemExpand = (curKey: string) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[English Template / 英文模板](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
fix #598 
### 💡 需求背景和解决方案
由于 #598  的改动会产生一个新的问题，当`collapsible`为`true`时，点击面板无法正常展开


### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://x.ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新增功能**
  - 优化了 ThoughtChain 组件在非受控模式下的折叠交互，点击标题时内容能更稳定地展开，进一步提升了用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->