### PR TITLE
docs: 补全文档中类似Prefix等属性

### DIFF
--- a/components/welcome/index.en-US.md
+++ b/components/welcome/index.en-US.md
@@ -29,6 +29,7 @@ Use the appropriate welcome recommendation component to effectively reduce the u
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| prefixCls | Prefix for style class names | string | - | - |
 | classNames | Custom style class names for different parts of each prompt item. | Record<'icon' \| 'title' \| 'description' \| 'extra', string> | - | - |
 | description | The description displayed in the prompt list. | React.ReactNode | - | - |
 | extra | The extra operation displayed at the end of the prompt list. | React.ReactNode | - | - |

--- a/components/welcome/index.zh-CN.md
+++ b/components/welcome/index.zh-CN.md
@@ -32,6 +32,7 @@ demo:
 
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| prefixCls | 样式类名的前缀 | string | - | - |
 | classNames | 自定义样式类名，用于各个提示项的不同部分。 | Record<'icon' \| 'title' \| 'description' \| 'extra', string> | - | - |
 | description | 显示在提示列表中的描述。 | React.ReactNode | - | - |
 | extra | 显示在提示列表末尾的额外操作。 | React.ReactNode | - | - |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [✅] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)


我看现在源码中应该都有类似Prefix，rootClassname这些prop，但是文档中有些组件缺少对这些属性的描述(比如Bubble)，有些组件又有这些属性的描述(比如Actions),不太确定是否需要给缺少的文档添加上这些描述，所以就先只修改了一个welcome组件。

而且文档中的通用属性这块的跳转也是404，是需要跳转到antd文档中的commonm-prop还是新开一个公共属性的描述呢？
<img width="754" height="122" alt="image" src="https://github.com/user-attachments/assets/f5aef185-0874-4550-bb45-adcd0639758f" />


### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.


> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
