### PR TITLE
fix: Prompts scroll styles

### DIFF
--- a/components/prompts/demo/nest.tsx
+++ b/components/prompts/demo/nest.tsx
@@ -26,7 +26,7 @@ const items: PromptsProps['items'] = [
     children: [
       {
         key: '1-1',
-        description: `What's new in X?`,
+        description: `What's new in X,What's new in XWhat's new in X?What's new in X,What's new in XWhat's new in X?`,
       },
       {
         key: '1-2',

--- a/components/prompts/demo/nest.tsx
+++ b/components/prompts/demo/nest.tsx
@@ -26,7 +26,7 @@ const items: PromptsProps['items'] = [
     children: [
       {
         key: '1-1',
-        description: `What's new in X,What's new in XWhat's new in X?What's new in X,What's new in XWhat's new in X?`,
+        description: `What's new in X?`,
       },
       {
         key: '1-2',

--- a/components/prompts/style/index.ts
+++ b/components/prompts/style/index.ts
@@ -4,9 +4,9 @@ import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/cssi
 import { genStyleHooks } from '../../theme/genStyleUtils';
 
 // biome-ignore lint/suspicious/noEmptyInterface: ComponentToken need to be empty by default
-export interface ComponentToken {}
+export interface ComponentToken { }
 
-export interface PromptsToken extends FullToken<'Prompts'> {}
+export interface PromptsToken extends FullToken<'Prompts'> { }
 
 const genPromptsStyle: GenerateStyle<PromptsToken> = (token) => {
   const { componentCls } = token;
@@ -32,7 +32,10 @@ const genPromptsStyle: GenerateStyle<PromptsToken> = (token) => {
       [`& ${componentCls}-list`]: {
         display: 'flex',
         gap: token.paddingSM,
-        overflowX: 'scroll',
+        overflowX: 'auto',
+        // Hide scrollbar
+        scrollbarWidth: 'none',
+        '-ms-overflow-style': 'none',
         '&::-webkit-scrollbar': {
           display: 'none',
         },


### PR DESCRIPTION



fix: windows上滚动条始终展示了
https://github.com/ant-design/x/issues/744


### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 优化了提示列表的横向滚动条表现，默认仅在需要时显示，并在各主流浏览器中隐藏了滚动条，提升视觉体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->