### PR TITLE
fix(docs): fixed the incorrect Semantic DOM component names in the think component

### DIFF
--- a/packages/x/components/think/demo/_semantic.tsx
+++ b/packages/x/components/think/demo/_semantic.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => {
 
   return (
     <SemanticPreview
-      componentName="Sender"
+      componentName="Think"
       semantics={[
         { name: 'root', desc: locale.root },
         { name: 'status', desc: locale.status },


### PR DESCRIPTION
…ink component

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [✅] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx
<img width="1346" height="380" alt="image" src="https://github.com/user-attachments/assets/251d9736-7e46-4fb5-9ff8-c5f55a0a6147" />
<img width="1394" height="369" alt="image" src="https://github.com/user-attachments/assets/d7d8db32-87d9-4470-a20e-a6c3bd9b3a53" />

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
