### PR TITLE
feat(XMarkdown): add block and streamstatus to code component

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
@@ -254,21 +254,26 @@ describe('XMarkdown', () => {
       expect(container).toMatchSnapshot();
     });
   });
+});
 
-  it('should pass block and streamStatus props to custom code component', () => {
-    const CodeComponent = jest.fn(() => null);
+describe('custom code component props', () => {
+  const CodeComponent = jest.fn(() => null);
+
+  beforeEach(() => {
+    CodeComponent.mockClear();
+  });
+
+  it('should pass block=false and streamStatus=done for inline code', () => {
     const markdownInlineCodeFinished = 'Inline `code` here';
-    const markdownFenceCodeUnfinished = '```js\nconst a';
-    const markdownFencedCodeBlockFinished = '```js\nconst a = 1;\n```';
-    const markdownIndentedCodeBlockUnfinished = '    const a = 1';
-
     render(<XMarkdown content={markdownInlineCodeFinished} components={{ code: CodeComponent }} />);
     expect(CodeComponent).toHaveBeenCalledWith(
       expect.objectContaining({ block: false, streamStatus: 'done' }),
       undefined,
     );
+  });
 
-    CodeComponent.mockClear();
+  it('should pass block=true and streamStatus=loading for unfinished fenced code blocks start ```', () => {
+    const markdownFenceCodeUnfinished = '```';
     render(
       <XMarkdown content={markdownFenceCodeUnfinished} components={{ code: CodeComponent }} />,
     );
@@ -276,8 +281,21 @@ describe('XMarkdown', () => {
       expect.objectContaining({ block: true, streamStatus: 'loading' }),
       undefined,
     );
+  });
 
-    CodeComponent.mockClear();
+  it('should pass block=true and streamStatus=loading for unfinished fenced code blocks', () => {
+    const markdownFenceCodeUnfinished = '```js\nconst a';
+    render(
+      <XMarkdown content={markdownFenceCodeUnfinished} components={{ code: CodeComponent }} />,
+    );
+    expect(CodeComponent).toHaveBeenCalledWith(
+      expect.objectContaining({ block: true, streamStatus: 'loading' }),
+      undefined,
+    );
+  });
+
+  it('should pass block=true and streamStatus=done for finished fenced code blocks', () => {
+    const markdownFencedCodeBlockFinished = '```js\nconst a = 1;\n```';
     render(
       <XMarkdown content={markdownFencedCodeBlockFinished} components={{ code: CodeComponent }} />,
     );
@@ -285,8 +303,10 @@ describe('XMarkdown', () => {
       expect.objectContaining({ block: true, streamStatus: 'done' }),
       undefined,
     );
+  });
 
-    CodeComponent.mockClear();
+  it('should pass block=true and streamStatus=done for indented code blocks', () => {
+    const markdownIndentedCodeBlockUnfinished = '    const a = 1';
     render(
       <XMarkdown
         content={markdownIndentedCodeBlockUnfinished}

--- a/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
@@ -41,7 +41,7 @@ const testCases = [
   {
     title: 'Render code block',
     markdown: "```javascript\nconsole.log('hello');\n```",
-    html: '<pre><code class="language-javascript">console.log(\'hello\');\n</code></pre>\n',
+    html: '<pre><code data-block="true" data-state="done" class="language-javascript">console.log(\'hello\');\n</code></pre>\n',
   },
   {
     title: 'Render link',
@@ -253,5 +253,49 @@ describe('XMarkdown', () => {
       );
       expect(container).toMatchSnapshot();
     });
+  });
+
+  it('should pass block and streamStatus props to custom code component', () => {
+    const CodeComponent = jest.fn(() => null);
+    const markdownInlineCodeFinished = 'Inline `code` here';
+    const markdownFenceCodeUnfinished = '```js\nconst a';
+    const markdownFencedCodeBlockFinished = '```js\nconst a = 1;\n```';
+    const markdownIndentedCodeBlockUnfinished = '    const a = 1';
+
+    render(<XMarkdown content={markdownInlineCodeFinished} components={{ code: CodeComponent }} />);
+    expect(CodeComponent).toHaveBeenCalledWith(
+      expect.objectContaining({ block: false, streamStatus: 'done' }),
+      undefined,
+    );
+
+    CodeComponent.mockClear();
+    render(
+      <XMarkdown content={markdownFenceCodeUnfinished} components={{ code: CodeComponent }} />,
+    );
+    expect(CodeComponent).toHaveBeenCalledWith(
+      expect.objectContaining({ block: true, streamStatus: 'loading' }),
+      undefined,
+    );
+
+    CodeComponent.mockClear();
+    render(
+      <XMarkdown content={markdownFencedCodeBlockFinished} components={{ code: CodeComponent }} />,
+    );
+    expect(CodeComponent).toHaveBeenCalledWith(
+      expect.objectContaining({ block: true, streamStatus: 'done' }),
+      undefined,
+    );
+
+    CodeComponent.mockClear();
+    render(
+      <XMarkdown
+        content={markdownIndentedCodeBlockUnfinished}
+        components={{ code: CodeComponent }}
+      />,
+    );
+    expect(CodeComponent).toHaveBeenCalledWith(
+      expect.objectContaining({ block: true, streamStatus: 'done' }),
+      undefined,
+    );
   });
 });

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -7,20 +7,53 @@ type ParserOptions = {
   openLinksInNewTab?: boolean;
 };
 
+export const other = {
+  escapeTestNoEncode: /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/,
+  escapeTest: /[&<>"']/,
+  notSpaceStart: /^\S*/,
+  endingNewline: /\n$/,
+  escapeReplace: /[&<>"']/g,
+  escapeReplaceNoEncode: /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/g,
+};
+
+const escapeReplacements: { [index: string]: string } = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+const getEscapeReplacement = (ch: string) => escapeReplacements[ch];
+
+export function escape(html: string, encode?: boolean) {
+  if (encode) {
+    if (other.escapeTest.test(html)) {
+      return html.replace(other.escapeReplace, getEscapeReplacement);
+    }
+  } else {
+    if (other.escapeTestNoEncode.test(html)) {
+      return html.replace(other.escapeReplaceNoEncode, getEscapeReplacement);
+    }
+  }
+
+  return html;
+}
+
 class Parser {
   options: ParserOptions;
   markdownInstance: Marked;
 
   constructor(options: ParserOptions = {}) {
-    const { markedConfig = {}, openLinksInNewTab } = options;
+    const { markedConfig = {} } = options;
     this.options = options;
     this.markdownInstance = new Marked(markedConfig);
-    this.configureRenderer(openLinksInNewTab);
-    this.configureParagraph();
+    this.configureLinkRenderer();
+    this.configureParagraphRenderer();
+    this.configureCodeRenderer();
   }
 
-  private configureRenderer(openLinksInNewTab?: boolean) {
-    if (!openLinksInNewTab) return;
+  private configureLinkRenderer() {
+    if (!this.options.openLinksInNewTab) return;
 
     const renderer = {
       link(this: Renderer, { href, title, tokens }: Tokens.Link) {
@@ -32,13 +65,31 @@ class Parser {
     this.markdownInstance.use({ renderer });
   }
 
-  public configureParagraph() {
+  public configureParagraphRenderer() {
     const { paragraphTag } = this.options;
     if (!paragraphTag) return;
 
     const renderer = {
       paragraph(this: Renderer, { tokens }: Tokens.Paragraph) {
         return `<${paragraphTag}>${this.parser.parseInline(tokens)}</${paragraphTag}>\n`;
+      },
+    };
+    this.markdownInstance.use({ renderer });
+  }
+
+  public configureCodeRenderer() {
+    const renderer = {
+      code({ text, raw, lang, escaped, codeBlockStyle }: Tokens.Code): string {
+        const langString = (lang || '').match(other.notSpaceStart)?.[0];
+        const code = text.replace(other.endingNewline, '') + '\n';
+        const isIndentedCode = codeBlockStyle === 'indented';
+        // if code is indented, it's done because it has no end tag
+        const streamStatus = isIndentedCode || raw.endsWith('```') ? 'done' : 'loading';
+        const escapedCode = escaped ? code : escape(code, true);
+
+        const classAttr = langString ? ` class="language-${escape(langString)}"` : '';
+
+        return `<pre><code data-block="true" data-state="${streamStatus}"${classAttr}>${escapedCode}</code></pre>\n`;
       },
     };
     this.markdownInstance.use({ renderer });

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -25,7 +25,7 @@ const escapeReplacements: { [index: string]: string } = {
 };
 const getEscapeReplacement = (ch: string) => escapeReplacements[ch];
 
-export function escape(html: string, encode?: boolean) {
+export function escapeHtml(html: string, encode?: boolean) {
   if (encode) {
     if (other.escapeTest.test(html)) {
       return html.replace(other.escapeReplace, getEscapeReplacement);
@@ -85,9 +85,9 @@ class Parser {
         const isIndentedCode = codeBlockStyle === 'indented';
         // if code is indented, it's done because it has no end tag
         const streamStatus = isIndentedCode || raw.endsWith('```') ? 'done' : 'loading';
-        const escapedCode = escaped ? code : escape(code, true);
+        const escapedCode = escaped ? code : escapeHtml(code, true);
 
-        const classAttr = langString ? ` class="language-${escape(langString)}"` : '';
+        const classAttr = langString ? ` class="language-${escapeHtml(langString)}"` : '';
 
         return `<pre><code data-block="true" data-state="${streamStatus}"${classAttr}>${escapedCode}</code></pre>\n`;
       },

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -84,7 +84,8 @@ class Parser {
         const code = text.replace(other.endingNewline, '') + '\n';
         const isIndentedCode = codeBlockStyle === 'indented';
         // if code is indented, it's done because it has no end tag
-        const streamStatus = isIndentedCode || raw.endsWith('```') ? 'done' : 'loading';
+        const streamStatus =
+          isIndentedCode || /(`{3,})([^`]*)\1/m.test(raw.trim()) ? 'done' : 'loading';
         const escapedCode = escaped ? code : escapeHtml(code, true);
 
         const classAttr = langString ? ` class="language-${escapeHtml(langString)}"` : '';

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -109,6 +109,13 @@ class Renderer {
           .trim();
         props.className = classes || '';
 
+        if (name === 'code') {
+          const { 'data-block': block = 'false', 'data-state': codeStreamStatus = 'done' } =
+            attribs || {};
+          props.block = block === 'true';
+          props.streamStatus = codeStreamStatus as ComponentProps['streamStatus'];
+        }
+
         if (children) {
           props.children = this.processChildren(children as DOMNode[], unclosedTags, cidRef);
         }

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -113,7 +113,7 @@ class Renderer {
           const { 'data-block': block = 'false', 'data-state': codeStreamStatus = 'done' } =
             attribs || {};
           props.block = block === 'true';
-          props.streamStatus = codeStreamStatus as ComponentProps['streamStatus'];
+          props.streamStatus = codeStreamStatus === 'loading' ? 'loading' : 'done';
         }
 
         if (children) {

--- a/packages/x/docs/x-markdown/components.en-US.md
+++ b/packages/x/docs/x-markdown/components.en-US.md
@@ -116,8 +116,8 @@ const UserCard = ({ domNode, streamStatus }) => {
 ## ComponentProps
 
 | Property | Description | Type | Default |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | domNode | Component DOM node from html-react-parser, containing parsed DOM node information | [`DOMNode`](https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace) | - |
-| streamStatus | Streaming rendering supports two states: `loading` indicates content is being loaded, and `done` indicates loading is complete. Currently, only HTML format and fenced code blocks are supported. Since indented code blocks lack a clear end delimiter, they always return the `done` state. | - |
+| streamStatus | Streaming rendering supports two states: `loading` indicates content is being loaded, and `done` indicates loading is complete. Currently, only HTML format and fenced code blocks are supported. Since indented code blocks lack a clear end delimiter, they always return the `done` state. | `'loading' \| 'done'` |  | - |
 | children | Content wrapped in the component, containing text content of DOM nodes | `React.ReactNode` | - |
 | rest | Component properties, supports all standard HTML attributes (such as `href`, `title`, `className`, etc.) and custom data attributes | `Record<string, any>` | - |

--- a/packages/x/docs/x-markdown/components.en-US.md
+++ b/packages/x/docs/x-markdown/components.en-US.md
@@ -118,6 +118,6 @@ const UserCard = ({ domNode, streamStatus }) => {
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | domNode | Component DOM node from html-react-parser, containing parsed DOM node information | [`DOMNode`](https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace) | - |
-| streamStatus | Streaming status, `loading` indicates loading in progress, `done` indicates loading completed | `'loading' \| 'done'` | - |
+| streamStatus | Streaming rendering supports two states: `loading` indicates content is being loaded, and `done` indicates loading is complete. Currently, only HTML format and fenced code blocks are supported. Since indented code blocks lack a clear end delimiter, they always return the `done` state. | - |
 | children | Content wrapped in the component, containing text content of DOM nodes | `React.ReactNode` | - |
 | rest | Component properties, supports all standard HTML attributes (such as `href`, `title`, `className`, etc.) and custom data attributes | `Record<string, any>` | - |

--- a/packages/x/docs/x-markdown/components.en-US.md
+++ b/packages/x/docs/x-markdown/components.en-US.md
@@ -116,8 +116,8 @@ const UserCard = ({ domNode, streamStatus }) => {
 ## ComponentProps
 
 | Property | Description | Type | Default |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | domNode | Component DOM node from html-react-parser, containing parsed DOM node information | [`DOMNode`](https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace) | - |
-| streamStatus | Streaming rendering supports two states: `loading` indicates content is being loaded, and `done` indicates loading is complete. Currently, only HTML format and fenced code blocks are supported. Since indented code blocks lack a clear end delimiter, they always return the `done` state. | `'loading' \| 'done'` |  | - |
+| streamStatus | Streaming rendering supports two states: `loading` indicates content is being loaded, and `done` indicates loading is complete. Currently, only HTML format and fenced code blocks are supported. Since indented code blocks lack a clear end delimiter, they always return the `done` state. | `'loading' \| 'done'` | - |
 | children | Content wrapped in the component, containing text content of DOM nodes | `React.ReactNode` | - |
 | rest | Component properties, supports all standard HTML attributes (such as `href`, `title`, `className`, etc.) and custom data attributes | `Record<string, any>` | - |

--- a/packages/x/docs/x-markdown/components.zh-CN.md
+++ b/packages/x/docs/x-markdown/components.zh-CN.md
@@ -118,6 +118,6 @@ const UserCard = ({ domNode, streamStatus }) => {
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | domNode | 来自 html-react-parser 的组件 DOM 节点，包含解析后的 DOM 节点信息 | [`DOMNode`](https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace) | - |
-| streamStatus | 流式状态，`loading` 表示正在加载，`done` 表示加载完成 | `'loading' \| 'done'` | - |
+| streamStatus | 流式渲染支持两种状态：`loading` 表示内容正在加载中，`done` 表示加载已完成。当前仅支持 HTML 格式以及带围栏的代码块（fenced code）。由于缩进代码块（indented code）没有明确的结束符，因此始终返回 `done` 状态 | `'loading' \| 'done'` | - |
 | children | 包裹在组件中的内容，包含 DOM 节点的文本内容 | `React.ReactNode` | - |
 | rest | 组件属性，支持所有标准 HTML 属性（如 `href`、`title`、`className` 等）和自定义数据属性 | `Record<string, any>` | - |

--- a/packages/x/docs/x-markdown/examples.en-US.md
+++ b/packages/x/docs/x-markdown/examples.en-US.md
@@ -59,7 +59,7 @@ Used for rendering streaming Markdown format returned by LLMs.
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | domNode | Component Element from html-react-parser, contains the parsed DOM node information | [`DOMNode`](https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace) | - |
-| streamStatus | Streaming status, `loading` indicates streaming in progress, `done` indicates streaming complete | `'loading' \| 'done'` | - |
+| streamStatus | Streaming rendering supports two states: `loading` indicates content is being loaded, and `done` indicates loading is complete. Currently, only HTML format and fenced code blocks are supported. Since indented code blocks lack a clear end delimiter, they always return the `done` state. | `'loading' \| 'done'` | - |
 | rest | Component properties, supports all standard HTML attributes (e.g. `href`, `title`, `className`, etc.) and custom data attributes | `Record<string, any>` | - |
 
 ## FAQ

--- a/packages/x/docs/x-markdown/examples.zh-CN.md
+++ b/packages/x/docs/x-markdown/examples.zh-CN.md
@@ -59,7 +59,7 @@ order: 2
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | domNode | 来自 html-react-parser 的组件 DOM 节点，包含解析后的 DOM 节点信息 | [`DOMNode`](https://github.com/remarkablemark/html-react-parser?tab=readme-ov-file#replace) | - |
-| streamStatus | 流式状态，`loading` 表示正在加载，`done` 表示加载完成 | `'loading' \| 'done'` | - |
+| streamStatus |流式渲染支持两种状态：`loading` 表示内容正在加载中，`done` 表示加载已完成。当前仅支持 HTML 格式以及带围栏的代码块（fenced code）。由于缩进代码块（indented code）没有明确的结束符，因此始终返回 `done` 状态 | `'loading' \| 'done'` | - |
 | rest | 组件属性，支持所有标准 HTML 属性（如 `href`、`title`、`className` 等）和自定义数据属性 | `Record<string, any>` | - |
 
 ## FAQ


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - Code 组件难以识别是块级还是行内组件，以及需要 streamStatus 判断流式状态。
> - 通过覆写 renderer.code 传入自定义的属性识别块机和流式状态。


### 📝 Change Log

> - feat：code 组件新增 block 属性
> - fix: code 组件 streamStatus 状态不准

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
