### PR TITLE
fix: thought-chain collapsible not work(#743)

### DIFF
--- a/components/thought-chain/demo/collapsible.tsx
+++ b/components/thought-chain/demo/collapsible.tsx
@@ -41,17 +41,19 @@ const items: ThoughtChainProps['items'] = [
     status: 'pending',
   },
 ];
-const collapsible: ThoughtChainProps['collapsible'] = {
-  expandedKeys: ['item-2'],
-  onExpand: (expandedKeys) => {
-    console.log(expandedKeys);
-  },
-};
 
-const App: React.FC = () => (
-  <Card style={{ width: 500 }}>
-    <ThoughtChain items={items} collapsible={collapsible} />
-  </Card>
-);
+const App: React.FC = () => {
+  const [expandedKeys, setExpandedKeys] = React.useState(['item-2']);
+
+  const onExpand = (keys: string[]) => {
+    console.log(keys);
+    setExpandedKeys(keys);
+  };
+  return (
+    <Card style={{ width: 500 }}>
+      <ThoughtChain items={items} collapsible={{ expandedKeys, onExpand }} />
+    </Card>
+  );
+};
 
 export default App;

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -34,7 +34,7 @@ type UseCollapsible = (
 ];
 
 const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) => {
-  const isCollapsibleBoolean = typeof collapsible === 'boolean';
+  const isThoughtChainUnControlled = typeof collapsible === 'boolean' || !collapsible?.expandedKeys;
   // ============================ Collapsible ============================
   const [enableCollapse, customizeExpandedKeys, customizeOnExpand] = React.useMemo(() => {
     let baseConfig: RequiredCollapsibleOptions = {
@@ -57,14 +57,14 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
   const [mergedExpandedKeys, setMergedExpandedKeys] = useMergedState<
     RequiredCollapsibleOptions['expandedKeys']
   >(customizeExpandedKeys, {
-    value: isCollapsibleBoolean ? undefined : customizeExpandedKeys,
+    value: isThoughtChainUnControlled ? undefined : customizeExpandedKeys,
     onChange: customizeOnExpand,
   });
 
   // ============================ Event ============================
   const onItemExpand = (curKey: string) => {
     setMergedExpandedKeys((preKeys) => {
-      const targetPreKeys = isCollapsibleBoolean ? preKeys : customizeExpandedKeys;
+      const targetPreKeys = isThoughtChainUnControlled ? preKeys : customizeExpandedKeys;
       const keys = targetPreKeys.includes(curKey)
         ? targetPreKeys.filter((key) => key !== curKey)
         : [...targetPreKeys, curKey];

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -55,16 +55,18 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
   // ============================ ExpandedKeys ============================
   const [mergedExpandedKeys, setMergedExpandedKeys] = useMergedState<
     RequiredCollapsibleOptions['expandedKeys']
-  >(customizeExpandedKeys, {
+  >(customizeExpandedKeys ?? [], {
+    value: customizeExpandedKeys,
     onChange: customizeOnExpand,
   });
 
   // ============================ Event ============================
   const onItemExpand = (curKey: string) => {
     setMergedExpandedKeys((preKeys) => {
-      const keys = preKeys?.includes(curKey)
-        ? preKeys.filter((key) => key !== curKey)
-        : [...preKeys, curKey];
+      const targetPreKeys = customizeExpandedKeys ?? preKeys;
+      const keys = targetPreKeys.includes(curKey)
+        ? targetPreKeys.filter((key) => key !== curKey)
+        : [...targetPreKeys, curKey];
       customizeOnExpand?.(keys);
       return keys;
     });

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -56,7 +56,7 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
   // ============================ ExpandedKeys ============================
   const [mergedExpandedKeys, setMergedExpandedKeys] = useMergedState<
     RequiredCollapsibleOptions['expandedKeys']
-  >(customizeExpandedKeys ?? [], {
+  >(customizeExpandedKeys, {
     value: isCollapsibleBoolean ? undefined : customizeExpandedKeys,
     onChange: customizeOnExpand,
   });

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -34,6 +34,7 @@ type UseCollapsible = (
 ];
 
 const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) => {
+  const isCollapsibleBoolean = typeof collapsible === 'boolean';
   // ============================ Collapsible ============================
   const [enableCollapse, customizeExpandedKeys, customizeOnExpand] = React.useMemo(() => {
     let baseConfig: RequiredCollapsibleOptions = {
@@ -56,14 +57,14 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
   const [mergedExpandedKeys, setMergedExpandedKeys] = useMergedState<
     RequiredCollapsibleOptions['expandedKeys']
   >(customizeExpandedKeys ?? [], {
-    value: customizeExpandedKeys,
+    value: isCollapsibleBoolean ? undefined : customizeExpandedKeys,
     onChange: customizeOnExpand,
   });
 
   // ============================ Event ============================
   const onItemExpand = (curKey: string) => {
     setMergedExpandedKeys((preKeys) => {
-      const targetPreKeys = customizeExpandedKeys ?? preKeys;
+      const targetPreKeys = isCollapsibleBoolean ? preKeys : customizeExpandedKeys;
       const keys = targetPreKeys.includes(curKey)
         ? targetPreKeys.filter((key) => key !== curKey)
         : [...targetPreKeys, curKey];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix: #743 

### 💡 Background and Solution

![image](https://github.com/user-attachments/assets/a6f858eb-cee7-4310-b6f3-0b9486d441ea)
修复思维链组件`collapsible`属性为对象时，传递expandedKeys受控模式失效问题
1. 首先判断思维链组件不受控的条件是传递的`collapsible`属性为`boolean`类型或者`!collapsible?.expandedKeys`为`true`，即不是数组
2. 在`useMergedState`中，默认值使用外部传递的`expandedKeys`，没传这里会为空数组，`value`在`collapsible`为对象时受控模式下需为外部的`expandedKeys`，在`onExpand`事件中决定使用外部的还是`preKeys`作为新增/删除的`set`依据，这在`onExpand`事件中如果外部传递`setExpandedKeys`时始终决定使用外部的`keys`，多次调用应都为空数组，如下：
![image](https://github.com/user-attachments/assets/bb4d369b-d0c3-476b-8b79-8aeb294c545b)

以上是我的个人理解提交的PR，作为首次PR，希望大佬Review一下指正不足，助我学习进步，Respect！


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **修复问题**
  - 修正了折叠面板在受控和非受控模式下的展开状态同步问题，确保自定义展开项时行为一致。
  - 优化了折叠面板的展开状态管理，支持动态响应用户操作，提升交互体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->