### PR TITLE
fix: fix Conversations ellipsis tooltip issues by removing it

### DIFF
--- a/components/conversations/Item.tsx
+++ b/components/conversations/Item.tsx
@@ -1,5 +1,5 @@
 import { EllipsisOutlined } from '@ant-design/icons';
-import { Dropdown, Tooltip, Typography } from 'antd';
+import { Dropdown, Typography } from 'antd';
 import type { MenuProps } from 'antd';
 import classnames from 'classnames';
 import React from 'react';
@@ -39,12 +39,6 @@ const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
   // ============================= MISC =============================
   const { disabled } = info;
 
-  // =========================== Ellipsis ===========================
-  const [inEllipsis, onEllipsis] = React.useState(false);
-
-  // =========================== Tooltip ============================
-  const [opened, setOpened] = React.useState(false);
-
   // ============================ Style =============================
   const mergedCls = classnames(
     className,
@@ -57,12 +51,6 @@ const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
   const onInternalClick: React.MouseEventHandler<HTMLLIElement> = () => {
     if (!disabled && onClick) {
       onClick(info);
-    }
-  };
-
-  const onOpenChange = (open: boolean) => {
-    if (open) {
-      setOpened(!open);
     }
   };
 
@@ -86,36 +74,21 @@ const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
 
   // ============================ Render ============================
   return (
-    <Tooltip
-      title={info.label}
-      open={inEllipsis && opened}
-      onOpenChange={setOpened}
-      placement={direction === 'rtl' ? 'left' : 'right'}
-    >
-      <li {...domProps} className={mergedCls} onClick={onInternalClick}>
-        {info.icon && <div className={`${prefixCls}-icon`}>{info.icon}</div>}
-        <Typography.Text
-          className={`${prefixCls}-label`}
-          ellipsis={{
-            onEllipsis,
-          }}
+    <li {...domProps} className={mergedCls} onClick={onInternalClick} title={`${info.label}`}>
+      {info.icon && <div className={`${prefixCls}-icon`}>{info.icon}</div>}
+      <Typography.Text className={`${prefixCls}-label`}>{info.label}</Typography.Text>
+      {!disabled && menu && (
+        <Dropdown
+          menu={dropdownMenu}
+          placement={direction === 'rtl' ? 'bottomLeft' : 'bottomRight'}
+          trigger={['click']}
+          disabled={disabled}
+          getPopupContainer={getPopupContainer}
         >
-          {info.label}
-        </Typography.Text>
-        {!disabled && menu && (
-          <Dropdown
-            menu={dropdownMenu}
-            placement={direction === 'rtl' ? 'bottomLeft' : 'bottomRight'}
-            trigger={['click']}
-            disabled={disabled}
-            onOpenChange={onOpenChange}
-            getPopupContainer={getPopupContainer}
-          >
-            {renderMenuTrigger(info)}
-          </Dropdown>
-        )}
-      </li>
-    </Tooltip>
+          {renderMenuTrigger(info)}
+        </Dropdown>
+      )}
+    </li>
   );
 };
 

--- a/components/conversations/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/conversations/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6,129 +6,45 @@ exports[`renders components/conversations/demo/basic.tsx extend context correctl
   style="width: 256px; background: #ffffff; border-radius: 6px;"
 >
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-active"
+    title="Conversation Item 1"
   >
     <span
-      aria-label="Conversation Item 1"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 1
     </span>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 1
-      </div>
-    </div>
-  </div>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 2"
   >
     <span
-      aria-label="Conversation Item 2"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 2
     </span>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 2
-      </div>
-    </div>
-  </div>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 3"
   >
     <span
-      aria-label="Conversation Item 3"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 3
     </span>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 3
-      </div>
-    </div>
-  </div>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-disabled"
+    title="Conversation Item 4"
   >
     <span
-      aria-label="Conversation Item 4"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 4
     </span>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 4
-      </div>
-    </div>
-  </div>
 </ul>
 `;
 
@@ -143,98 +59,35 @@ exports[`renders components/conversations/demo/controlled-mode.tsx extend contex
     style="width: 256px; background: #ffffff; border-radius: 6px;"
   >
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item ant-conversations-item-active"
+      title="Conversation Item 1"
     >
       <span
-        aria-label="Conversation Item 1"
-        class="ant-typography ant-typography-ellipsis ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 1
       </span>
     </li>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          id="test-id"
-          role="tooltip"
-        >
-          Conversation Item 1
-        </div>
-      </div>
-    </div>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 2"
     >
       <span
-        aria-label="Conversation Item 2"
-        class="ant-typography ant-typography-ellipsis ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 2
       </span>
     </li>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          id="test-id"
-          role="tooltip"
-        >
-          Conversation Item 2
-        </div>
-      </div>
-    </div>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 3"
     >
       <span
-        aria-label="Conversation Item 3"
-        class="ant-typography ant-typography-ellipsis ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 3
       </span>
     </li>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          id="test-id"
-          role="tooltip"
-        >
-          Conversation Item 3
-        </div>
-      </div>
-    </div>
   </ul>
   <div
     class="ant-flex ant-flex-gap-small"
@@ -280,98 +133,35 @@ exports[`renders components/conversations/demo/group.tsx extend context correctl
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-active"
+        title="Conversation Item 1"
       >
         <span
-          aria-label="Conversation Item 1"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 1
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation Item 1
-          </div>
-        </div>
-      </div>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation Item 2"
       >
         <span
-          aria-label="Conversation Item 2"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 2
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation Item 2
-          </div>
-        </div>
-      </div>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation Item 3"
       >
         <span
-          aria-label="Conversation Item 3"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 3
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation Item 3
-          </div>
-        </div>
-      </div>
     </ul>
   </li>
   <li>
@@ -388,36 +178,15 @@ exports[`renders components/conversations/demo/group.tsx extend context correctl
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-disabled"
+        title="Conversation Item 4"
       >
         <span
-          aria-label="Conversation Item 4"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 4
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation Item 4
-          </div>
-        </div>
-      </div>
     </ul>
   </li>
 </ul>
@@ -486,129 +255,45 @@ exports[`renders components/conversations/demo/group-sort.tsx extend context cor
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-active"
+        title="Conversation 1732204800000"
       >
         <span
-          aria-label="Conversation 1732204800000"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204800000
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation 1732204800000
-          </div>
-        </div>
-      </div>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204803600"
       >
         <span
-          aria-label="Conversation 1732204803600"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204803600
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation 1732204803600
-          </div>
-        </div>
-      </div>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204807200"
       >
         <span
-          aria-label="Conversation 1732204807200"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204807200
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation 1732204807200
-          </div>
-        </div>
-      </div>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204810800"
       >
         <span
-          aria-label="Conversation 1732204810800"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204810800
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation 1732204810800
-          </div>
-        </div>
-      </div>
     </ul>
   </li>
   <li>
@@ -667,67 +352,25 @@ exports[`renders components/conversations/demo/group-sort.tsx extend context cor
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204728000"
       >
         <span
-          aria-label="Conversation 1732204728000"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204728000
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation 1732204728000
-          </div>
-        </div>
-      </div>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204731600"
       >
         <span
-          aria-label="Conversation 1732204731600"
-          class="ant-typography ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204731600
         </span>
       </li>
-      <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            id="test-id"
-            role="tooltip"
-          >
-            Conversation 1732204731600
-          </div>
-        </div>
-      </div>
     </ul>
   </li>
 </ul>
@@ -792,12 +435,11 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
   style="width: 256px; background: #ffffff; border-radius: 6px;"
 >
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-active"
+    title="Conversation Item 1"
   >
     <span
-      aria-label="Conversation Item 1"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 1
     </span>
@@ -826,7 +468,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
     </span>
     <div
       class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomRight"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <ul
         class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
@@ -868,7 +510,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -918,7 +560,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -968,7 +610,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -991,33 +633,12 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
       />
     </div>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 1
-      </div>
-    </div>
-  </div>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 2"
   >
     <span
-      aria-label="Conversation Item 2"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 2
     </span>
@@ -1046,7 +667,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
     </span>
     <div
       class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomRight"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <ul
         class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
@@ -1088,7 +709,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -1138,7 +759,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -1188,7 +809,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -1211,33 +832,12 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
       />
     </div>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 2
-      </div>
-    </div>
-  </div>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 3"
   >
     <span
-      aria-label="Conversation Item 3"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 3
     </span>
@@ -1266,7 +866,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
     </span>
     <div
       class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomRight"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <ul
         class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
@@ -1308,7 +908,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -1358,7 +958,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -1408,7 +1008,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
         </li>
         <div
           class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
             class="ant-tooltip-arrow"
@@ -1431,57 +1031,16 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
       />
     </div>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 3
-      </div>
-    </div>
-  </div>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-disabled"
+    title="Conversation Item 4"
   >
     <span
-      aria-label="Conversation Item 4"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 4
     </span>
   </li>
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; top: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        id="test-id"
-        role="tooltip"
-      >
-        Conversation Item 4
-      </div>
-    </div>
-  </div>
 </ul>
 `;
 
@@ -1496,12 +1055,11 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
     style="width: 256px; background: #ffffff; border-radius: 6px;"
   >
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item ant-conversations-item-active"
+      title="Conversation Item 1"
     >
       <span
-        aria-label="Conversation Item 1"
-        class="ant-typography ant-typography-ellipsis ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 1
       </span>
@@ -1527,7 +1085,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
       </span>
       <div
         class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomRight"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150;"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <ul
           class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
@@ -1569,7 +1127,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -1619,7 +1177,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -1669,7 +1227,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -1692,33 +1250,12 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
         />
       </div>
     </li>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          id="test-id"
-          role="tooltip"
-        >
-          Conversation Item 1
-        </div>
-      </div>
-    </div>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 2"
     >
       <span
-        aria-label="Conversation Item 2"
-        class="ant-typography ant-typography-ellipsis ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 2
       </span>
@@ -1744,7 +1281,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
       </span>
       <div
         class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomRight"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150;"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <ul
           class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
@@ -1786,7 +1323,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -1836,7 +1373,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -1886,7 +1423,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -1909,33 +1446,12 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
         />
       </div>
     </li>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          id="test-id"
-          role="tooltip"
-        >
-          Conversation Item 2
-        </div>
-      </div>
-    </div>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 3"
     >
       <span
-        aria-label="Conversation Item 3"
-        class="ant-typography ant-typography-ellipsis ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 3
       </span>
@@ -1961,7 +1477,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
       </span>
       <div
         class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomRight"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150;"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <ul
           class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
@@ -2003,7 +1519,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -2053,7 +1569,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -2103,7 +1619,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           </li>
           <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
-            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1250;"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
           >
             <div
               class="ant-tooltip-arrow"
@@ -2126,57 +1642,16 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
         />
       </div>
     </li>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          id="test-id"
-          role="tooltip"
-        >
-          Conversation Item 3
-        </div>
-      </div>
-    </div>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item ant-conversations-item-disabled"
+      title="Conversation Item 4"
     >
       <span
-        aria-label="Conversation Item 4"
-        class="ant-typography ant-typography-ellipsis ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 4
       </span>
     </li>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-right"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          id="test-id"
-          role="tooltip"
-        >
-          Conversation Item 4
-        </div>
-      </div>
-    </div>
   </ul>
 </div>
 `;

--- a/components/conversations/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/conversations/__tests__/__snapshots__/demo.test.ts.snap
@@ -6,41 +6,41 @@ exports[`renders components/conversations/demo/basic.tsx correctly 1`] = `
   style="width:256px;background:#ffffff;border-radius:6px"
 >
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-active"
+    title="Conversation Item 1"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 1
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 2"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 2
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 3"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 3
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-disabled"
+    title="Conversation Item 4"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 4
     </span>
@@ -57,31 +57,31 @@ exports[`renders components/conversations/demo/controlled-mode.tsx correctly 1`]
     style="width:256px;background:#ffffff;border-radius:6px"
   >
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item ant-conversations-item-active"
+      title="Conversation Item 1"
     >
       <span
-        class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 1
       </span>
     </li>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 2"
     >
       <span
-        class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 2
       </span>
     </li>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 3"
     >
       <span
-        class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 3
       </span>
@@ -129,31 +129,31 @@ exports[`renders components/conversations/demo/group.tsx correctly 1`] = `
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-active"
+        title="Conversation Item 1"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 1
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation Item 2"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 2
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation Item 3"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 3
         </span>
@@ -174,11 +174,11 @@ exports[`renders components/conversations/demo/group.tsx correctly 1`] = `
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-disabled"
+        title="Conversation Item 4"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation Item 4
         </span>
@@ -249,41 +249,41 @@ exports[`renders components/conversations/demo/group-sort.tsx correctly 1`] = `
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-active"
+        title="Conversation 1732204800000"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204800000
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204803600"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204803600
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204807200"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204807200
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204810800"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204810800
         </span>
@@ -346,21 +346,21 @@ exports[`renders components/conversations/demo/group-sort.tsx correctly 1`] = `
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204728000"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204728000
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="Conversation 1732204731600"
       >
         <span
-          class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+          class="ant-typography ant-conversations-label"
         >
           Conversation 1732204731600
         </span>
@@ -425,11 +425,11 @@ exports[`renders components/conversations/demo/menu-trigger.tsx correctly 1`] = 
   style="width:256px;background:#ffffff;border-radius:6px"
 >
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-active"
+    title="Conversation Item 1"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 1
     </span>
@@ -458,11 +458,11 @@ exports[`renders components/conversations/demo/menu-trigger.tsx correctly 1`] = 
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 2"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 2
     </span>
@@ -491,11 +491,11 @@ exports[`renders components/conversations/demo/menu-trigger.tsx correctly 1`] = 
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="Conversation Item 3"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 3
     </span>
@@ -524,11 +524,11 @@ exports[`renders components/conversations/demo/menu-trigger.tsx correctly 1`] = 
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-disabled"
+    title="Conversation Item 4"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Conversation Item 4
     </span>
@@ -545,11 +545,11 @@ exports[`renders components/conversations/demo/with-menu.tsx correctly 1`] = `
     style="width:256px;background:#ffffff;border-radius:6px"
   >
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item ant-conversations-item-active"
+      title="Conversation Item 1"
     >
       <span
-        class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 1
       </span>
@@ -575,11 +575,11 @@ exports[`renders components/conversations/demo/with-menu.tsx correctly 1`] = `
       </span>
     </li>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 2"
     >
       <span
-        class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 2
       </span>
@@ -605,11 +605,11 @@ exports[`renders components/conversations/demo/with-menu.tsx correctly 1`] = `
       </span>
     </li>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item"
+      title="Conversation Item 3"
     >
       <span
-        class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 3
       </span>
@@ -635,11 +635,11 @@ exports[`renders components/conversations/demo/with-menu.tsx correctly 1`] = `
       </span>
     </li>
     <li
-      aria-describedby="test-id"
       class="ant-conversations-item ant-conversations-item-disabled"
+      title="Conversation Item 4"
     >
       <span
-        class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-conversations-label"
+        class="ant-typography ant-conversations-label"
       >
         Conversation Item 4
       </span>

--- a/components/conversations/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/conversations/__tests__/__snapshots__/index.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`Conversations Component Conversations component work 1`] = `
   class="ant-conversations"
 >
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="What is Ant Design X ?"
   >
     <div
       class="ant-conversations-icon"
@@ -18,18 +18,17 @@ exports[`Conversations Component Conversations component work 1`] = `
       </div>
     </div>
     <span
-      aria-label="What is Ant Design X ?"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       What is Ant Design X ?
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="[object Object]"
   >
     <span
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       <div>
         Getting Started:
@@ -44,34 +43,31 @@ exports[`Conversations Component Conversations component work 1`] = `
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item"
+    title="In Docker, use 🐑 Ollama and initialize"
   >
     <span
-      aria-label="In Docker, use 🐑 Ollama and initialize"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       In Docker, use 🐑 Ollama and initialize
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-disabled"
+    title="Expired, please go to the recycle bin to check"
   >
     <span
-      aria-label="Expired, please go to the recycle bin to check"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       Expired, please go to the recycle bin to check
     </span>
   </li>
   <li
-    aria-describedby="test-id"
     class="ant-conversations-item ant-conversations-item-disabled"
+    title="No key"
   >
     <span
-      aria-label="No key"
-      class="ant-typography ant-typography-ellipsis ant-conversations-label"
+      class="ant-typography ant-conversations-label"
     >
       No key
     </span>
@@ -97,8 +93,8 @@ exports[`Conversations Component rtl render component should be rendered correct
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="What is Ant Design X ?"
       >
         <div
           class="ant-conversations-icon"
@@ -110,8 +106,7 @@ exports[`Conversations Component rtl render component should be rendered correct
           </div>
         </div>
         <span
-          aria-label="What is Ant Design X ?"
-          class="ant-typography ant-typography-rtl ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-typography-rtl ant-conversations-label"
         >
           What is Ant Design X ?
         </span>
@@ -146,11 +141,11 @@ exports[`Conversations Component rtl render component should be rendered correct
       class="ant-conversations-list"
     >
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="[object Object]"
       >
         <span
-          class="ant-typography ant-typography-rtl ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-typography-rtl ant-conversations-label"
         >
           <div>
             Getting Started:
@@ -185,12 +180,11 @@ exports[`Conversations Component rtl render component should be rendered correct
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item"
+        title="In Docker, use 🐑 Ollama and initialize"
       >
         <span
-          aria-label="In Docker, use 🐑 Ollama and initialize"
-          class="ant-typography ant-typography-rtl ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-typography-rtl ant-conversations-label"
         >
           In Docker, use 🐑 Ollama and initialize
         </span>
@@ -216,23 +210,21 @@ exports[`Conversations Component rtl render component should be rendered correct
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-disabled"
+        title="Expired, please go to the recycle bin to check"
       >
         <span
-          aria-label="Expired, please go to the recycle bin to check"
-          class="ant-typography ant-typography-rtl ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-typography-rtl ant-conversations-label"
         >
           Expired, please go to the recycle bin to check
         </span>
       </li>
       <li
-        aria-describedby="test-id"
         class="ant-conversations-item ant-conversations-item-disabled"
+        title="No key"
       >
         <span
-          aria-label="No key"
-          class="ant-typography ant-typography-rtl ant-typography-ellipsis ant-conversations-label"
+          class="ant-typography ant-typography-rtl ant-conversations-label"
         >
           No key
         </span>

--- a/components/conversations/style/index.ts
+++ b/components/conversations/style/index.ts
@@ -39,6 +39,9 @@ const genConversationsStyle: GenerateStyle<ConversationsToken> = (token) => {
         },
         [`& ${componentCls}-label`]: {
           color: token.colorTextDescription,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
         },
       },
       // 会话列表项
@@ -73,8 +76,12 @@ const genConversationsStyle: GenerateStyle<ConversationsToken> = (token) => {
         // 悬浮、选中时激活操作菜单
         '&:hover, &-active': {
           [`& ${componentCls}-menu-icon`]: {
-            opacity: 1,
+            opacity: 0.6,
           },
+        },
+
+        [`${componentCls}-menu-icon:hover`]: {
+          opacity: 1,
         },
       },
       // 会话名


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/x/pull/766
close https://github.com/ant-design/x/issues/694
close https://github.com/ant-design/x/issues/765

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Conversations 里的省略文字后的 Tooltip 很影响体验（如 https://github.com/ant-design/x/issues/694 和 https://github.com/ant-design/x/issues/765），也让代码里的 UI 状态变得很复杂，不如直接去掉。参考 chatgpt 用原生的 title 实现。

- ChatGPT:
  <img width="394" alt="图片" src="https://github.com/user-attachments/assets/a698504e-0232-4c73-97e9-4e520a1578c9" />

| 修改前 | 修改后 |
| --- | --- |
| <img width="603" alt="截屏2025-04-25 16 00 25" src="https://github.com/user-attachments/assets/eeaed8e0-1612-4d8b-8095-8b82d3c8a47f" /> | <img width="369" alt="图片" src="https://github.com/user-attachments/assets/f9d97895-1797-43f8-aab3-920c46b433c0" /> |

- [x] 另外还参考 chatgpt 增加 `...` 图标的 hover 效果。 

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Replace ellipsis Tooltip in Conversations with native title to fix experience issues caused by Tooltip.          |
| 🇨🇳 Chinese | 用原生 title 替代 Conversations 里的省略 Tooltip，以解决 Tooltip 遮挡带来的各类体验问题。          |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 会话列表标签现在在超出长度时会自动显示省略号，并通过浏览器原生提示显示完整内容。
  - 会话列表菜单图标在悬停或激活时半透明，鼠标悬停在图标本身时将变为全不透明。

- **优化**
  - 简化了会话项的结构，移除了自定义气泡提示，提升了性能和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->