### PR TITLE
fix: enhance XMarkdown parser to support custom components with place…

### DIFF
--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -6,6 +6,7 @@ type ParserOptions = {
   paragraphTag?: string;
   openLinksInNewTab?: boolean;
   components?: XMarkdownProps['components'];
+  protectCustomTagNewlines?: boolean;
 };
 
 export const other = {
@@ -209,6 +210,9 @@ class Parser {
   }
 
   public parse(content: string) {
+    if (this.options.protectCustomTagNewlines) {
+      return this.markdownInstance.parse(content) as string;
+    }
     const { protected: protectedContent, placeholders } = this.protectCustomTags(content);
     const parsed = this.markdownInstance.parse(protectedContent) as string;
     return this.restorePlaceholders(parsed, placeholders);

--- a/packages/x-markdown/src/XMarkdown/index.tsx
+++ b/packages/x-markdown/src/XMarkdown/index.tsx
@@ -18,6 +18,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
     style,
     openLinksInNewTab,
     dompurifyConfig,
+    protectCustomTagNewlines,
   } = props;
 
   // ============================ style ============================
@@ -33,8 +34,9 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
         paragraphTag,
         openLinksInNewTab,
         components,
+        protectCustomTagNewlines,
       }),
-    [config, paragraphTag, openLinksInNewTab, components],
+    [config, paragraphTag, openLinksInNewTab, components, protectCustomTagNewlines],
   );
 
   const renderer = useMemo(

--- a/packages/x-markdown/src/XMarkdown/interface.ts
+++ b/packages/x-markdown/src/XMarkdown/interface.ts
@@ -142,6 +142,12 @@ interface XMarkdownProps {
    * @description DOMPurify configuration for HTML sanitization and XSS protection
    */
   dompurifyConfig?: DOMPurifyConfig;
+  /**
+   * @description 是否保护自定义标签中的换行符
+   * @description Whether to protect newlines in custom tags
+   * @default false
+   */
+  protectCustomTagNewlines?: boolean;
 }
 
 export type { XMarkdownProps, Token, Tokens, StreamStatus, ComponentProps, StreamingOption };


### PR DESCRIPTION
…holder protection

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> 当使用自定义组件的时候，如果组件的 children 存在\n\n 的情况，parse解析后会得到一个不符合预期的 dom 结构，children 内容被截断的情况。
<img width="2818" height="248" alt="image" src="https://github.com/user-attachments/assets/2c163496-4e58-4b62-92fa-94c371f6fc8c" />



> 修复之后可以这个自定义组件可以得到正确渲染
```
const TestComponent = React.memo((props: ComponentProps) => {
  const { children } = props;
  return <div style={{ padding: '12px 0', backgroundColor: 'red' }}>{children}</div>;
});

<test>好的，用户的问题是关于风力发\n\n电机组叶片覆冰运行的：1. **风险防范**：叶片覆冰可能引发</test>
```

<img width="682" height="157" alt="image" src="https://github.com/user-attachments/assets/9acd93a9-e0e0-444f-9f70-c8829c105c38" />




### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    enhance XMarkdown parser to support custom components with placeholder protection      |
| 🇨🇳 Chinese |   增强 XMarkdown 解析器，使其支持带占位符保护的自定义组件。        |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持通过 props 提供自定义组件映射以渲染自定义元素。
  * 新增可选开关 protectCustomTagNewlines，可在组件层控制是否保护自定义标签内的换行行为。

* **修复与改进**
  * 在解析流程中按配置有条件地保护并恢复自定义标签内部的多行内容，避免内部文本被错误拆分或修改。
  * 将该开关纳入依赖计算，配置变化时会重新计算以保持渲染一致。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->