### PR TITLE
chore: remove invalid check-commit script

### DIFF
--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -40,7 +40,6 @@
     "prepublishOnly": "tsx ../../scripts/pre-publish.ts x",
     "authors": "tsx scripts/generate-authors.ts",
     "changelog": "npm run lint:changelog && tsx scripts/print-changelog.ts",
-    "check-commit": "tsx scripts/check-commit.ts",
     "clean": "antd-tools run clean && rm -rf es lib coverage locale dist report.html artifacts.zip oss-artifacts.zip",
     "precompile": "npm run prestart",
     "compile": "father build && cp -r locale es",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ❓ 其他改动（删除了package.json中不存在的script脚本）

**问题：**
在 `packages/x/package.json` 中定义了 `"check-commit": "tsx scripts/check-commit.ts"`，但对应的脚本文件 `packages/x/scripts/check-commit.ts` 实际上并不存在。

**解决方案：**
删除了 `packages/x/package.json` 中无效的 `check-commit` 脚本。相关的 Git 状态检查逻辑（如果需要）应集成在标准的 `pre-publish` 流程中，而不是保留一个指向空路径的独立命令。

### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://x.ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix `check-commit` script error in package.json due to missing file. |
| 🇨🇳 中文 | 修复 package.json 中 `check-commit` 脚本指向不存在文件导致报错的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本发布说明

* **杂项优化**
  * 从项目配置中移除了 check-commit 脚本

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->