### PR TITLE
fix(XMarkdown)：动画效果渲染规则

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/x-markdown/src/XMarkdown/__test__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`XMarkdown animation parent is custom components 1`] = `
+<div>
+  <div
+    class="ant-x-markdown x-markdown"
+    style="direction: ltr;"
+  >
+    <p>
+      This is Text.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`XMarkdown animation parent is not custom components 1`] = `
+<div>
+  <div
+    class="ant-x-markdown x-markdown"
+    style="direction: ltr;"
+  >
+    <p>
+      <span
+        style="animation: x-markdown-fadeIn 200ms ease-in-out forwards;"
+      >
+        This is Text.
+      </span>
+    </p>
+  </div>
+</div>
+`;

--- a/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
@@ -120,6 +120,8 @@ const testCases = [
   },
 ];
 
+const CustomParagraph = (props: any) => <p>{props.children}</p>;
+
 type ITestCase = {
   markdown: string;
   html: string;
@@ -230,6 +232,26 @@ describe('XMarkdown', () => {
       expect(link).not.toHaveAttribute('target');
       expect(link).not.toHaveAttribute('rel');
       expect(link).toHaveTextContent('Google');
+    });
+  });
+
+  describe('animation', () => {
+    it('parent is not custom components', () => {
+      const { container } = render(
+        <XMarkdown content="This is Text." streaming={{ enableAnimation: true }} />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('parent is custom components', () => {
+      const { container } = render(
+        <XMarkdown
+          content="This is Text."
+          components={{ p: CustomParagraph }}
+          streaming={{ enableAnimation: true }}
+        />,
+      );
+      expect(container).toMatchSnapshot();
     });
   });
 });

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -81,7 +81,11 @@ class Renderer {
       // Check if it's a text node with data
       const isValidTextNode =
         domNode.type === 'text' && domNode.data && Renderer.NON_WHITESPACE_REGEX.test(domNode.data);
-      if (enableAnimation && isValidTextNode) {
+      // Skip animation for text nodes inside custom components to preserve their internal structure
+      const parentTagName = (domNode.parent as Element)?.name;
+      const isParentCustomComponent = parentTagName && this.options.components?.[parentTagName];
+      const shouldReplaceText = enableAnimation && isValidTextNode && !isParentCustomComponent;
+      if (shouldReplaceText) {
         return React.createElement(AnimationText, { text: domNode.data, key, animationConfig });
       }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - 开启动画后，会将所有文本节点使用 AnimationText 进行渲染，导致自定义组件难以获取到 children 文本。
> - 解决方案：动画效果 AnimationText 组件替换规则：跳过父节点是自定义组件的文本节点

### 📝 Change Log

> - 修改动画效果 AnimationText 组件替换规则：父节点是自定义组件的文本节点

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
