### PR TITLE
fix: Simplify the logic for using common prefixes in typing hooks.

### DIFF
--- a/components/bubble/hooks/useTypedEffect.ts
+++ b/components/bubble/hooks/useTypedEffect.ts
@@ -57,13 +57,11 @@ const useTypedEffect = (
       // If there's no common prefix, start from beginning
       // If there's a common prefix, start from the point where they differ
       if (commonPrefixLength === 0) {
+        // Scenario 1: No common prefix, start from the beginning (AI completely changes the thinking process of the answer).
         setTypingIndex(1);
-      } else if (commonPrefixLength < content.length) {
-        // Start from the next character after the common prefix
-        setTypingIndex(commonPrefixLength + 1);
       } else {
-        // New content is shorter or same as common prefix, show all
-        setTypingIndex(content.length);
+        // Scenario 2: There is a common prefix, start from the point where they differ (common streaming output scenario)
+        setTypingIndex(commonPrefixLength + 1);
       }
     }
     prevContentRef.current = content;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 修复 Bubble 组件打字效果中公共前缀逻辑的冗余判断条件

### 💡 需求背景和解决方案

**问题描述：**
在 Bubble 组件的打字效果（useTypedEffect）中，处理公共前缀的逻辑存在不必要的条件判断：

```typescript
if (commonPrefixLength === 0) {
  setTypingIndex(1);
} else if (commonPrefixLength < content.length) {
  // Start from the next character after the common prefix
  setTypingIndex(commonPrefixLength + 1);
} else {
  // New content is shorter or same as common prefix, show all
  setTypingIndex(content.length);
}
```

其中 else 逻辑中 `// New content is shorter or same as common prefix, show all` 处理是冗余的，在逻辑上不存在：新内容长度小于公共前缀长度：
- 因为公共前缀是基于新内容判断出的。
- 新内容长度只会大于等于公共前缀长度。

**解决方案：**
简化逻辑，移除不必要的条件判断：

```typescript
if (commonPrefixLength === 0) {
  // 场景1：无公共前缀，从头开始（AI完全改变答案思路）
  setTypingIndex(1);
} else {
  // 场景2：有公共前缀，从差异点开始（常见的流式输出场景）
  setTypingIndex(commonPrefixLength + 1);
}
```

这样使逻辑更加清晰，避免了不存在的边缘情况判断。

**API 变化：**
无 API 变化，这是内部逻辑优化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | fix(Bubble): remove redundant condition in typing effect common prefix logic |
| 🇨🇳 中文 | 修复(Bubble)：移除打字效果公共前缀逻辑中的冗余条件判断 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了内容变更时的打字动画逻辑，修复了新内容与前一内容相同时未能正确显示差异的问题，提升了打字效果的连贯性和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->