### PR TITLE
fix(x-sdk): add throttling to ChatMessagesStore to prevent "Maximum update depth exceeded" during streaming

### DIFF
--- a/packages/x-sdk/src/x-chat/store.ts
+++ b/packages/x-sdk/src/x-chat/store.ts
@@ -131,6 +131,15 @@ export class ChatMessagesStore<T extends { id: number | string }> {
     this.listeners.push(callback);
     return () => {
       this.listeners = this.listeners.filter((listener) => listener !== callback);
+      // Clean up throttle timer when no listeners remain to prevent memory leaks
+      // and "setState on unmounted component" warnings
+      if (this.listeners.length === 0) {
+        if (this.throttleTimer) {
+          clearTimeout(this.throttleTimer);
+          this.throttleTimer = null;
+        }
+        this.pendingEmit = false;
+      }
     };
   };
 


### PR DESCRIPTION
## Summary

This PR adds throttling to `ChatMessagesStore.emitListeners()` to prevent "Maximum update depth exceeded"
warnings during SSE streaming.

Fixes #540
Related to #913

## Problem

During SSE streaming (common with LLM integrations), each chunk triggers `setMessages()` → `emitListeners()` →
React re-render. When chunks arrive rapidly, React detects nested updates exceeding its depth limit:

Warning: Maximum update depth exceeded. This can happen when a component
calls setState inside useEffect, but useEffect either doesn't have a
dependency array, or one of the dependencies changes on every render.

## Solution

Add a 50ms throttle to `emitListeners()` with:

- **Leading edge**: First update triggers immediately for responsive UI
- **Trailing edge**: Pending updates are flushed after throttle interval
- **Initialization bypass**: No throttle during constructor to avoid startup delay

## Changes

- Added `throttleTimer`, `pendingEmit`, `throttleInterval` private properties
- Added `throttledEmitListeners()` private method
- Added `setMessagesInternal()` private method with throttle control
- Modified `setMessages()` to use throttled emit
- Modified constructor to use non-throttled initialization

## Testing

### Before
- Dozens of "Maximum update depth exceeded" warnings during streaming
- Console flooded with warnings affecting DX

### After
- Zero warnings
- Smooth streaming output
- No perceptible delay in UI updates

## Compatibility

- No breaking changes to public API
- `setMessages()` signature unchanged
- All existing tests should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 destroy() 方法，用于清理消息存储并释放节流计时器，便于销毁/重置实例。
* **Bug修复**
  * 优化消息流的节流与发射逻辑，避免高频流式更新导致的深度更新错误，提升实时消息稳定性与性能。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->