### PR TITLE
将Sender组件的SenderRef类型export出来，方便开发者直接通过import type {SenderRef} from '…

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -7,7 +7,7 @@ export { default as Attachments } from './attachments';
 export type { AttachmentsProps } from './attachments';
 
 export { default as Sender } from './sender';
-export type { SenderProps } from './sender';
+export type { SenderProps,SenderRef } from './sender';
 
 export { default as Bubble } from './bubble';
 export type { BubbleProps } from './bubble';


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 无

### 💡 需求背景和解决方案

> 1. 要解决的具体问题。
Sender组件只用Ref时，需提供类型，所以需要export SenderRef
> 2. 列出最终的 API 实现和用法。
```node
import type { SenderRef } from '@ant-design/x';      
const senderInputRef = useRef<SenderRef>(null);
```
> 3. 涉及UI/交互变动建议提供截图或 GIF。


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    export type SenderRef       |
| 🇨🇳 Chinese |     export type SenderRef      |
