### PR TITLE
Chore/fix scripts tsconfig typeroots

### DIFF
--- a/packages/x/scripts/tsconfig.json
+++ b/packages/x/scripts/tsconfig.json
@@ -11,7 +11,6 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "allowJs": true,
     "noEmitOnError": false,
     "importHelpers": false,
     "types": ["node"]


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- N/A

### 💡 Background and Solution

- **Fix Type Resolution**: Previously, `typeRoots` pointed to a non-existent relative path (`../node_modules/@types`). Removed it to let TypeScript automatically resolve types from the project root.
- **Fix Compile Error**: Removed `"allowJs": true`. This setting caused TypeScript to attempt compiling standalone JS files (like `scripts/visual-regression/upload.js`) in place, resulting in "overwrite input file" errors.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix scripts tsconfig: remove redundant `typeRoots` and disable `allowJs` to avoid compilation errors. |
| 🇨🇳 Chinese | 修复 scripts tsconfig：移除冗余的 `typeRoots` 并禁用 `allowJs` 以避免 JS 文件覆盖报错。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新说明

* **杂项**
  * 调整 TypeScript 编译器配置，优化项目构建设置。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->