### PR TITLE
feat: useXAgent add refreshDeps option

### DIFF
--- a/components/use-x-agent/index.ts
+++ b/components/use-x-agent/index.ts
@@ -26,6 +26,7 @@ export interface XAgentConfigPreset {
 }
 export interface XAgentConfigCustom<Message, Input, Output> {
   request?: RequestFn<Message, Input, Output>;
+  refreshDeps?: any[];
 }
 
 export type XAgentConfig<Message, Input, Output> = Partial<XAgentConfigPreset> &
@@ -97,7 +98,7 @@ export default function useXAgent<
   Input = RequestFnInfo<Message>,
   Output = SSEOutput,
 >(config: XAgentConfig<Message, Input, Output>) {
-  const { request, ...restConfig } = config;
+  const { request, refreshDeps = [], ...restConfig } = config;
 
   return React.useMemo(
     () =>
@@ -113,6 +114,6 @@ export default function useXAgent<
           ...restConfig,
         }),
       ] as const,
-    [config?.baseURL, config?.dangerouslyApiKey, config?.model],
+    [config?.baseURL, config?.dangerouslyApiKey, config?.model, ...refreshDeps],
   );
 }

--- a/components/use-x-agent/index.zh-CN.md
+++ b/components/use-x-agent/index.zh-CN.md
@@ -51,6 +51,7 @@ type useXAgent<AgentMessage> = (
 | 属性    | 说明                         | 类型      | 默认值 | 版本 |
 | ------- | ---------------------------- | --------- | ------ | ---- |
 | request | 配置自定义请求，支持流式更新 | RequestFn |        |      |
+| refreshDeps | Agent 实例更新的依赖列表，使用场景详见 [#536](https://github.com/ant-design/x/issues/536)。 | any[] |        |      |
 
 #### RequestFn
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Fix #536.

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

- useXAgent add `refreshDeps` option to get latest value in request function.

```
import React from 'react';
import { useXAgent } from '@ant-design/x';

const App = () => {
  const [value, setValue] = React.useState('');

  const [form] = Form.useForm();

  const [agent] = useXAgent({
    request: () => {
      console.log(value);
    },
    refreshDeps: [value],
  });
};

export default App;
```

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 🆕 useXAgent add `refreshDeps` option.         |
| 🇨🇳 Chinese | - 🆕 useXAgent 新增 `refreshDeps` 选项，作为 Agent 实例更新的依赖列表，使用场景详见 [#536](https://github.com/ant-design/x/issues/536)。           |
