### PR TITLE
fix(XMarkdown): replace useStreaming regex to avoid compatibility issues

### DIFF
--- a/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
@@ -165,17 +165,22 @@ const sanitizeForURIComponent = (input: string): string => {
 
     // 处理代理对：保留合法，跳过孤立
     if (charCode >= 0xd800 && charCode <= 0xdbff) {
-      if (i + 1 < input.length) {
-        const nextCharCode = input.charCodeAt(i + 1);
-        if (nextCharCode >= 0xdc00 && nextCharCode <= 0xdfff) {
-          result += input[i] + input[i + 1];
-          i++;
-        }
+      // High surrogate
+      // Check for a following low surrogate to form a valid pair
+      if (
+        i + 1 < input.length &&
+        input.charCodeAt(i + 1) >= 0xdc00 &&
+        input.charCodeAt(i + 1) <= 0xdfff
+      ) {
+        result += input[i] + input[i + 1];
+        i++; // Skip the low surrogate as it's already processed
       }
-    } else if (charCode >= 0xdc00 && charCode <= 0xdfff) {
-    } else {
+      // Lone high surrogates are otherwise skipped
+    } else if (charCode < 0xdc00 || charCode > 0xdfff) {
+      // Append characters that are not lone low surrogates
       result += input[i];
     }
+    // Lone low surrogates are otherwise skipped
   }
   return result;
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - #1436 

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Replace useStreaming regex to avoid compatibility issues  |
| 🇨🇳 Chinese |  替换正则避免 ios 兼容性问题。   |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了 URI 编码对代理对（surrogate pairs）的处理：保留有效高/低代理对并省略孤立代理单元，遇到 URIError 时使用更稳健的清理与重新编码逻辑（替代此前的正则移除方案），从而在多语言与特殊字符场景下提高稳定性与编码准确性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->