### PR TITLE
fix(ThoughtChain): fix status overriding custom icon, duplicate className, and contentOpen undefined

### DIFF
--- a/packages/x/components/thought-chain/Node.tsx
+++ b/packages/x/components/thought-chain/Node.tsx
@@ -52,15 +52,26 @@ const ThoughtChainNode: React.FC<ThoughtChainNodeProps> = (props) => {
   const nodeCls = `${prefixCls}-node`;
 
   // ============================ Content Open ============================
-  const contentOpen = expandedKeys?.includes(key);
-  let iconNode: React.ReactNode = <div className={clsx(`${nodeCls}-index-icon`)}>{index + 1}</div>;
+  const contentOpen = expandedKeys?.includes(key) ?? false;
 
-  iconNode = icon === false ? null : icon || iconNode;
+  let iconNode: React.ReactNode;
+  if (icon === false) {
+    iconNode = null;
+  } else if (icon) {
+    // User explicitly provided an icon — always use it
+    iconNode = icon;
+  } else if (status) {
+    // No user icon but has status — let Status component show the status icon
+    iconNode = undefined;
+  } else {
+    // No user icon and no status — show the default index number
+    iconNode = <div className={clsx(`${nodeCls}-index-icon`)}>{index + 1}</div>;
+  }
 
   // ============================ Render ============================
   return (
     <div {...domProps} className={clsx(nodeCls, className, classNames.item)} style={props.style}>
-      {iconNode && (
+      {(iconNode || status) && (
         <Status
           className={clsx(`${nodeCls}-icon`, classNames.itemIcon, {
             [`${nodeCls}-icon-${line}`]: typeof line !== 'boolean',

--- a/packages/x/components/thought-chain/Status.tsx
+++ b/packages/x/components/thought-chain/Status.tsx
@@ -74,7 +74,7 @@ const Status: React.FC<StatusProps> = (props) => {
   // ============================ Style ============================
   const statusCls = `${prefixCls}-status`;
 
-  const IconNode = status ? StatusIcon[status] : icon;
+  const IconNode = icon || (status ? StatusIcon[status] : null);
 
   // ============================ Render ============================
   return (

--- a/packages/x/components/thought-chain/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/x/components/thought-chain/__tests__/__snapshots__/index.test.tsx.snap
@@ -73,22 +73,24 @@ exports[`ThoughtChain Component ThoughtChain component work 1`] = `
       class="ant-thought-chain-status ant-thought-chain-node-icon ant-thought-chain-status-error"
     >
       <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle"
+        aria-label="check-circle"
+        class="anticon anticon-check-circle"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="check-circle"
           fill="currentColor"
-          fill-rule="evenodd"
           focusable="false"
           height="1em"
           viewBox="64 64 896 896"
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm0 76c-205.4 0-372 166.6-372 372s166.6 372 372 372 372-166.6 372-372-166.6-372-372-372zm128.01 198.83c.03 0 .05.01.09.06l45.02 45.01a.2.2 0 01.05.09.12.12 0 010 .07c0 .02-.01.04-.05.08L557.25 512l127.87 127.86a.27.27 0 01.05.06v.02a.12.12 0 010 .07c0 .03-.01.05-.05.09l-45.02 45.02a.2.2 0 01-.09.05.12.12 0 01-.07 0c-.02 0-.04-.01-.08-.05L512 557.25 384.14 685.12c-.04.04-.06.05-.08.05a.12.12 0 01-.07 0c-.03 0-.05-.01-.09-.05l-45.02-45.02a.2.2 0 01-.05-.09.12.12 0 010-.07c0-.02.01-.04.06-.08L466.75 512 338.88 384.14a.27.27 0 01-.05-.06l-.01-.02a.12.12 0 010-.07c0-.03.01-.05.05-.09l45.02-45.02a.2.2 0 01.09-.05.12.12 0 01.07 0c.02 0 .04.01.08.06L512 466.75l127.86-127.86c.04-.05.06-.06.08-.06a.12.12 0 01.07 0z"
+            d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+          <path
+            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
           />
         </svg>
       </span>
@@ -133,21 +135,24 @@ exports[`ThoughtChain Component ThoughtChain component work 1`] = `
       class="ant-thought-chain-status ant-thought-chain-node-icon ant-thought-chain-status-loading"
     >
       <span
-        aria-label="loading"
-        class="anticon anticon-loading anticon-spin"
+        aria-label="check-circle"
+        class="anticon anticon-check-circle"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="loading"
+          data-icon="check-circle"
           fill="currentColor"
           focusable="false"
           height="1em"
-          viewBox="0 0 1024 1024"
+          viewBox="64 64 896 896"
           width="1em"
         >
           <path
-            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+            d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+          <path
+            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
           />
         </svg>
       </span>
@@ -267,22 +272,24 @@ exports[`ThoughtChain Component test theme component should be rendered correctl
       class="ant-thought-chain-status ant-thought-chain-node-icon ant-thought-chain-status-error"
     >
       <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle"
+        aria-label="check-circle"
+        class="anticon anticon-check-circle"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="check-circle"
           fill="currentColor"
-          fill-rule="evenodd"
           focusable="false"
           height="1em"
           viewBox="64 64 896 896"
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm0 76c-205.4 0-372 166.6-372 372s166.6 372 372 372 372-166.6 372-372-166.6-372-372-372zm128.01 198.83c.03 0 .05.01.09.06l45.02 45.01a.2.2 0 01.05.09.12.12 0 010 .07c0 .02-.01.04-.05.08L557.25 512l127.87 127.86a.27.27 0 01.05.06v.02a.12.12 0 010 .07c0 .03-.01.05-.05.09l-45.02 45.02a.2.2 0 01-.09.05.12.12 0 01-.07 0c-.02 0-.04-.01-.08-.05L512 557.25 384.14 685.12c-.04.04-.06.05-.08.05a.12.12 0 01-.07 0c-.03 0-.05-.01-.09-.05l-45.02-45.02a.2.2 0 01-.05-.09.12.12 0 010-.07c0-.02.01-.04.06-.08L466.75 512 338.88 384.14a.27.27 0 01-.05-.06l-.01-.02a.12.12 0 010-.07c0-.03.01-.05.05-.09l45.02-45.02a.2.2 0 01.09-.05.12.12 0 01.07 0c.02 0 .04.01.08.06L512 466.75l127.86-127.86c.04-.05.06-.06.08-.06a.12.12 0 01.07 0z"
+            d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+          <path
+            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
           />
         </svg>
       </span>
@@ -327,21 +334,24 @@ exports[`ThoughtChain Component test theme component should be rendered correctl
       class="ant-thought-chain-status ant-thought-chain-node-icon ant-thought-chain-status-loading"
     >
       <span
-        aria-label="loading"
-        class="anticon anticon-loading anticon-spin"
+        aria-label="check-circle"
+        class="anticon anticon-check-circle"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="loading"
+          data-icon="check-circle"
           fill="currentColor"
           focusable="false"
           height="1em"
-          viewBox="0 0 1024 1024"
+          viewBox="64 64 896 896"
           width="1em"
         >
           <path
-            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+            d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+          <path
+            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
           />
         </svg>
       </span>

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleOutlined } from '@ant-design/icons';
+import { CheckCircleOutlined, RocketOutlined } from '@ant-design/icons';
 import React from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -201,5 +201,77 @@ describe('ThoughtChain Component', () => {
     const itemElement = container.querySelector('.ant-thought-chain-node');
     expect(itemElement).toBeInTheDocument();
     expect(window.getComputedStyle(itemElement as Element).backgroundColor).toBe('red');
+  });
+
+  it('should preserve custom icon when status is also provided', () => {
+    const { container } = render(
+      <ThoughtChain
+        items={[
+          {
+            key: 'icon-test',
+            title: 'Test',
+            icon: <RocketOutlined data-testid="custom-icon" />,
+            status: 'loading',
+          },
+        ]}
+      />,
+    );
+
+    // Custom icon should be rendered, not the default LoadingOutlined
+    const statusEl = container.querySelector('.ant-thought-chain-status');
+    expect(statusEl).toBeTruthy();
+    // The custom RocketOutlined icon should be present
+    expect(statusEl!.querySelector('.anticon-rocket')).toBeTruthy();
+    // The default LoadingOutlined from status should NOT be present
+    expect(statusEl!.querySelector('.anticon-loading')).toBeFalsy();
+  });
+
+  it('should fall back to status icon when no custom icon is provided', () => {
+    const { container } = render(
+      <ThoughtChain
+        items={[
+          {
+            key: 'status-only',
+            title: 'Test',
+            status: 'success',
+          },
+        ]}
+      />,
+    );
+
+    const statusEl = container.querySelector('.ant-thought-chain-status');
+    expect(statusEl).toBeTruthy();
+    // Should show the success CheckCircleOutlined icon
+    expect(statusEl!.querySelector('.anticon-check-circle')).toBeTruthy();
+  });
+
+  it('should not have duplicate className on root element', () => {
+    const { container } = render(<ThoughtChain className="my-custom-class" items={items} />);
+
+    const root = container.querySelector('.ant-thought-chain');
+    // className should appear only once in the class list
+    const classList = Array.from(root!.classList);
+    const count = classList.filter((c) => c === 'my-custom-class').length;
+    expect(count).toBe(1);
+  });
+
+  it('should handle undefined expandedKeys gracefully for collapsible items', () => {
+    // Render without expandedKeys prop — contentOpen should be false, not undefined
+    const { container } = render(
+      <ThoughtChain
+        items={[
+          {
+            key: 'collapse-test',
+            title: 'Collapsible',
+            content: 'Hidden content',
+            collapsible: true,
+          },
+        ]}
+      />,
+    );
+
+    // Content should NOT be visible (collapsed by default)
+    const contentEl = container.querySelector('.ant-thought-chain-node-content');
+    expect(contentEl).toBeFalsy();
   });
 });

--- a/packages/x/components/thought-chain/index.tsx
+++ b/packages/x/components/thought-chain/index.tsx
@@ -59,7 +59,6 @@ const ForwardThoughtChain = React.forwardRef<any, ThoughtChainProps>((props, ref
     rootClassName,
     hashId,
     cssVarCls,
-    className,
     classNames.root,
     `${prefixCls}-box`,
     {
@@ -142,5 +141,5 @@ if (process.env.NODE_ENV !== 'production') {
   ThoughtChain.displayName = 'ThoughtChain';
 }
 
-export type { ThoughtChainProps, ThoughtChainItemType, ThoughtChainItemProps };
+export type { ThoughtChainItemProps, ThoughtChainItemType, ThoughtChainProps };
 export default ThoughtChain;


### PR DESCRIPTION
## Summary

- **Status overrides icon**: When both `icon` and `status` are set on a ThoughtChain item, the custom icon was silently replaced by the built-in status icon. Now custom icons take priority; status icons are used as fallback only.
- **Duplicate className**: `className` was passed twice to `clsx()` in ThoughtChain's root element (copy-paste error).
- **contentOpen undefined**: `expandedKeys?.includes(key)` could return `undefined` which was passed to CSSMotion's `visible` prop. Now defaults to `false` via `?? false`.

## Test plan

- [x] Added test: custom icon preserved when status is also provided
- [x] Added test: status icon used as fallback when no custom icon
- [x] Added test: no duplicate className on root element
- [x] Added test: undefined expandedKeys handled gracefully
- [x] All 13 tests pass, snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 修复了样式类名重复应用的问题
  * 改进了图标渲染逻辑，确保自定义图标优先于状态图标显示
  * 优化了节点展开/折叠状态的默认行为处理

* **测试**
  * 添加了图标与状态交互的验证测试
  * 增强了折叠节点的默认行为测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->