### PR TITLE
fix: 修复 Skill 组件 Tooltip 子元素必须为 React 元素的问题

### DIFF
--- a/packages/x/components/sender/components/Skill.tsx
+++ b/packages/x/components/sender/components/Skill.tsx
@@ -63,7 +63,13 @@ const Skill: React.FC<SkillProps> = ({
   }, [closable, removeSkill]);
 
   const mergeTitle = title || value;
-  const titleNode = toolTip ? <Tooltip {...toolTip}>{mergeTitle}</Tooltip> : mergeTitle;
+  const titleNode = toolTip ? (
+    <Tooltip {...toolTip}>
+      <span>{mergeTitle}</span>
+    </Tooltip>
+  ) : (
+    mergeTitle
+  );
 
   return (
     <div className={`${componentCls}-wrapper`} contentEditable={false}>


### PR DESCRIPTION
根据本次修复内容，以下是中文 PR 模板：

---

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

修复 Sender 组件中 Skill 使用 Tooltip 时测试用例报错的问题。

### 💡 需求背景和解决方案

**问题描述：**

Skill 组件在使用 `toolTip` 属性时，`Tooltip` 的子元素直接传入字符串，导致 `Tooltip` 内部的 `Trigger` 组件调用 `React.Children.only` 时抛出错误：

```
React.Children.only expected to receive a single React element child.
```

**解决方案：**

将 `Tooltip` 的子元素用 `<span>` 包裹，确保传入的是 React 元素而非纯字符串。

```tsx
// 修复前
const titleNode = toolTip ? <Tooltip {...toolTip}>{mergeTitle}</Tooltip> : mergeTitle;

// 修复后
const titleNode = toolTip ? (
  <Tooltip {...toolTip}>
    <span>{mergeTitle}</span>
  </Tooltip>
) : (
  mergeTitle
);
```

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Skill component Tooltip children must be a React element |
| 🇨🇳 中文 | 修复 Skill 组件 Tooltip 子元素必须为 React 元素的问题 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为标题添加了工具提示（Tooltip）支持，当提供工具提示内容时会在标题上显示。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->