### PR TITLE
fix(XMarkdown): component key repeat

### DIFF
--- a/packages/x-markdown/src/XMarkdown/AnimationText.tsx
+++ b/packages/x-markdown/src/XMarkdown/AnimationText.tsx
@@ -38,7 +38,7 @@ const AnimationText = React.memo<AnimationTextProps>((props) => {
   return (
     <>
       {chunks.map((text, index) => (
-        <span style={animationStyle} key={`${index}-${text}`}>
+        <span style={animationStyle} key={`animation-text-${index}`}>
           {text}
         </span>
       ))}

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -76,7 +76,7 @@ class Renderer {
   private createReplaceElement(unclosedTags: Set<string> | undefined, cidRef: { current: number }) {
     const { enableAnimation, animationConfig } = this.options.streaming || {};
     return (domNode: DOMNode) => {
-      const key = cidRef.current++;
+      const key = 'x-markdown-component' + cidRef.current++;
 
       // Check if it's a text node with data
       const isValidTextNode =


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - 在开启动画且没有覆盖自定义组件时，会出现 key 重复。因为 XMarkdown 里指定的 key 的规则和 react 默认规则一致，导致 key 重复
> - 通过给 XMarkdown 组件 key 加上前缀，避免重复问题。

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - fix:  component key 新增前缀，避免 key 重复

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
