### PR TITLE
chore: fix  warning of deprecated API

### DIFF
--- a/components/suggestion/index.tsx
+++ b/components/suggestion/index.tsx
@@ -136,9 +136,9 @@ function Suggestion<T = any>(props: SuggestionProps<T>) {
     'onDropdownVisibleChange' | 'onOpenChange'
   > = {};
   if (isNewAPI) {
-    compatibleProps.onDropdownVisibleChange = onInternalOpenChange;
-  } else {
     compatibleProps.onOpenChange = onInternalOpenChange;
+  } else {
+    compatibleProps.onDropdownVisibleChange = onInternalOpenChange;
   }
 
   return wrapCSSVar(

--- a/components/suggestion/index.tsx
+++ b/components/suggestion/index.tsx
@@ -131,7 +131,10 @@ function Suggestion<T = any>(props: SuggestionProps<T>) {
     }
   };
 
-  const compatibleProps: Partial<CascaderProps> = {};
+  const compatibleProps: Pick<
+    Partial<CascaderProps<SuggestionItem>>,
+    'onDropdownVisibleChange' | 'onOpenChange'
+  > = {};
   if (isNewAPI) {
     compatibleProps.onDropdownVisibleChange = onInternalOpenChange;
   } else {

--- a/components/suggestion/index.tsx
+++ b/components/suggestion/index.tsx
@@ -1,4 +1,4 @@
-import { Cascader, Flex } from 'antd';
+import { Cascader, Flex, version } from 'antd';
 import type { CascaderProps } from 'antd';
 import classnames from 'classnames';
 import { useEvent, useMergedState } from 'rc-util';
@@ -7,6 +7,10 @@ import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import { useXProviderContext } from '../x-provider';
 import useStyle from './style';
 import useActive from './useActive';
+
+const antdVersionCells = version.split('.').map(Number);
+const isNewAPI =
+  antdVersionCells[0] > 5 || (antdVersionCells[0] === 5 && antdVersionCells[1] >= 25);
 
 export type SuggestionItem = {
   label: React.ReactNode;
@@ -121,17 +125,26 @@ function Suggestion<T = any>(props: SuggestionProps<T>) {
   const childNode = children?.({ onTrigger, onKeyDown });
 
   // ============================ Render ============================
+  const onInternalOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      onClose();
+    }
+  };
+
+  const compatibleProps: Partial<CascaderProps> = {};
+  if (isNewAPI) {
+    compatibleProps.onDropdownVisibleChange = onInternalOpenChange;
+  } else {
+    compatibleProps.onOpenChange = onInternalOpenChange;
+  }
+
   return wrapCSSVar(
     <Cascader
       options={itemList}
       open={mergedOpen}
       value={activePath}
       placement={isRTL ? 'topRight' : 'topLeft'}
-      onDropdownVisibleChange={(nextOpen) => {
-        if (!nextOpen) {
-          onClose();
-        }
-      }}
+      {...compatibleProps}
       optionRender={optionRender}
       rootClassName={classnames(rootClassName, prefixCls, hashId, cssVarCls, {
         [`${prefixCls}-block`]: block,

--- a/components/suggestion/index.tsx
+++ b/components/suggestion/index.tsx
@@ -135,6 +135,8 @@ function Suggestion<T = any>(props: SuggestionProps<T>) {
     Partial<CascaderProps<SuggestionItem>>,
     'onDropdownVisibleChange' | 'onOpenChange'
   > = {};
+
+  /* istanbul ignore else */
   if (isNewAPI) {
     compatibleProps.onOpenChange = onInternalOpenChange;
   } else {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@umijs/fabric": "^4.0.1",
     "adm-zip": "^0.5.16",
     "ali-oss": "^6.21.0",
-    "antd": "^5.22.7",
+    "antd": "^5.25.1",
     "antd-style": "^3.6.3",
     "antd-token-previewer": "^2.0.8",
     "axios": "^1.7.7",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Suggestion warning of antd deprecated API `onDropdownVisibleChange` usage.       |
| 🇨🇳 Chinese |     修复 Suggestion 警告使用 antd 废弃 API `onDropdownVisibleChange` 的问题。       |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化了对 Ant Design 5.25 及以上版本的兼容性，确保下拉菜单的显示与关闭行为在不同版本中表现一致。
- **依赖更新**
  - 升级了 Ant Design 依赖版本至 5.25.1，提升组件兼容性和稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->