### PR TITLE
feat(use-x-chat): add updating status

### DIFF
--- a/components/use-x-chat/index.ts
+++ b/components/use-x-chat/index.ts
@@ -36,6 +36,7 @@ export interface MessageInfo<Message extends SimpleType> {
   id: number | string;
   message: Message;
   status: MessageStatus;
+  updating: boolean;
 }
 
 export type DefaultMessageInfo<Message extends SimpleType> = Pick<MessageInfo<Message>, 'message'> &
@@ -77,15 +78,17 @@ export default function useXChat<
     (defaultMessages || []).map((info, index) => ({
       id: `default_${index}`,
       status: 'local',
+      updating: false,
       ...info,
     })),
   );
 
-  const createMessage = (message: AgentMessage, status: MessageStatus) => {
+  const createMessage = (message: AgentMessage, status: MessageStatus, updating = false) => {
     const msg: MessageInfo<AgentMessage> = {
       id: `msg_${idRef.current}`,
       message,
       status,
+      updating,
     };
 
     idRef.current += 1;
@@ -111,6 +114,7 @@ export default function useXChat<
           id: key,
           message: bubbleMsg,
           status: agentMsg.status,
+          updating: agentMsg.updating,
         });
       });
     });
@@ -164,10 +168,11 @@ export default function useXChat<
     let updatingMsgId: number | string | null = null;
     const updateMessage = (message: AgentMessage, status: MessageStatus) => {
       let msg = getMessages().find((info) => info.id === updatingMsgId);
+      const updating = status === 'loading';
 
       if (!msg) {
         // Create if not exist
-        msg = createMessage(message, status);
+        msg = createMessage(message, status, updating);
         setMessages((ori) => {
           const oriWithoutPending = ori.filter((info) => info.id !== loadingMsgId);
           return [...oriWithoutPending, msg!];
@@ -182,6 +187,7 @@ export default function useXChat<
                 ...info,
                 message,
                 status,
+                updating,
               };
             }
             return info;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] ⭐️ 功能增强

### 💡 需求背景和解决方案

在使用流式传输时，会调用 onUpdate 更新 message 的内容，因此增加了一个 updating 状态，表示 message 内容正在更新。

### 实现效果

进行流式传输时，可以通过 states 和 updating 控制 UI 状态。

https://github.com/user-attachments/assets/26d02e30-31a1-4fcb-a990-d3d201edc2a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化了消息处理逻辑，现在用户在发送或更新消息时可直观地看到加载状态及更新后的反馈，体验更加实时和流畅。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->