### PR TITLE
feat(use-x-chat): add updating status

### DIFF
--- a/components/use-x-chat/__tests__/index.test.tsx
+++ b/components/use-x-chat/__tests__/index.test.tsx
@@ -173,7 +173,7 @@ describe('useXChat', () => {
       fireEvent.change(container.querySelector('input')!, { target: { value: 'little' } });
       expect(getMessages(container)).toEqual([
         expectMessage('little', 'local'),
-        expectMessage('bamboo', 'loading'),
+        expectMessage('bamboo', 'updating'),
       ]);
 
       await waitFakeTimer();
@@ -208,7 +208,7 @@ describe('useXChat', () => {
     fireEvent.change(container.querySelector('input')!, { target: { value: 'little' } });
     expect(getMessages(container)).toEqual([
       expectMessage('little', 'local'),
-      expectMessage('bamboo', 'loading'),
+      expectMessage('bamboo', 'updating'),
     ]);
 
     await waitFakeTimer();

--- a/components/use-x-chat/index.ts
+++ b/components/use-x-chat/index.ts
@@ -5,7 +5,7 @@ import useSyncState from './useSyncState';
 
 export type SimpleType = string | number | boolean | object;
 
-export type MessageStatus = 'local' | 'loading' | 'success' | 'error';
+export type MessageStatus = 'local' | 'loading' | 'updating' | 'success' | 'error';
 
 type RequestPlaceholderFn<Message extends SimpleType> = (
   message: Message,
@@ -199,7 +199,7 @@ export default function useXChat<
       },
       {
         onUpdate: (message) => {
-          updateMessage(message, 'loading');
+          updateMessage(message, 'updating');
         },
         onSuccess: (message) => {
           updateMessage(message, 'success');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] ⭐️ 功能增强

### 💡 需求背景和解决方案

在使用流式传输时，会调用 onUpdate 更新 message 的内容，现有的 message status 不足以描述全部的执行状态。因此增加了一个 updating 状态，表示 message 内容正在更新。

变更后的 status 状态表示：

- loading：表示 request 正在调用
- updating：表示正在更新 message
- success: 表示 request 已经调用完成

### 实现效果

进行流式传输时，通过 states 是否为 loading 更便于控制加载中的 UI 状态。


https://github.com/user-attachments/assets/143bb4b4-3adb-43e1-8af0-455bcdb13fa7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了新的“更新中”消息状态，提供了更细致的状态反馈。
- **测试**
  - 更新了状态检测相关的测试用例，确保消息状态在更新过程中显示更加准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->