### PR TITLE
fix: Bubble.List  footer  has no  key

### DIFF
--- a/components/bubble/BubbleList.tsx
+++ b/components/bubble/BubbleList.tsx
@@ -48,6 +48,7 @@ const BubbleListItem: React.ForwardRefRenderFunction<
 > = ({ _key, ...restProps }, ref) => (
   <Bubble
     {...restProps}
+    _key={_key}
     ref={(node) => {
       if (node) {
         (ref as React.RefObject<Record<string, BubbleRef>>).current[_key!] = node;

--- a/components/bubble/demo/markdown.tsx
+++ b/components/bubble/demo/markdown.tsx
@@ -15,7 +15,6 @@ Link: [Ant Design X](https://x.ant.design)
 `.trim();
 
 const renderMarkdown: BubbleProps['messageRender'] = (content) => {
-  console.log('content', content);
   return (
     <Typography>
       {/* biome-ignore lint/security/noDangerouslySetInnerHtml: used in demo */}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
https://github.com/ant-design/x/issues/875
https://github.com/ant-design/x/issues/875

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix the issue where Bubble. List ` footer ` does not return a key   |
| 🇨🇳 Chinese |  修复 Bubble.List `footer` 未返回key的问题        |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了 Bubble 组件未正确接收 _key 属性的问题，提升了组件数据一致性。

- **Chores**
  - 移除了 markdown 渲染演示中的调试日志输出，使控制台更为清洁。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->