### PR TITLE
docs: Modified the error in writing the extension budget symbol in mar…

### DIFF
--- a/packages/x/components/x-provider/index.en-US.md
+++ b/packages/x/components/x-provider/index.en-US.md
@@ -48,7 +48,7 @@ import { XProvider  } from '@ant-design/x';
 import zhCN from 'antd/locale/zh_CN';
 import zhCN_X from '@ant-design/x/locale/zh_CN';
 
-<XProvider locale={{...zhCN_X,..zhCN}}>
+<XProvider locale={{...zhCN_X,...zhCN}}>
   <App />
 </XProvider>
 ```

--- a/packages/x/components/x-provider/index.zh-CN.md
+++ b/packages/x/components/x-provider/index.zh-CN.md
@@ -53,7 +53,7 @@ import { XProvider  } from '@ant-design/x';
 import zhCN from 'antd/locale/zh_CN';
 import zhCN_X from '@ant-design/x/locale/zh_CN';
 
-<XProvider locale={{...zhCN_X,..zhCN}}>
+<XProvider locale={{...zhCN_X,...zhCN}}>
   <App />
 </XProvider>
 ```


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x ] 🌐 Internationalization

### 🔗 Related Issues

> - N/A (This is a direct fix for an incorrect code example in the documentation.)

### 💡 Background and Solution

> - **Background:** The documentation examples for `XProvider` in both Chinese (`index.zh-CN.md`) and English (`index.en-US.md`) contained an incorrect syntax in the JSX code block for the `locale` prop: `{...zhCN_X,..zhCN}`. This syntax is invalid JavaScript/TypeScript due to the double dot `..` before `zhCN`.
> - **Solution:** Corrected the syntax to `{...zhCN_X, ...zhCN}` in both affected documentation files. This ensures the object spread syntax is valid and accurately demonstrates how to merge locale configurations from `@ant-design/x` and `antd`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an incorrect code example in the `XProvider` documentation regarding locale configuration. |
| 🇨🇳 Chinese | 修复了 `XProvider` 文档中关于国际化设置配置的错误代码示例。 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了国际化配置文件中的语法错误，确保locale对象正确合并和应用。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->