### PR TITLE
fix(ThoughtChain): remove duplicate className and default contentOpen to false

### DIFF
--- a/packages/x/components/thought-chain/Node.tsx
+++ b/packages/x/components/thought-chain/Node.tsx
@@ -52,7 +52,7 @@ const ThoughtChainNode: React.FC<ThoughtChainNodeProps> = (props) => {
   const nodeCls = `${prefixCls}-node`;
 
   // ============================ Content Open ============================
-  const contentOpen = expandedKeys?.includes(key);
+  const contentOpen = expandedKeys?.includes(key) ?? false;
   let iconNode: React.ReactNode = <div className={clsx(`${nodeCls}-index-icon`)}>{index + 1}</div>;
 
   iconNode = icon === false ? null : icon || iconNode;

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -202,4 +202,14 @@ describe('ThoughtChain Component', () => {
     expect(itemElement).toBeInTheDocument();
     expect(window.getComputedStyle(itemElement as Element).backgroundColor).toBe('red');
   });
+
+  it('should not have duplicate className on root element', () => {
+    const { container } = render(<ThoughtChain className="my-custom-class" items={items} />);
+
+    const root = container.querySelector('.ant-thought-chain');
+    // className should appear only once in the class list
+    const classList = Array.from(root!.classList);
+    const count = classList.filter((c) => c === 'my-custom-class').length;
+    expect(count).toBe(1);
+  });
 });

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -207,9 +207,12 @@ describe('ThoughtChain Component', () => {
     const { container } = render(<ThoughtChain className="my-custom-class" items={items} />);
 
     const root = container.querySelector('.ant-thought-chain');
-    // className should appear only once in the class list
-    const classList = Array.from(root!.classList);
-    const count = classList.filter((c) => c === 'my-custom-class').length;
+    expect(root).toBeTruthy();
+    // Read the raw class attribute string instead of classList, because
+    // DOMTokenList de-duplicates tokens per DOM spec and cannot detect
+    // duplicate tokens in the source class attribute.
+    const classAttr = root!.getAttribute('class') ?? '';
+    const count = (classAttr.match(/\bmy-custom-class\b/g) ?? []).length;
     expect(count).toBe(1);
   });
 

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -212,4 +212,24 @@ describe('ThoughtChain Component', () => {
     const count = classList.filter((c) => c === 'my-custom-class').length;
     expect(count).toBe(1);
   });
+
+  it('should handle undefined expandedKeys gracefully for collapsible items', () => {
+    // Render without expandedKeys prop — contentOpen should be false, not undefined
+    const { container } = render(
+      <ThoughtChain
+        items={[
+          {
+            key: 'collapse-test',
+            title: 'Collapsible',
+            content: 'Hidden content',
+            collapsible: true,
+          },
+        ]}
+      />,
+    );
+
+    // Content should NOT be visible (collapsed by default)
+    const contentEl = container.querySelector('.ant-thought-chain-node-content');
+    expect(contentEl).toBeFalsy();
+  });
 });

--- a/packages/x/components/thought-chain/index.tsx
+++ b/packages/x/components/thought-chain/index.tsx
@@ -59,7 +59,6 @@ const ForwardThoughtChain = React.forwardRef<any, ThoughtChainProps>((props, ref
     rootClassName,
     hashId,
     cssVarCls,
-    className,
     classNames.root,
     `${prefixCls}-box`,
     {
@@ -142,5 +141,5 @@ if (process.env.NODE_ENV !== 'production') {
   ThoughtChain.displayName = 'ThoughtChain';
 }
 
-export type { ThoughtChainProps, ThoughtChainItemType, ThoughtChainItemProps };
+export type { ThoughtChainItemProps, ThoughtChainItemType, ThoughtChainProps };
 export default ThoughtChain;


### PR DESCRIPTION
## Summary

Two minor code-quality fixes for the ThoughtChain component:

1. **Duplicate className**: `className` was passed twice to `clsx()` in the root element's merged class computation (copy-paste error in `index.tsx`).

2. **contentOpen undefined**: `expandedKeys?.includes(key)` returns `undefined` when `expandedKeys` is not provided. Added `?? false` to ensure a proper boolean is passed to CSSMotion's `visible` prop (`Node.tsx`).

## Test plan

- [x] Added test: `className` appears only once in root element's classList
- [x] Added test: collapsible items are collapsed by default when no expandedKeys provided
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 ThoughtChain 组件中自定义 className 被重复应用的问题，确保自定义类仅附加一次于根元素。
  * 修复折叠节点默认展开行为：在未提供 expandedKeys 时，节点内容默认收起（contentOpen 为 false）。

* **Tests**
  * 新增测试：验证自定义类名不重复注入及在未传入展开键时折叠节点内容不可见。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->