### PR TITLE
fix(XMarkdown): correct merge dompurifyConfig

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__test__/Renderer.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__test__/Renderer.test.ts
@@ -403,7 +403,7 @@ describe('Renderer', () => {
 
     it('should deduplicate tags in ADD_TAGS', () => {
       const userConfig = {
-        ALLOWED_TAGS: ['custom-tag'],
+        ADD_TAGS: ['custom-tag', 'custom-tag2'],
       };
 
       const renderer = new Renderer({
@@ -417,8 +417,8 @@ describe('Renderer', () => {
       const configureDOMPurify = (renderer as any).configureDOMPurify.bind(renderer);
       const config = configureDOMPurify();
 
-      const customTagCount = config.ADD_TAGS.filter((tag: string) => tag === 'custom-tag').length;
-      expect(customTagCount).toBe(1);
+      expect(config.ADD_TAGS).toEqual(['custom-tag', 'custom-tag2']);
+      expect(config.ALLOWED_TAGS).toBeUndefined();
     });
   });
 

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -63,7 +63,7 @@ class Renderer {
     const customComponents = Object.keys(this.options.components || {});
     const userConfig = this.options.dompurifyConfig || {};
 
-    const allowedTags = Array.isArray(userConfig.ALLOWED_TAGS) ? userConfig.ALLOWED_TAGS : [];
+    const allowedTags = Array.isArray(userConfig.ADD_TAGS) ? userConfig.ADD_TAGS : [];
     const addAttr = Array.isArray(userConfig.ADD_ATTR) ? userConfig.ADD_ATTR : [];
 
     return {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 💡 Background and Solution

> -  dompurifyConfig.ALLOWED_TAGS 错误合并到 ADD_TAGS。

### 📝 Change Log

> - 修复 dompurifyConfig.ALLOWED_TAGS 被错误合并到 ADD_TAGS。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
