### PR TITLE
fix[Attachments]: fix maxCount prop to attachments components

### DIFF
--- a/components/attachments/index.tsx
+++ b/components/attachments/index.tsx
@@ -1,11 +1,10 @@
 import { type GetProp, GetRef, Upload, type UploadProps } from 'antd';
 import classnames from 'classnames';
+import { useEvent, useMergedState } from 'rc-util';
 import React from 'react';
-
 import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import { useXProviderContext } from '../x-provider';
-
-import { useEvent, useMergedState } from 'rc-util';
+import { AttachmentContext } from './context';
 import DropArea from './DropArea';
 import FileList, { type FileListProps } from './FileList';
 import FileListCard from './FileList/FileListCard';
@@ -14,7 +13,6 @@ import PlaceholderUploader, {
   type PlaceholderType,
 } from './PlaceholderUploader';
 import SilentUploader from './SilentUploader';
-import { AttachmentContext } from './context';
 import useStyle from './style';
 
 export type SemanticType = 'list' | 'item' | 'placeholder' | 'upload';
@@ -70,6 +68,7 @@ function Attachments(props: AttachmentsProps, ref: React.Ref<AttachmentsRef>) {
     overflow,
     imageProps,
     disabled,
+    maxCount,
     classNames = {},
     styles = {},
     ...uploadProps
@@ -124,6 +123,7 @@ function Attachments(props: AttachmentsProps, ref: React.Ref<AttachmentsRef>) {
   const mergedUploadProps: UploadProps = {
     ...uploadProps,
     fileList,
+    maxCount,
     onChange: triggerChange,
   };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix: [https://github.com/ant-design/x/issues/1044](https://github.com/ant-design/x/issues/1044)

### 💡 Background and Solution
the maxCount property is not vaild when setting maxCount property
SilentUploader component does not set maxCount to antd's Upload componen

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix maxCount prop not working in Attachments component |
| 🇨🇳 Chinese | 修复 Attachments 组件 maxCount 属性不生效 |
