### PR TITLE
docs: sender supplement documents to address user inquiries

### DIFF
--- a/components/sender/index.en-US.md
+++ b/components/sender/index.en-US.md
@@ -39,7 +39,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | actions | Custom actions,set as `actions: false` when you don't need default actions | ReactNode \| (oriNode, info: { components:ActionsComponents }) => ReactNode | - | - |
 | allowSpeech | Whether to allow speech input | boolean \| SpeechConfig | false | - |
 | classNames | Class name | [See below](#semantic-dom) | - | - |
-| components | Custom components, The default input is[Input.TextArea](https://ant.design/components/input#api),When customizing input, it is necessary to refer to `Input. TextArea` to implement props to avoid incomplete functionality | Record<'input', ComponentType> | - | - |
+| components | Custom components, The default input is[Input.TextArea](https://ant.design/components/input#api),Ensure that when customizing the input component, all necessary props are implemented as per `Input.TextArea` to avoid any incomplete functionality. | Record<'input', ComponentType> | - | - |
 | defaultValue | Default value of input | string | - | - |
 | disabled | Whether to disable | boolean | false | - |
 | loading | Whether it is loading | boolean | false | - |

--- a/components/sender/index.en-US.md
+++ b/components/sender/index.en-US.md
@@ -39,7 +39,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | actions | Custom actions,set as `actions: false` when you don't need default actions | ReactNode \| (oriNode, info: { components:ActionsComponents }) => ReactNode | - | - |
 | allowSpeech | Whether to allow speech input | boolean \| SpeechConfig | false | - |
 | classNames | Class name | [See below](#semantic-dom) | - | - |
-| components | Custom components | Record<'input', ComponentType> | - | - |
+| components | Custom components, The default input is[Input.TextArea](https://ant.design/components/input#api),When customizing input, it is necessary to refer to `Input. TextArea` to implement props to avoid incomplete functionality | Record<'input', ComponentType> | - | - |
 | defaultValue | Default value of input | string | - | - |
 | disabled | Whether to disable | boolean | false | - |
 | loading | Whether it is loading | boolean | false | - |

--- a/components/sender/index.zh-CN.md
+++ b/components/sender/index.zh-CN.md
@@ -40,7 +40,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*cOfrS4fVkOMAAA
 | actions | 自定义按钮，当不需要默认操作按钮时，可以设为 `actions={false}` | ReactNode \| (oriNode, info: { components: ActionsComponents }) => ReactNode | - | - |
 | allowSpeech | 是否允许语音输入 | boolean \| SpeechConfig | false | - |
 | classNames | 样式类名 | [见下](#semantic-dom) | - | - |
-| components | 自定义组件，input默认为[Input.TextArea](https://ant.design/components/input-cn#api)，自定义input时需参考`Input.TextArea`实现props以免功能不全 | Record<'input', ComponentType> | - | - |
+| components | 自定义组件，input默认为[Input.TextArea](https://ant.design/components/input-cn#api)，确保在自定义输入组件时，按照 `Input.TextArea` 实现所有必要的 props，以避免功能不全。 | Record<'input', ComponentType> | - | - |
 | defaultValue | 输入框默认值 | string | - | - |
 | disabled | 是否禁用 | boolean | false | - |
 | loading | 是否加载中 | boolean | false | - |

--- a/components/sender/index.zh-CN.md
+++ b/components/sender/index.zh-CN.md
@@ -40,7 +40,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*cOfrS4fVkOMAAA
 | actions | 自定义按钮，当不需要默认操作按钮时，可以设为 `actions={false}` | ReactNode \| (oriNode, info: { components: ActionsComponents }) => ReactNode | - | - |
 | allowSpeech | 是否允许语音输入 | boolean \| SpeechConfig | false | - |
 | classNames | 样式类名 | [见下](#semantic-dom) | - | - |
-| components | 自定义组件 | Record<'input', ComponentType> | - | - |
+| components | 自定义组件，input默认为[Input.TextArea](https://ant.design/components/input-cn#api)，自定义input时需参考`Input.TextArea`实现props以免功能不全 | Record<'input', ComponentType> | - | - |
 | defaultValue | 输入框默认值 | string | - | - |
 | disabled | 是否禁用 | boolean | false | - |
 | loading | 是否加载中 | boolean | false | - |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

https://github.com/ant-design/x/issues/697

### 💡 Background and Solution

用户对自定义input用法疑问较多，补充其描述。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 明确说明 `SenderProps` 的 `components` 属性默认使用 Ant Design 的 `Input.TextArea` 组件。
  - 建议自定义输入组件时参考 `Input.TextArea` 的 props，以避免功能不完整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->