### PR TITLE
fix[Attachments]: fix maxCount prop to attachments components

### DIFF
--- a/components/actions/ActionMenu.tsx
+++ b/components/actions/ActionMenu.tsx
@@ -1,8 +1,8 @@
 import { EllipsisOutlined } from '@ant-design/icons';
 import { Dropdown, MenuProps } from 'antd';
 import React from 'react';
-import { ActionsProps } from '.';
 import { useXProviderContext } from '../x-provider';
+import { ActionsProps } from '.';
 import { ActionItem, ItemType } from './interface';
 
 export const findItem = (keyPath: string[], items: ActionItem[]): ActionItem | null => {
@@ -31,7 +31,7 @@ const ActionMenu = (props: { item: ItemType } & Pick<ActionsProps, 'prefixCls' |
   const icon = item?.icon ?? <EllipsisOutlined />;
 
   const menuProps: MenuProps = {
-    items: children,
+    items: children as MenuProps['items'],
     onClick: ({ key, keyPath, domEvent }) => {
       if (findItem(keyPath, children)?.onItemClick) {
         findItem(keyPath, children)?.onItemClick?.(findItem(keyPath, children) as ActionItem);

--- a/components/attachments/FileList/index.tsx
+++ b/components/attachments/FileList/index.tsx
@@ -4,8 +4,8 @@ import classnames from 'classnames';
 import { CSSMotionList } from 'rc-motion';
 import React from 'react';
 import type { Attachment } from '..';
-import SilentUploader from '../SilentUploader';
 import { AttachmentContext } from '../context';
+import SilentUploader from '../SilentUploader';
 import FileListCard from './FileListCard';
 
 export interface FileListProps {
@@ -15,6 +15,7 @@ export interface FileListProps {
   overflow?: 'scrollX' | 'scrollY' | 'wrap';
   upload: UploadProps;
   imageProps?: ImageProps;
+  maxCount?: number;
 
   // Semantic
   listClassName?: string;
@@ -42,8 +43,8 @@ export default function FileList(props: FileListProps) {
     uploadStyle,
     itemStyle,
     imageProps,
+    maxCount,
   } = props;
-
   const listCls = `${prefixCls}-list`;
 
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -150,7 +151,7 @@ export default function FileList(props: FileListProps) {
         }}
       </CSSMotionList>
       {!disabled && (
-        <SilentUploader upload={upload}>
+        <SilentUploader upload={upload} maxCount={maxCount}>
           <Button
             className={classnames(uploadClassName, `${listCls}-upload-btn`)}
             style={uploadStyle}

--- a/components/attachments/SilentUploader.tsx
+++ b/components/attachments/SilentUploader.tsx
@@ -5,20 +5,26 @@ export interface SilentUploaderProps {
   children: React.ReactElement;
   upload: UploadProps;
   rootClassName?: string;
+  maxCount?: number;
 }
 
 /**
  * SilentUploader is only wrap children with antd Upload component.
  */
 function SilentUploader(props: SilentUploaderProps, ref: React.Ref<GetRef<typeof Upload>>) {
-  const { children, upload, rootClassName } = props;
+  const { children, upload, rootClassName, maxCount } = props;
 
   const uploadRef = React.useRef<GetRef<typeof Upload>>(null);
   React.useImperativeHandle(ref, () => uploadRef.current!);
-
   // ============================ Render ============================
   return (
-    <Upload {...upload} showUploadList={false} rootClassName={rootClassName} ref={uploadRef}>
+    <Upload
+      {...upload}
+      showUploadList={false}
+      rootClassName={rootClassName}
+      ref={uploadRef}
+      maxCount={maxCount}
+    >
       {children}
     </Upload>
   );

--- a/components/attachments/__tests__/index.test.tsx
+++ b/components/attachments/__tests__/index.test.tsx
@@ -1,4 +1,3 @@
-import { GetProp } from 'antd';
 import React from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';

--- a/components/attachments/__tests__/index.test.tsx
+++ b/components/attachments/__tests__/index.test.tsx
@@ -1,9 +1,9 @@
+import { GetProp } from 'antd';
 import React from 'react';
-
-import Attachments, { type AttachmentsProps } from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import Attachments, { type AttachmentsProps } from '..';
 
 describe('attachments', () => {
   mountTest(() => <Attachments />);
@@ -97,5 +97,48 @@ describe('attachments', () => {
     );
 
     expect(container.querySelector('.ant-attachment-list-overflow-scrollY')).toBeTruthy();
+  });
+
+  it('maxCount', async () => {
+    const onChange = jest.fn();
+    const presetFiles = Array.from({ length: 5 }).map(
+      (_, index) =>
+        ({
+          uid: String(index),
+          name: `file-${index}.jpg`,
+          status: 'done',
+          thumbUrl: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+          url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        }) as const,
+    );
+
+    const { container } = render(
+      renderAttachments({
+        maxCount: 5,
+        items: presetFiles,
+        onChange,
+      }),
+    );
+
+    expect(container.querySelectorAll('.ant-attachment-list-card')).toHaveLength(5);
+
+    const uploadBtn = container.querySelector('.ant-upload-wrapper .ant-btn');
+    expect(uploadBtn).toBeTruthy();
+
+    if (uploadBtn) {
+      fireEvent.click(uploadBtn);
+
+      const fileInput = container.querySelector('input[type="file"]');
+      if (fileInput) {
+        fireEvent.change(fileInput, {
+          target: { files: [new File(['test'], 'test-file.jpg', { type: 'image/jpeg' })] },
+        });
+        await waitFakeTimer();
+        if (onChange.mock.calls.length > 0) {
+          const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+          expect(lastCall[0].fileList.length).toBeLessThanOrEqual(5);
+        }
+      }
+    }
   });
 });

--- a/components/attachments/__tests__/index.test.tsx
+++ b/components/attachments/__tests__/index.test.tsx
@@ -126,7 +126,6 @@ describe('attachments', () => {
 
     if (uploadBtn) {
       fireEvent.click(uploadBtn);
-
       const fileInput = container.querySelector('input[type="file"]');
       if (fileInput) {
         fireEvent.change(fileInput, {

--- a/components/attachments/index.tsx
+++ b/components/attachments/index.tsx
@@ -1,11 +1,10 @@
 import { type GetProp, GetRef, Upload, type UploadProps } from 'antd';
 import classnames from 'classnames';
+import { useEvent, useMergedState } from 'rc-util';
 import React from 'react';
-
 import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import { useXProviderContext } from '../x-provider';
-
-import { useEvent, useMergedState } from 'rc-util';
+import { AttachmentContext } from './context';
 import DropArea from './DropArea';
 import FileList, { type FileListProps } from './FileList';
 import FileListCard from './FileList/FileListCard';
@@ -14,7 +13,6 @@ import PlaceholderUploader, {
   type PlaceholderType,
 } from './PlaceholderUploader';
 import SilentUploader from './SilentUploader';
-import { AttachmentContext } from './context';
 import useStyle from './style';
 
 export type SemanticType = 'list' | 'item' | 'placeholder' | 'upload';
@@ -70,6 +68,7 @@ function Attachments(props: AttachmentsProps, ref: React.Ref<AttachmentsRef>) {
     overflow,
     imageProps,
     disabled,
+    maxCount,
     classNames = {},
     styles = {},
     ...uploadProps
@@ -223,6 +222,7 @@ function Attachments(props: AttachmentsProps, ref: React.Ref<AttachmentsRef>) {
             ...styles.item,
           }}
           imageProps={imageProps}
+          maxCount={maxCount}
         />
         {getPlaceholderNode('inline', hasFileList ? { style: { display: 'none' } } : {}, uploadRef)}
         <DropArea


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix: [https://github.com/ant-design/x/issues/1044](https://github.com/ant-design/x/issues/1044)

### 💡 Background and Solution
the maxCount property is not vaild when setting maxCount property
SilentUploader component does not set maxCount to antd's Upload componen

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix maxCount prop not working in Attachments component |
| 🇨🇳 Chinese | 修复 Attachments 组件 maxCount 属性不生效 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 附件组件现支持通过 `maxCount` 属性限制最大上传文件数量。

* **测试**
  * 增加了针对最大文件数量限制的测试用例，确保文件数不会超过设定上限。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->