### PR TITLE
docs(attachments): add high-quality preview example for image attachments

### DIFF
--- a/components/attachments/demo/with-sender.tsx
+++ b/components/attachments/demo/with-sender.tsx
@@ -1,7 +1,9 @@
 import { CloudUploadOutlined, LinkOutlined } from '@ant-design/icons';
 import { Attachments, AttachmentsProps, Sender } from '@ant-design/x';
-import { App, Badge, Button, Flex, type GetProp, type GetRef, Typography } from 'antd';
+import { App, Badge, Button, Flex, type GetProp, type GetRef, Typography, UploadProps } from 'antd';
 import React from 'react';
+
+type FileType = Parameters<GetProp<UploadProps, 'beforeUpload'>>[0];
 
 const Demo = () => {
   const [open, setOpen] = React.useState(true);
@@ -27,7 +29,20 @@ const Demo = () => {
         // Mock not real upload file
         beforeUpload={() => false}
         items={items}
-        onChange={({ fileList }) => setItems(fileList)}
+        onChange={({ file, fileList }) => {
+          if (file.status === 'removed') {
+            setItems(fileList);
+            return;
+          }
+          file.url = window.URL.createObjectURL(file as FileType);
+          const newFileList = fileList.slice();
+          newFileList.splice(
+            fileList.findIndex((item) => item.uid === file.uid),
+            1,
+            file,
+          );
+          setItems(newFileList);
+        }}
         placeholder={(type) =>
           type === 'drop'
             ? {


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Before:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6d5d74ed-7d1b-4223-a45f-7770e0530d69" />

After:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b8e8a1fc-3531-4d7e-b073-8622e35cabda" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add high-quality preview example for image attachments |
| 🇨🇳 Chinese | 为Attachments组件添加高清预览上次图片的示例 |
