### PR TITLE
fix(XMarkdown): correct code streamStatus when code after \n\n

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__test__/index.test.tsx
@@ -279,7 +279,7 @@ describe('custom code component props', () => {
     {
       title:
         'should pass block=true and streamStatus=loading for unfinished fenced code blocks start ```',
-      markdown: '```',
+      markdown: '   ```',
       block: true,
       streamStatus: 'loading',
     },
@@ -295,12 +295,19 @@ describe('custom code component props', () => {
         'should pass block=true and streamStatus=loading for unfinished fenced code blocks with ```',
       markdown: '```js\nconsole.log(`log`);\n```',
       block: true,
-      streamStatus: 'loading',
+      streamStatus: 'done',
     },
     {
       title:
         'should pass block=true and streamStatus=done for finished fenced code blocks with ```',
-      markdown: '```js\n console.log(`log`);\n```\n',
+      markdown: 'start text\n```js\n console.log(`log`);\n```\n end text',
+      block: true,
+      streamStatus: 'done',
+    },
+    {
+      title:
+        'should pass block=true and streamStatus=done for finished fenced code blocks with ```\n\n',
+      markdown: 'start text\n```js\n console.log(`log`);\n```\n\n end text',
       block: true,
       streamStatus: 'done',
     },
@@ -321,7 +328,14 @@ describe('custom code component props', () => {
     {
       title:
         'should pass block=true and streamStatus=done for finished fenced code blocks with ~~~',
-      markdown: '~~~js\n console.log(`log`);\n~~~\n',
+      markdown: 'start text\n ~~~js\n console.log(`log`);\n~~~\n end text',
+      block: true,
+      streamStatus: 'done',
+    },
+    {
+      title:
+        'should pass block=true and streamStatus=done for finished fenced code blocks with ~~~\n\n',
+      markdown: 'start text\n\n ~~~js\n console.log(`log`);\n~~~\n\n end text',
       block: true,
       streamStatus: 'done',
     },

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -14,8 +14,7 @@ export const other = {
   endingNewline: /\n$/,
   escapeReplace: /[&<>"']/g,
   escapeReplaceNoEncode: /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/g,
-  completeFencedCode:
-    /^ {0,3}(`{3,}(?=[^`\n]*(?:\n|$))|~{3,})(?:[^\n]*)(?:\n|$)([\s\S]*?)(?:\n|$) {0,3}\1[~`]* *\n/,
+  completeFencedCode: /^ {0,3}(`{3,}|~{3,})([\s\S]*?)\n {0,3}\1[ \n\t]*$/,
 };
 
 const escapeReplacements: { [index: string]: string } = {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Fix set code streamStastus wrong when code after \n\n

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **功能移除**
  * 移除了 Actions 操作菜单组件
  * 移除了 Attachments 文件附件组件
  * 移除了 Bubble 气泡消息组件及其列表功能
  * 移除了主题编辑器和相关自定义页面
  * 移除了主页和多个文档相关页面布局

* **基础设施更新**
  * 更新了构建配置和持续集成工作流程
  * 调整了代码检查和构建工具链

<!-- end of auto-generated comment: release notes by coderabbit.ai -->