### PR TITLE
docs: optimize FileCard docs and demos

### DIFF
--- a/components/attachments/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/attachments/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -776,16 +776,16 @@ exports[`renders components/attachments/demo/files-custom.tsx extend context cor
     >
       <div
         class="ant-attachment-list-card-icon"
-        style="color: #8c8c8c;"
       >
         <span
-          aria-label="copy"
-          class="anticon anticon-copy"
+          aria-label="robot"
+          class="anticon anticon-robot"
           role="img"
+          style="color: rgb(250, 183, 20);"
         >
           <svg
             aria-hidden="true"
-            data-icon="copy"
+            data-icon="robot"
             fill="currentColor"
             focusable="false"
             height="1em"
@@ -793,7 +793,7 @@ exports[`renders components/attachments/demo/files-custom.tsx extend context cor
             width="1em"
           >
             <path
-              d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
+              d="M300 328a60 60 0 10120 0 60 60 0 10-120 0zM852 64H172c-17.7 0-32 14.3-32 32v660c0 17.7 14.3 32 32 32h680c17.7 0 32-14.3 32-32V96c0-17.7-14.3-32-32-32zm-32 660H204V128h616v596zM604 328a60 60 0 10120 0 60 60 0 10-120 0zm250.2 556H169.8c-16.5 0-29.8 14.3-29.8 32v36c0 4.4 3.3 8 7.4 8h729.1c4.1 0 7.4-3.6 7.4-8v-36c.1-17.7-13.2-32-29.7-32zM664 508H360c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h304c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
             />
           </svg>
         </span>
@@ -822,6 +822,226 @@ exports[`renders components/attachments/demo/files-custom.tsx extend context cor
             class="ant-attachment-list-card-ellipsis-prefix"
           >
             109 KB
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+    >
+      <div
+        class="ant-attachment-list-card-icon"
+      >
+        <span
+          aria-label="file-image"
+          class="anticon anticon-file-image"
+          role="img"
+          style="color: rgb(22, 119, 255);"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="file-image"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M854.6 288.7L639.4 73.4c-6-6-14.2-9.4-22.7-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.6-9.4-22.6zM400 402c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40 17.9-40 40-40zm296 294H328c-6.7 0-10.4-7.7-6.3-12.9l99.8-127.2a8 8 0 0112.6 0l41.1 52.4 77.8-99.2a8 8 0 0112.6 0l136.5 174c4.3 5.2.5 12.9-6.1 12.9zm-94-370V137.8L790.2 326H602z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-attachment-list-card-content"
+      >
+        <div
+          class="ant-attachment-list-card-name"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            image-file
+          </div>
+          <div
+            class="ant-attachment-list-card-ellipsis-suffix"
+          >
+            .png
+          </div>
+        </div>
+        <div
+          class="ant-attachment-list-card-desc"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            326 KB
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+    >
+      <div
+        class="ant-attachment-list-card-icon"
+      >
+        <span
+          aria-label="copy"
+          class="anticon anticon-copy"
+          role="img"
+          style="color: rgb(140, 140, 140);"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="copy"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-attachment-list-card-content"
+      >
+        <div
+          class="ant-attachment-list-card-name"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            pdf-file
+          </div>
+          <div
+            class="ant-attachment-list-card-ellipsis-suffix"
+          >
+            .pdf
+          </div>
+        </div>
+        <div
+          class="ant-attachment-list-card-desc"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            434 KB
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+    >
+      <div
+        class="ant-attachment-list-card-icon"
+      >
+        <span
+          aria-label="video-camera"
+          class="anticon anticon-video-camera"
+          role="img"
+          style="color: rgb(255, 77, 79);"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="video-camera"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M912 302.3L784 376V224c0-35.3-28.7-64-64-64H128c-35.3 0-64 28.7-64 64v576c0 35.3 28.7 64 64 64h592c35.3 0 64-28.7 64-64V648l128 73.7c21.3 12.3 48-3.1 48-27.6V330c0-24.6-26.7-40-48-27.7zM328 352c0 4.4-3.6 8-8 8H208c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h112c4.4 0 8 3.6 8 8v48zm560 273l-104-59.8V458.9L888 399v226z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-attachment-list-card-content"
+      >
+        <div
+          class="ant-attachment-list-card-name"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            video-file
+          </div>
+          <div
+            class="ant-attachment-list-card-ellipsis-suffix"
+          >
+            .mp4
+          </div>
+        </div>
+        <div
+          class="ant-attachment-list-card-desc"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            651 KB
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+    >
+      <div
+        class="ant-attachment-list-card-icon"
+      >
+        <span
+          aria-label="audio"
+          class="anticon anticon-audio"
+          role="img"
+          style="color: rgb(255, 110, 49);"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="audio"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 624c93.9 0 170-75.2 170-168V232c0-92.8-76.1-168-170-168s-170 75.2-170 168v224c0 92.8 76.1 168 170 168zm330-170c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 140.3-113.7 254-254 254S258 594.3 258 454c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 168.7 126.6 307.9 290 327.6V884H326.7c-13.7 0-24.7 14.3-24.7 32v36c0 4.4 2.8 8 6.2 8h407.6c3.4 0 6.2-3.6 6.2-8v-36c0-17.7-11-32-24.7-32H548V782.1c165.3-18 294-158 294-328.1z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-attachment-list-card-content"
+      >
+        <div
+          class="ant-attachment-list-card-name"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            audio-file
+          </div>
+          <div
+            class="ant-attachment-list-card-ellipsis-suffix"
+          >
+            .mp3
+          </div>
+        </div>
+        <div
+          class="ant-attachment-list-card-desc"
+        >
+          <div
+            class="ant-attachment-list-card-ellipsis-prefix"
+          >
+            760 KB
           </div>
         </div>
       </div>
@@ -863,226 +1083,6 @@ exports[`renders components/attachments/demo/files-custom.tsx extend context cor
               </svg>
             </span>
             Preview
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-    >
-      <div
-        class="ant-attachment-list-card-icon"
-        style="color: #8c8c8c;"
-      >
-        <span
-          aria-label="video-camera"
-          class="anticon anticon-video-camera"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="video-camera"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M912 302.3L784 376V224c0-35.3-28.7-64-64-64H128c-35.3 0-64 28.7-64 64v576c0 35.3 28.7 64 64 64h592c35.3 0 64-28.7 64-64V648l128 73.7c21.3 12.3 48-3.1 48-27.6V330c0-24.6-26.7-40-48-27.7zM328 352c0 4.4-3.6 8-8 8H208c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h112c4.4 0 8 3.6 8 8v48zm560 273l-104-59.8V458.9L888 399v226z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-attachment-list-card-content"
-      >
-        <div
-          class="ant-attachment-list-card-name"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            pdf-file
-          </div>
-          <div
-            class="ant-attachment-list-card-ellipsis-suffix"
-          >
-            .pdf
-          </div>
-        </div>
-        <div
-          class="ant-attachment-list-card-desc"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            434 KB
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-    >
-      <div
-        class="ant-attachment-list-card-icon"
-        style="color: #8c8c8c;"
-      >
-        <span
-          aria-label="audio"
-          class="anticon anticon-audio"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="audio"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M512 624c93.9 0 170-75.2 170-168V232c0-92.8-76.1-168-170-168s-170 75.2-170 168v224c0 92.8 76.1 168 170 168zm330-170c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 140.3-113.7 254-254 254S258 594.3 258 454c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 168.7 126.6 307.9 290 327.6V884H326.7c-13.7 0-24.7 14.3-24.7 32v36c0 4.4 2.8 8 6.2 8h407.6c3.4 0 6.2-3.6 6.2-8v-36c0-17.7-11-32-24.7-32H548V782.1c165.3-18 294-158 294-328.1z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-attachment-list-card-content"
-      >
-        <div
-          class="ant-attachment-list-card-name"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            video-file
-          </div>
-          <div
-            class="ant-attachment-list-card-ellipsis-suffix"
-          >
-            .mp4
-          </div>
-        </div>
-        <div
-          class="ant-attachment-list-card-desc"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            651 KB
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-    >
-      <div
-        class="ant-attachment-list-card-icon"
-        style="color: #8c8c8c;"
-      >
-        <span
-          aria-label="copy"
-          class="anticon anticon-copy"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="copy"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-attachment-list-card-content"
-      >
-        <div
-          class="ant-attachment-list-card-name"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            audio-file
-          </div>
-          <div
-            class="ant-attachment-list-card-ellipsis-suffix"
-          >
-            .mp3
-          </div>
-        </div>
-        <div
-          class="ant-attachment-list-card-desc"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            760 KB
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-    >
-      <div
-        class="ant-attachment-list-card-icon"
-        style="color: #8c8c8c;"
-      >
-        <span
-          aria-label="copy"
-          class="anticon anticon-copy"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="copy"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-attachment-list-card-content"
-      >
-        <div
-          class="ant-attachment-list-card-name"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            markdown-file
-          </div>
-          <div
-            class="ant-attachment-list-card-ellipsis-suffix"
-          >
-            .md
-          </div>
-        </div>
-        <div
-          class="ant-attachment-list-card-desc"
-        >
-          <div
-            class="ant-attachment-list-card-ellipsis-prefix"
-          >
-            Custom description here
           </div>
         </div>
       </div>

--- a/components/attachments/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/attachments/__tests__/__snapshots__/demo.test.tsx.snap
@@ -710,16 +710,16 @@ Array [
       >
         <div
           class="ant-attachment-list-card-icon"
-          style="color:#8c8c8c"
         >
           <span
-            aria-label="copy"
-            class="anticon anticon-copy"
+            aria-label="robot"
+            class="anticon anticon-robot"
             role="img"
+            style="color:rgb(250, 183, 20)"
           >
             <svg
               aria-hidden="true"
-              data-icon="copy"
+              data-icon="robot"
               fill="currentColor"
               focusable="false"
               height="1em"
@@ -727,7 +727,7 @@ Array [
               width="1em"
             >
               <path
-                d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
+                d="M300 328a60 60 0 10120 0 60 60 0 10-120 0zM852 64H172c-17.7 0-32 14.3-32 32v660c0 17.7 14.3 32 32 32h680c17.7 0 32-14.3 32-32V96c0-17.7-14.3-32-32-32zm-32 660H204V128h616v596zM604 328a60 60 0 10120 0 60 60 0 10-120 0zm250.2 556H169.8c-16.5 0-29.8 14.3-29.8 32v36c0 4.4 3.3 8 7.4 8h729.1c4.1 0 7.4-3.6 7.4-8v-36c.1-17.7-13.2-32-29.7-32zM664 508H360c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h304c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
               />
             </svg>
           </span>
@@ -756,6 +756,226 @@ Array [
               class="ant-attachment-list-card-ellipsis-prefix"
             >
               109 KB
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+      >
+        <div
+          class="ant-attachment-list-card-icon"
+        >
+          <span
+            aria-label="file-image"
+            class="anticon anticon-file-image"
+            role="img"
+            style="color:rgb(22, 119, 255)"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="file-image"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M854.6 288.7L639.4 73.4c-6-6-14.2-9.4-22.7-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.6-9.4-22.6zM400 402c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40 17.9-40 40-40zm296 294H328c-6.7 0-10.4-7.7-6.3-12.9l99.8-127.2a8 8 0 0112.6 0l41.1 52.4 77.8-99.2a8 8 0 0112.6 0l136.5 174c4.3 5.2.5 12.9-6.1 12.9zm-94-370V137.8L790.2 326H602z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-attachment-list-card-content"
+        >
+          <div
+            class="ant-attachment-list-card-name"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              image-file
+            </div>
+            <div
+              class="ant-attachment-list-card-ellipsis-suffix"
+            >
+              .png
+            </div>
+          </div>
+          <div
+            class="ant-attachment-list-card-desc"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              326 KB
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+      >
+        <div
+          class="ant-attachment-list-card-icon"
+        >
+          <span
+            aria-label="copy"
+            class="anticon anticon-copy"
+            role="img"
+            style="color:rgb(140, 140, 140)"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="copy"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-attachment-list-card-content"
+        >
+          <div
+            class="ant-attachment-list-card-name"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              pdf-file
+            </div>
+            <div
+              class="ant-attachment-list-card-ellipsis-suffix"
+            >
+              .pdf
+            </div>
+          </div>
+          <div
+            class="ant-attachment-list-card-desc"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              434 KB
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+      >
+        <div
+          class="ant-attachment-list-card-icon"
+        >
+          <span
+            aria-label="video-camera"
+            class="anticon anticon-video-camera"
+            role="img"
+            style="color:rgb(255, 77, 79)"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="video-camera"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 302.3L784 376V224c0-35.3-28.7-64-64-64H128c-35.3 0-64 28.7-64 64v576c0 35.3 28.7 64 64 64h592c35.3 0 64-28.7 64-64V648l128 73.7c21.3 12.3 48-3.1 48-27.6V330c0-24.6-26.7-40-48-27.7zM328 352c0 4.4-3.6 8-8 8H208c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h112c4.4 0 8 3.6 8 8v48zm560 273l-104-59.8V458.9L888 399v226z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-attachment-list-card-content"
+        >
+          <div
+            class="ant-attachment-list-card-name"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              video-file
+            </div>
+            <div
+              class="ant-attachment-list-card-ellipsis-suffix"
+            >
+              .mp4
+            </div>
+          </div>
+          <div
+            class="ant-attachment-list-card-desc"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              651 KB
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
+      >
+        <div
+          class="ant-attachment-list-card-icon"
+        >
+          <span
+            aria-label="audio"
+            class="anticon anticon-audio"
+            role="img"
+            style="color:rgb(255, 110, 49)"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="audio"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 624c93.9 0 170-75.2 170-168V232c0-92.8-76.1-168-170-168s-170 75.2-170 168v224c0 92.8 76.1 168 170 168zm330-170c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 140.3-113.7 254-254 254S258 594.3 258 454c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 168.7 126.6 307.9 290 327.6V884H326.7c-13.7 0-24.7 14.3-24.7 32v36c0 4.4 2.8 8 6.2 8h407.6c3.4 0 6.2-3.6 6.2-8v-36c0-17.7-11-32-24.7-32H548V782.1c165.3-18 294-158 294-328.1z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-attachment-list-card-content"
+        >
+          <div
+            class="ant-attachment-list-card-name"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              audio-file
+            </div>
+            <div
+              class="ant-attachment-list-card-ellipsis-suffix"
+            >
+              .mp3
+            </div>
+          </div>
+          <div
+            class="ant-attachment-list-card-desc"
+          >
+            <div
+              class="ant-attachment-list-card-ellipsis-prefix"
+            >
+              760 KB
             </div>
           </div>
         </div>
@@ -797,226 +1017,6 @@ Array [
                 </svg>
               </span>
               Preview
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-      >
-        <div
-          class="ant-attachment-list-card-icon"
-          style="color:#8c8c8c"
-        >
-          <span
-            aria-label="video-camera"
-            class="anticon anticon-video-camera"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="video-camera"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M912 302.3L784 376V224c0-35.3-28.7-64-64-64H128c-35.3 0-64 28.7-64 64v576c0 35.3 28.7 64 64 64h592c35.3 0 64-28.7 64-64V648l128 73.7c21.3 12.3 48-3.1 48-27.6V330c0-24.6-26.7-40-48-27.7zM328 352c0 4.4-3.6 8-8 8H208c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h112c4.4 0 8 3.6 8 8v48zm560 273l-104-59.8V458.9L888 399v226z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-attachment-list-card-content"
-        >
-          <div
-            class="ant-attachment-list-card-name"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              pdf-file
-            </div>
-            <div
-              class="ant-attachment-list-card-ellipsis-suffix"
-            >
-              .pdf
-            </div>
-          </div>
-          <div
-            class="ant-attachment-list-card-desc"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              434 KB
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-      >
-        <div
-          class="ant-attachment-list-card-icon"
-          style="color:#8c8c8c"
-        >
-          <span
-            aria-label="audio"
-            class="anticon anticon-audio"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="audio"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 624c93.9 0 170-75.2 170-168V232c0-92.8-76.1-168-170-168s-170 75.2-170 168v224c0 92.8 76.1 168 170 168zm330-170c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 140.3-113.7 254-254 254S258 594.3 258 454c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8 0 168.7 126.6 307.9 290 327.6V884H326.7c-13.7 0-24.7 14.3-24.7 32v36c0 4.4 2.8 8 6.2 8h407.6c3.4 0 6.2-3.6 6.2-8v-36c0-17.7-11-32-24.7-32H548V782.1c165.3-18 294-158 294-328.1z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-attachment-list-card-content"
-        >
-          <div
-            class="ant-attachment-list-card-name"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              video-file
-            </div>
-            <div
-              class="ant-attachment-list-card-ellipsis-suffix"
-            >
-              .mp4
-            </div>
-          </div>
-          <div
-            class="ant-attachment-list-card-desc"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              651 KB
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-      >
-        <div
-          class="ant-attachment-list-card-icon"
-          style="color:#8c8c8c"
-        >
-          <span
-            aria-label="copy"
-            class="anticon anticon-copy"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="copy"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-attachment-list-card-content"
-        >
-          <div
-            class="ant-attachment-list-card-name"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              audio-file
-            </div>
-            <div
-              class="ant-attachment-list-card-ellipsis-suffix"
-            >
-              .mp3
-            </div>
-          </div>
-          <div
-            class="ant-attachment-list-card-desc"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              760 KB
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-attachment-list-card ant-attachment-list-card-status-done ant-attachment-list-card-type-overview"
-      >
-        <div
-          class="ant-attachment-list-card-icon"
-          style="color:#8c8c8c"
-        >
-          <span
-            aria-label="copy"
-            class="anticon anticon-copy"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="copy"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM382 896h-.2L232 746.2v-.2h150v150z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-attachment-list-card-content"
-        >
-          <div
-            class="ant-attachment-list-card-name"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              markdown-file
-            </div>
-            <div
-              class="ant-attachment-list-card-ellipsis-suffix"
-            >
-              .md
-            </div>
-          </div>
-          <div
-            class="ant-attachment-list-card-desc"
-          >
-            <div
-              class="ant-attachment-list-card-ellipsis-prefix"
-            >
-              Custom description here
             </div>
           </div>
         </div>

--- a/components/attachments/demo/files-custom.tsx
+++ b/components/attachments/demo/files-custom.tsx
@@ -1,4 +1,10 @@
-import { AudioFilled, CopyFilled, FileImageFilled, VideoCameraFilled } from '@ant-design/icons';
+import {
+  AudioFilled,
+  CopyFilled,
+  FileImageFilled,
+  RobotOutlined,
+  VideoCameraFilled,
+} from '@ant-design/icons';
 import { Attachments } from '@ant-design/x';
 import { App, Flex } from 'antd';
 import React from 'react';
@@ -18,36 +24,43 @@ const Demo = () => {
       uid: '1',
       name: 'excel-file.xlsx',
       size: 111111,
-      icon: <CopyFilled />,
+      icon: <RobotOutlined style={{ color: 'rgb(250, 183, 20)' }} />,
       type: 'file',
     },
     {
       uid: '2',
       name: 'image-file.png',
       size: 333333,
-      icon: <FileImageFilled />,
+      icon: <FileImageFilled style={{ color: 'rgb(22, 119, 255)' }} />,
       type: 'file',
     },
     {
       uid: '3',
       name: 'pdf-file.pdf',
       size: 444444,
-      icon: <CopyFilled />,
+      icon: <CopyFilled style={{ color: 'rgb(140, 140, 140)' }} />,
       type: 'file',
     },
     {
       uid: '4',
       name: 'video-file.mp4',
       size: 666666,
-      icon: <VideoCameraFilled />,
+      icon: <VideoCameraFilled style={{ color: 'rgb(255, 77, 79)' }} />,
       type: 'file',
     },
     {
       uid: '5',
       name: 'audio-file.mp3',
       size: 777777,
-      icon: <AudioFilled />,
+      icon: <AudioFilled style={{ color: 'rgb(255, 110, 49)' }} />,
       type: 'file',
+    },
+    {
+      uid: '6',
+      name: 'image name without file ext',
+      size: 888888,
+      url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+      type: 'image',
     },
   ];
 

--- a/components/attachments/index.en-US.md
+++ b/components/attachments/index.en-US.md
@@ -23,7 +23,7 @@ The Attachments component is used in scenarios where a set of attachment informa
 <code src="./demo/overflow.tsx">Overflow</code>
 <code src="./demo/with-sender.tsx">Combination</code>
 <code src="./demo/files.tsx">File Card</code>
-<code src="./demo/files-custom.tsx">Custom File Card</code>
+<code src="./demo/files-custom.tsx">Custom Card Icon</code>
 
 ## API
 
@@ -78,8 +78,8 @@ interface Attachment extends UploadFile {
 | item | Attachment, same as Upload `UploadFile` | Attachment | - | - |
 | onRemove | A callback function, will be executed when removing file button is clicked, remove event will be prevented when the return value is false or a Promise which resolve(false) or reject | (item: Attachment) => boolean \| Promise | - | - |
 | imageProps | Image config, same as [Image](https://ant.design/components/image) | ImageProps | - | - |
-| icon | Custom Icon | React.ReactNode \| PresetIcons | - | - |
-| type | Is the image type | 'file' \| 'image' | `file` | - |
+| icon | Custom Icon | React.ReactNode \| PresetIcons | - | 1.6.0 |
+| type | Defines file type, when type is `image`, it will display in image preview mode | 'file' \| 'image' | `file` | 1.6.0 |
 
 ```ts
 type PresetIcons =

--- a/components/attachments/index.zh-CN.md
+++ b/components/attachments/index.zh-CN.md
@@ -24,7 +24,7 @@ Attachments 组件用于需要展示一组附件信息集合的场景。
 <code src="./demo/overflow.tsx">超出样式</code>
 <code src="./demo/with-sender.tsx">组合示例</code>
 <code src="./demo/files.tsx">文件卡片</code>
-<code src="./demo/files-custom.tsx">自定义文件卡片</code>
+<code src="./demo/files-custom.tsx">自定义卡片图标</code>
 
 ## API
 
@@ -72,8 +72,8 @@ interface PlaceholderType {
 | item | 附件，同 Upload `UploadFile` | Attachment | - | - |
 | onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | (item: Attachment) => boolean \| Promise | - | - |
 | imageProps | 图片属性，同 antd [Image](https://ant.design/components/image) 属性 | ImageProps | - | - |
-| icon | 自定义图标 | React.ReactNode \| PresetIcons | - | - |
-| type | 是否图片类型 | 'file' \| 'image' | `file` | - |
+| icon | 自定义图标 | React.ReactNode \| PresetIcons | - | 1.6.0 |
+| type | 定义文件类型，当类型为`image`时，会展示为图片预览模式 | 'file' \| 'image' | `file` | 1.6.0 |
 
 ```ts
 type PresetIcons =


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 文件卡片示例新增了一个无扩展名的图片文件项，丰富了文件类型展示。
  * 文件卡片的图标样式进行了优化，不同类型文件的图标颜色更加直观区分。

* **文档**
  * 示例名称由“自定义文件卡片”更新为“自定义卡片图标”。
  * API 文档中 `icon` 和 `type` 属性补充了自 1.6.0 版本支持的说明。
  * `type` 属性描述优化，明确当为 `image` 时将以图片预览模式展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->