### PR TITLE
 fix: prevent event listener leak in useShortcutKeys

### DIFF
--- a/packages/x/components/_util/hooks/use-shortcut-keys.ts
+++ b/packages/x/components/_util/hooks/use-shortcut-keys.ts
@@ -223,7 +223,7 @@ const useShortcutKeys = (
 
     return () => {
       document.removeEventListener('keydown', onKeydown);
-      document.addEventListener('keyup', onKeyup);
+      document.removeEventListener('keyup', onKeyup);
     };
   }, [flattenShortcutKeys.length, observer]);
   return [shortcutAction, shortcutKeysInfo, subscribe];


### PR DESCRIPTION
## 🐛 Bug Description

Found a critical memory leak in `packages/x/components/_util/hooks/use-shortcut-keys.ts` at line 226.

The cleanup function incorrectly uses `addEventListener` instead of `removeEventListener` for the `keyup` event.

### Before
```typescript
return () => {
  document.removeEventListener('keydown', onKeydown);
  document.addEventListener('keyup', onKeyup);  // ❌ BUG!
};
### After
return () => {
  document.removeEventListener('keydown', onKeydown);
  document.removeEventListener('keyup', onKeyup);  // ✅ FIXED
};

💥 Impact
This bug causes:

Memory Leak: Old keyup listeners accumulate on every re-render
Performance Degradation: Multiple callbacks triggered per keypress
Potential Crash: Memory exhaustion in long-running apps
Scope: Affects ALL components using shortcut keys
🔧 Changes
File: packages/x/components/_util/hooks/use-shortcut-keys.ts
Lines Changed: 1
Type: Bug Fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了快捷键监听器的清理问题，确保组件卸载时能够正确移除键盘事件监听器，避免残留监听器导致的功能异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->