### PR TITLE
Fix: 修复思维链折叠问题, 增加collapsible demo

### DIFF
--- a/components/thought-chain/demo/collapsible.tsx
+++ b/components/thought-chain/demo/collapsible.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { ThoughtChain } from '@ant-design/x';
 import type { ThoughtChainProps } from '@ant-design/x';
+import React from 'react';
 
 import { Card, Typography } from 'antd';
 
@@ -32,6 +32,19 @@ const items: ThoughtChainProps['items'] = [
     content: mockContent,
   },
   {
+    key: '2',
+    title: 'Click me to expand the content',
+    description: 'Collapsible',
+    content: mockContent,
+  },
+  {
+    key: '3',
+    title: 'Click me to expand the content',
+    description: 'Collapsible',
+    content: mockContent,
+  },
+  {
+    key: '4',
     title: 'Click me to expand the content',
     description: 'Collapsible',
     content: mockContent,
@@ -40,6 +53,12 @@ const items: ThoughtChainProps['items'] = [
 
 export default () => (
   <Card style={{ width: 500 }}>
-    <ThoughtChain items={items} collapsible />
+    <ThoughtChain
+      items={items}
+      collapsible={{
+        // items[0] key
+        expandedKeys: ['2'],
+      }}
+    />
   </Card>
 );

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -55,8 +55,7 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
   // ============================ ExpandedKeys ============================
   const [mergedExpandedKeys, setMergedExpandedKeys] = useMergedState<
     RequiredCollapsibleOptions['expandedKeys']
-  >([], {
-    value: customizeExpandedKeys,
+  >(customizeExpandedKeys, {
     onChange: customizeOnExpand,
   });
 

--- a/components/thought-chain/index.en-US.md
+++ b/components/thought-chain/index.en-US.md
@@ -57,7 +57,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### CollapsibleOptions
 
-:::info{title=default} When the parameter `collapsible` config `true`, the `default value` be like:
+:::info When the parameter `collapsible` config `true`, the `default value` be like:
 
 ```ts
 {

--- a/components/thought-chain/index.en-US.md
+++ b/components/thought-chain/index.en-US.md
@@ -57,6 +57,17 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### CollapsibleOptions
 
+:::info{title=default} When the parameter `collapsible` config `true`, the `default value` be like:
+
+```ts
+{
+  expandedKeys: [],
+  onExpand: () => {},
+}
+```
+
+:::
+
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | expandedKeys | Current expanded keys | string[] | None | - |

--- a/components/thought-chain/index.zh-CN.md
+++ b/components/thought-chain/index.zh-CN.md
@@ -58,6 +58,17 @@ demo:
 
 ### CollapsibleOptions
 
+:::info{title=默认值} 当参数 `collapsible` 配置为 `true` 时, 默认值如下:
+
+```ts
+{
+  expandedKeys: [],
+  onExpand: () => {},
+}
+```
+
+:::
+
 | 属性         | 说明                   | 类型                             | 默认值 | 版本 |
 | ------------ | ---------------------- | -------------------------------- | ------ | ---- |
 | expandedKeys | 当前展开的节点         | string[]                         | -      | -    |

--- a/components/thought-chain/index.zh-CN.md
+++ b/components/thought-chain/index.zh-CN.md
@@ -58,7 +58,7 @@ demo:
 
 ### CollapsibleOptions
 
-:::info{title=默认值} 当参数 `collapsible` 配置为 `true` 时, 默认值如下:
+:::info当参数 `collapsible` 配置为 `true` 时, 默认值如下:
 
 ```ts
 {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

[线上思维链可折叠demo](https://x.ant.design/components/thought-chain-cn#thought-chain-demo-collapsible)

**当前问题**：点击折叠不可展开、收起

![20250331155541_rec_](https://github.com/user-attachments/assets/99b683d4-e4ce-4443-a1b8-fd252e1e75b3)

**预期**：点击折叠可展开、收起

![20250331155206_rec_](https://github.com/user-attachments/assets/f08d8c97-9b28-4674-b9b9-4eb773bda255)

### 💡 Background and Solution

在`useMergedState`中设置 `option.value`之后无法获取最新的 `mergedValue`，导致无法触发思维链的展开折叠功能

![image](https://github.com/user-attachments/assets/8db52d6b-1b7a-4b75-9cbd-2644ba50cdd0)

[`useMergedState`](https://github.com/react-component/util/blob/288022820d2ab899c799ac6336155dedf3e9a766/src/hooks/useMergedState.ts#L19)

![image](https://github.com/user-attachments/assets/78dd0022-1889-4cdb-9a89-fe39ad997d68)

### 📝 Change Log

修复思维链折叠问题

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    ✅      |
| 🇨🇳 Chinese |  ✅       |
