### PR TITLE
Add autoSize property to Sender component

### DIFF
--- a/components/sender/demo/basic.tsx
+++ b/components/sender/demo/basic.tsx
@@ -38,6 +38,7 @@ const Demo: React.FC = () => {
           setLoading(false);
           message.error('Cancel sending!');
         }}
+        autoSize={{ minRows: 2, maxRows: 6 }}
       />
       <Sender value="Force as loading" loading readOnly />
       <Sender disabled value="Set to disabled" />

--- a/components/sender/index.en-US.md
+++ b/components/sender/index.en-US.md
@@ -53,6 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | onChange | Callback when input value changes | (value: string, event?: React.FormEvent<`HTMLTextAreaElement`> \| React.ChangeEvent<`HTMLTextAreaElement`> ) => void | - | - |
 | onCancel | Callback when click cancel button | () => void | - | - |
 | onPasteFile | Callback when paste files | (firstFile: File, files: FileList) => void | - | - |
+| autoSize | Height auto size feature, can be set to true \| false or an object { minRows: 2, maxRows: 6 } | { maxRows: 8 } | - |
 
 ```typescript | pure
 type SpeechConfig = {

--- a/components/sender/index.en-US.md
+++ b/components/sender/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | onChange | Callback when input value changes | (value: string, event?: React.FormEvent<`HTMLTextAreaElement`> \| React.ChangeEvent<`HTMLTextAreaElement`> ) => void | - | - |
 | onCancel | Callback when click cancel button | () => void | - | - |
 | onPasteFile | Callback when paste files | (firstFile: File, files: FileList) => void | - | - |
-| autoSize | Height auto size feature, can be set to true \| false or an object { minRows: 2, maxRows: 6 } | { maxRows: 8 } | - |
+| autoSize | Height auto size feature, can be set to true \| false or an object { minRows: 2, maxRows: 6 } | boolean \| { minRows?: number; maxRows?: number } | { maxRows: 8 } | - |
 
 ```typescript | pure
 type SpeechConfig = {

--- a/components/sender/index.tsx
+++ b/components/sender/index.tsx
@@ -74,6 +74,7 @@ export interface SenderProps
   allowSpeech?: AllowSpeech;
   prefix?: React.ReactNode;
   header?: React.ReactNode;
+  autoSize?: boolean | { minRows?: number; maxRows?: number };
 }
 
 export type SenderRef = {
@@ -114,6 +115,7 @@ const ForwardSender = React.forwardRef<SenderRef, SenderProps>((props, ref) => {
     header,
     onPaste,
     onPasteFile,
+    autoSize = { maxRows: 8 },
     ...rest
   } = props;
 
@@ -308,7 +310,7 @@ const ForwardSender = React.forwardRef<SenderRef, SenderProps>((props, ref) => {
           disabled={disabled}
           style={{ ...contextConfig.styles.input, ...styles.input }}
           className={classnames(inputCls, contextConfig.classNames.input, classNames.input)}
-          autoSize={{ maxRows: 8 }}
+          autoSize={autoSize}
           value={innerValue}
           onChange={(event) => {
             triggerValueChange(

--- a/components/sender/index.zh-CN.md
+++ b/components/sender/index.zh-CN.md
@@ -54,6 +54,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*cOfrS4fVkOMAAA
 | onChange | 输入框值改变的回调 | (value: string, event?: React.FormEvent<`HTMLTextAreaElement`> \| React.ChangeEvent<`HTMLTextAreaElement`> ) => void | - | - |
 | onCancel | 点击取消按钮的回调 | () => void | - | - |
 | onPasteFile | 黏贴文件的回调 | (firstFile: File, files: FileList) => void | - | - |
+| autoSize | 自适应内容高度，可设置为 true \| false 或对象：{ minRows: 2, maxRows: 6 } | boolean \| { minRows?: number; maxRows?: number } | { maxRows: 8 } | - |
 
 ```typescript | pure
 type SpeechConfig = {


### PR DESCRIPTION
Fixes #635

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ant-design/x/pull/637?shareId=d88d5536-1872-4e16-84fa-822c55a81aae).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 为文本输入区域添加了自动调整高度的功能，用户现在可以通过简单配置来设定最小行数和最大行数。
  - 新增的配置选项支持布尔值或对象形式，确保在不同输入量下都能获得最佳显示效果，同时保持现有功能的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->