### PR TITLE
fix(sender): avoid submit after composition end in safari

### DIFF
--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -177,6 +177,26 @@ describe('Sender Component', () => {
       });
       expect(onSubmit).toHaveBeenCalledWith('bamboo', [], undefined);
     });
+
+    it('should not submit when Enter is pressed within 100ms after composition end', () => {
+      const onSubmit = jest.fn();
+      const { container } = render(<Sender value="bamboo" onSubmit={onSubmit} />);
+      const textarea = container.querySelector('textarea')!;
+
+      act(() => {
+        fireEvent.compositionStart(textarea);
+      });
+
+      act(() => {
+        fireEvent.compositionEnd(textarea);
+      });
+
+      act(() => {
+        fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
   });
 
   it('Sender.Header not can be focus', () => {

--- a/packages/x/components/sender/components/TextArea.tsx
+++ b/packages/x/components/sender/components/TextArea.tsx
@@ -115,7 +115,9 @@ const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
   const onInternalKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     const eventRes = onKeyDown?.(e);
     const { key, shiftKey, ctrlKey, altKey, metaKey } = e;
-    const isJustFinishedComposition = Date.now() - lastCompositionEndTick.current < 100;
+    const COMPOSITION_END_DEBOUNCE_MS = 100;
+    const isJustFinishedComposition =
+      Date.now() - lastCompositionEndTick.current < COMPOSITION_END_DEBOUNCE_MS;
 
     if (
       isCompositionRef.current ||

--- a/packages/x/components/sender/components/TextArea.tsx
+++ b/packages/x/components/sender/components/TextArea.tsx
@@ -101,6 +101,7 @@ const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
 
   // ============================ Submit ============================
   const isCompositionRef = React.useRef(false);
+  const lastCompositionEndTick = React.useRef(0);
 
   const onInternalCompositionStart = () => {
     isCompositionRef.current = true;
@@ -108,13 +109,20 @@ const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
 
   const onInternalCompositionEnd = () => {
     isCompositionRef.current = false;
+    lastCompositionEndTick.current = Date.now();
   };
 
   const onInternalKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     const eventRes = onKeyDown?.(e);
     const { key, shiftKey, ctrlKey, altKey, metaKey } = e;
+    const isJustFinishedComposition = Date.now() - lastCompositionEndTick.current < 100;
 
-    if (isCompositionRef.current || key !== 'Enter' || eventRes === false) {
+    if (
+      isCompositionRef.current ||
+      isJustFinishedComposition ||
+      key !== 'Enter' ||
+      eventRes === false
+    ) {
       return;
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [✅] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
#1700 
> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 优化文本输入区域中 Enter 键的处理：在输入法（如中文、日文）组合结束后的短时间内（约100毫秒）按 Enter 不再误触提交，避免在组合刚结束时意外发送消息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->