### PR TITLE
fix(XMarkdown): prevent user renderer from being overridden

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
@@ -319,3 +319,128 @@ describe('custom code component props', () => {
     );
   });
 });
+
+describe('extensions', () => {
+  it('user extension should be called before default extension', () => {});
+
+  it('should use default link renderer when user renderer returns false', () => {
+    const { container } = render(
+      <XMarkdown
+        content="[Google](https://google.com)"
+        openLinksInNewTab
+        config={{
+          renderer: {
+            link() {
+              return false as any;
+            },
+          },
+        }}
+      />,
+    );
+    const link = container.querySelector('a');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://google.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveTextContent('Google');
+  });
+
+  it('should use user link renderer when it returns non-false', () => {
+    const { container } = render(
+      <XMarkdown
+        content="[Google](https://google.com)"
+        config={{
+          renderer: {
+            link({ href, text }) {
+              return `<a href="${href}" class="custom-link">${text}</a>`;
+            },
+          },
+        }}
+      />,
+    );
+    const link = container.querySelector('a');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('custom-link');
+    expect(link).not.toHaveAttribute('target');
+    expect(link).not.toHaveAttribute('rel');
+    expect(link).toHaveTextContent('Google');
+  });
+
+  it('should use default paragraph renderer when user renderer returns false', () => {
+    const { container } = render(
+      <XMarkdown
+        content="Hello"
+        paragraphTag="div"
+        config={{
+          renderer: {
+            paragraph() {
+              return false as any;
+            },
+          },
+        }}
+      />,
+    );
+    expect(container.querySelector('div')).toHaveTextContent('Hello');
+  });
+
+  it('should use user paragraph renderer when it returns non-false', () => {
+    const { container } = render(
+      <XMarkdown
+        content="Hello"
+        config={{
+          renderer: {
+            paragraph({ text }) {
+              return `<section>${text}</section>`;
+            },
+          },
+        }}
+      />,
+    );
+    expect(container.querySelector('section')).toHaveTextContent('Hello');
+  });
+
+  it('should use default code renderer when user renderer returns false', async () => {
+    const content = `\`\`\`javascript
+console.log("javascript");
+\`\`\``;
+    const { container } = render(
+      <XMarkdown
+        content={content}
+        config={{
+          renderer: {
+            code() {
+              return false as any;
+            },
+          },
+        }}
+      />,
+    );
+    const codeElement = container.querySelector('code');
+    expect(codeElement).toBeInTheDocument();
+    expect(codeElement).toHaveAttribute('data-block', 'true');
+    expect(codeElement).toHaveAttribute('data-state', 'done');
+  });
+
+  it('should use user code renderer when it returns non-false', () => {
+    const content = `\`\`\`js
+console.log(1);
+\`\`\``;
+    const { container } = render(
+      <XMarkdown
+        content={content}
+        config={{
+          renderer: {
+            code({ lang, text }) {
+              return `<pre><code class="lang-${lang}">${text.trim()}</code></pre>`;
+            },
+          },
+        }}
+      />,
+    );
+    const code = container.querySelector('pre code');
+    expect(code).toHaveClass('lang-js');
+    expect(code).toHaveTextContent('console.log(1);');
+    expect(code).not.toHaveAttribute('data-block');
+    expect(code).not.toHaveAttribute('data-state');
+  });
+});

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -46,10 +46,13 @@ class Parser {
   constructor(options: ParserOptions = {}) {
     const { markedConfig = {} } = options;
     this.options = options;
-    this.markdownInstance = new Marked(markedConfig);
+    this.markdownInstance = new Marked();
+
     this.configureLinkRenderer();
     this.configureParagraphRenderer();
     this.configureCodeRenderer();
+    // user config at last
+    this.markdownInstance.use(markedConfig);
   }
 
   private configureLinkRenderer() {

--- a/packages/x/docs/x-markdown/demo/streaming/combined.tsx
+++ b/packages/x/docs/x-markdown/demo/streaming/combined.tsx
@@ -89,6 +89,7 @@ const App: React.FC = () => {
             <XMarkdown
               className={className}
               content={content as string}
+              paragraphTag="div"
               streaming={{
                 hasNextChunk: isStreaming && enableCache,
                 enableAnimation,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - 用户配置 code、paragraph、link renderer 是可能会被覆盖。原因是 XMarkdown 默认的 renderer 优先级高于用户传入。
> - 移动传入 renderer 顺序，使得用户传入的 renderer 优先级更高。


### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - 调整用户传入 renderer 的优先级，防止被组件默认 renderer 覆盖。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
