### PR TITLE
fix: correct scripts tsconfig typeRoots

### DIFF
--- a/packages/x/scripts/tsconfig.json
+++ b/packages/x/scripts/tsconfig.json
@@ -14,7 +14,6 @@
     "allowJs": true,
     "noEmitOnError": false,
     "importHelpers": false,
-    "typeRoots": ["../../node_modules/@types"],
     "types": ["node"]
   },
   "include": ["./"],


### PR DESCRIPTION
### 🤔 This is a ...
- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
- N/A

### 💡 Background and Solution
- `packages/x/scripts/tsconfig.json` 的 `typeRoots` 原来指向 `../node_modules/@types`，该目录在 scripts 包内并不存在，导致脚本编译无法解析全局类型。
- 将配置改为 `../../node_modules/@types`，确保脚本能读取仓库根目录安装的类型声明。

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix script tsconfig `typeRoots` so scripts resolve shared typings correctly. |
| 🇨🇳 Chinese | 修复 scripts tsconfig `typeRoots` 路径，确保脚本能解析根目录共享的类型声明。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了项目配置以优化类型定义的解析路径。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->