### PR TITLE
fix(ThoughtChain): default contentOpen to false instead of undefined

### DIFF
--- a/packages/x/components/thought-chain/Node.tsx
+++ b/packages/x/components/thought-chain/Node.tsx
@@ -52,7 +52,7 @@ const ThoughtChainNode: React.FC<ThoughtChainNodeProps> = (props) => {
   const nodeCls = `${prefixCls}-node`;
 
   // ============================ Content Open ============================
-  const contentOpen = expandedKeys?.includes(key);
+  const contentOpen = expandedKeys?.includes(key) ?? false;
   let iconNode: React.ReactNode = <div className={clsx(`${nodeCls}-index-icon`)}>{index + 1}</div>;
 
   iconNode = icon === false ? null : icon || iconNode;

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -202,4 +202,24 @@ describe('ThoughtChain Component', () => {
     expect(itemElement).toBeInTheDocument();
     expect(window.getComputedStyle(itemElement as Element).backgroundColor).toBe('red');
   });
+
+  it('should handle undefined expandedKeys gracefully for collapsible items', () => {
+    // Render without expandedKeys prop — contentOpen should be false, not undefined
+    const { container } = render(
+      <ThoughtChain
+        items={[
+          {
+            key: 'collapse-test',
+            title: 'Collapsible',
+            content: 'Hidden content',
+            collapsible: true,
+          },
+        ]}
+      />,
+    );
+
+    // Content should NOT be visible (collapsed by default)
+    const contentEl = container.querySelector('.ant-thought-chain-node-content');
+    expect(contentEl).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Summary

`expandedKeys?.includes(key)` returns `undefined` when `expandedKeys` is undefined (e.g. when ThoughtChain is used without controlled `expandedKeys`). This `undefined` value was passed directly to CSSMotion's `visible` prop, which expects a boolean.

```tsx
// Before (Node.tsx line 55)
const contentOpen = expandedKeys?.includes(key);  // could be undefined

// After
const contentOpen = expandedKeys?.includes(key) ?? false;
```

## Test plan

- [x] Added test: collapsible items are collapsed by default when no expandedKeys provided
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了思维链组件可折叠节点在无展开键时的状态处理问题，确保节点内容在对应情况下能正确保持收起状态，提升组件的稳定性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->