### PR TITLE
fix(Safari): Event execution sequence

### DIFF
--- a/components/sender/index.tsx
+++ b/components/sender/index.tsx
@@ -101,6 +101,8 @@ const sharedRenderComponents = {
   SpeechButton,
 };
 
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
 const ForwardSender = React.forwardRef<SenderRef, SenderProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
@@ -219,6 +221,9 @@ const ForwardSender = React.forwardRef<SenderRef, SenderProps>((props, ref) => {
   };
 
   const onInternalCompositionEnd = () => {
+    if (isSafari) {
+      return;
+    }
     isCompositionRef.current = false;
   };
 
@@ -240,6 +245,10 @@ const ForwardSender = React.forwardRef<SenderRef, SenderProps>((props, ref) => {
           triggerSend();
         }
         break;
+    }
+
+    if (isSafari) {
+      isCompositionRef.current = false;
     }
 
     onKeyPress?.(e);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

fix #872 
the execution order of Chrome is `onInternalCompositionStart`-`onInternalKeyPress`-`onInternalCompositionEnd`

![Image](https://github.com/user-attachments/assets/c1a5d876-ce41-45cd-9ef7-9b469863fec2)

Safari is `onInternalCompositionStart`-`onInternalCompositionEnd`-`onInternalKeyPress`

![Image](https://github.com/user-attachments/assets/9b446e74-aeb7-4f7c-9caa-edefe0b4d267)

so,` isCompositionRef.current` is not work in Safari

After recognizing that the browser is Safari, I adjusted `isCompositionRef.current` to ensure consistency with the execution order of Chrome

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
