### PR TITLE
fix: thought-chain is not controlled (#743)

### DIFF
--- a/components/thought-chain/__tests__/index.test.tsx
+++ b/components/thought-chain/__tests__/index.test.tsx
@@ -86,23 +86,42 @@ describe('ThoughtChain Component', () => {
   });
 
   it('ThoughtChain component work with controlled mode', async () => {
+    const onExpand = jest.fn();
     const App = () => {
-      const [expandedKeys] = React.useState<string[]>(['test2']);
+      const [expandedKeys] = React.useState<string[]>(['test1']);
       return (
         <ThoughtChain
           items={items}
           collapsible={{
             expandedKeys,
+            onExpand: (keys) => {
+              onExpand(keys);
+            },
           }}
         />
       );
     };
     const { container } = render(<App />);
 
-    const expandBodyElements = container.querySelectorAll<HTMLDivElement>(
+    const expandBodyBeforeElements = container.querySelectorAll<HTMLDivElement>(
       '.ant-thought-chain-item-content-box',
     );
-    expect(expandBodyElements).toHaveLength(1);
+    expect(expandBodyBeforeElements).toHaveLength(1);
+
+    const itemHeaderElement = container.querySelectorAll<HTMLDivElement>(
+      '.ant-thought-chain-item-header-box',
+    )[0];
+    fireEvent.click(itemHeaderElement as Element);
+    expect(onExpand).toHaveBeenCalledWith([]);
+
+    // click again
+    fireEvent.click(itemHeaderElement as Element);
+    expect(onExpand).toHaveBeenCalledWith([]);
+
+    const expandBodyAfterElements = container.querySelectorAll<HTMLDivElement>(
+      '.ant-thought-chain-item-content-box',
+    );
+    expect(expandBodyAfterElements).toHaveLength(1);
   });
 
   it('ThoughtChain component work collapsible without expandedKeys', async () => {

--- a/components/thought-chain/__tests__/index.test.tsx
+++ b/components/thought-chain/__tests__/index.test.tsx
@@ -104,4 +104,37 @@ describe('ThoughtChain Component', () => {
     );
     expect(expandBodyElements).toHaveLength(1);
   });
+
+  it('ThoughtChain component work collapsible without expandedKeys', async () => {
+    const onExpand = jest.fn();
+    const App = () => {
+      return (
+        <ThoughtChain
+          items={items}
+          collapsible={{
+            onExpand: (keys) => {
+              onExpand(keys);
+            },
+          }}
+        />
+      );
+    };
+    const { container } = render(<App />);
+
+    const expandBodyElementBefore = container.querySelectorAll<HTMLDivElement>(
+      '.ant-thought-chain-item-content-box',
+    );
+    expect(expandBodyElementBefore).toHaveLength(0);
+
+    const element = container.querySelectorAll<HTMLDivElement>(
+      '.ant-thought-chain-item-header-box',
+    )[0];
+    fireEvent.click(element as Element);
+    expect(onExpand).toHaveBeenCalledWith(['test1']);
+
+    const expandBodyElementsAfter = container.querySelectorAll<HTMLDivElement>(
+      '.ant-thought-chain-item-content-box',
+    );
+    expect(expandBodyElementsAfter).toHaveLength(1);
+  });
 });

--- a/components/thought-chain/demo/collapsible.tsx
+++ b/components/thought-chain/demo/collapsible.tsx
@@ -41,17 +41,19 @@ const items: ThoughtChainProps['items'] = [
     status: 'pending',
   },
 ];
-const collapsible: ThoughtChainProps['collapsible'] = {
-  expandedKeys: ['item-2'],
-  onExpand: (expandedKeys) => {
-    console.log(expandedKeys);
-  },
-};
 
-const App: React.FC = () => (
-  <Card style={{ width: 500 }}>
-    <ThoughtChain items={items} collapsible={collapsible} />
-  </Card>
-);
+const App: React.FC = () => {
+  const [expandedKeys, setExpandedKeys] = React.useState(['item-2']);
+
+  const onExpand = (keys: string[]) => {
+    console.log(keys);
+    setExpandedKeys(keys);
+  };
+  return (
+    <Card style={{ width: 500 }}>
+      <ThoughtChain items={items} collapsible={{ expandedKeys, onExpand }} />
+    </Card>
+  );
+};
 
 export default App;

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -34,7 +34,7 @@ type UseCollapsible = (
 ];
 
 const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) => {
-  const isThoughtChainUnControlled = typeof collapsible === 'boolean' || !collapsible?.expandedKeys;
+  const isThoughtChainUnControlled = typeof collapsible === 'boolean' || collapsible?.expandedKeys !== undefined;
   // ============================ Collapsible ============================
   const [enableCollapse, customizeExpandedKeys, customizeOnExpand] = React.useMemo(() => {
     let baseConfig: RequiredCollapsibleOptions = {

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -34,7 +34,8 @@ type UseCollapsible = (
 ];
 
 const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) => {
-  const isThoughtChainUnControlled = typeof collapsible === 'boolean' || collapsible?.expandedKeys !== undefined;
+  const isThoughtChainUnControlled =
+    typeof collapsible === 'boolean' || collapsible?.expandedKeys === undefined;
   // ============================ Collapsible ============================
   const [enableCollapse, customizeExpandedKeys, customizeOnExpand] = React.useMemo(() => {
     let baseConfig: RequiredCollapsibleOptions = {

--- a/components/thought-chain/hooks/useCollapsible.ts
+++ b/components/thought-chain/hooks/useCollapsible.ts
@@ -34,6 +34,7 @@ type UseCollapsible = (
 ];
 
 const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) => {
+  const isThoughtChainUnControlled = typeof collapsible === 'boolean' || !collapsible?.expandedKeys;
   // ============================ Collapsible ============================
   const [enableCollapse, customizeExpandedKeys, customizeOnExpand] = React.useMemo(() => {
     let baseConfig: RequiredCollapsibleOptions = {
@@ -56,15 +57,17 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
   const [mergedExpandedKeys, setMergedExpandedKeys] = useMergedState<
     RequiredCollapsibleOptions['expandedKeys']
   >(customizeExpandedKeys, {
+    value: isThoughtChainUnControlled ? undefined : customizeExpandedKeys,
     onChange: customizeOnExpand,
   });
 
   // ============================ Event ============================
   const onItemExpand = (curKey: string) => {
     setMergedExpandedKeys((preKeys) => {
-      const keys = preKeys?.includes(curKey)
-        ? preKeys.filter((key) => key !== curKey)
-        : [...preKeys, curKey];
+      const targetPreKeys = isThoughtChainUnControlled ? preKeys : customizeExpandedKeys;
+      const keys = targetPreKeys.includes(curKey)
+        ? targetPreKeys.filter((key) => key !== curKey)
+        : [...targetPreKeys, curKey];
       customizeOnExpand?.(keys);
       return keys;
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix: #743 

### 💡 Background and Solution

![image](https://github.com/user-attachments/assets/a6f858eb-cee7-4310-b6f3-0b9486d441ea)
修复思维链组件`collapsible`属性为对象时，传递expandedKeys受控模式失效问题
1. 首先判断思维链组件不受控的条件是传递的`collapsible`属性为`boolean`类型或者`!collapsible?.expandedKeys`为`true`，即不是数组
2. 在`useMergedState`中，默认值使用外部传递的`expandedKeys`，没传这里会为空数组，`value`在`collapsible`为对象时受控模式下需为外部的`expandedKeys`，在`onExpand`事件中决定使用外部的还是`preKeys`作为新增/删除的`set`依据，这在`onExpand`事件中如果外部传递`setExpandedKeys`时始终决定使用外部的`keys`，多次调用应都为空数组，如下：
![image](https://github.com/user-attachments/assets/bb4d369b-d0c3-476b-8b79-8aeb294c545b)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 折叠面板现支持受控与非受控两种用法，用户可根据需求选择由组件内部或外部管理展开状态。
- **重构**
  - 优化了折叠面板的状态管理逻辑，实现更灵活的交互体验。
- **测试**
  - 新增折叠面板非受控模式的测试用例，确保交互行为符合预期。
  - 调整受控模式测试，验证折叠和展开行为及回调触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->