### PR TITLE
fix(sender): preserve runtime slots across slotConfig ref changes

### DIFF
--- a/packages/x/components/sender/__tests__/use-slot-config-state.test.ts
+++ b/packages/x/components/sender/__tests__/use-slot-config-state.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook } from '@testing-library/react';
+import useSlotConfigState from '../hooks/use-slot-config-state';
+import type { SlotConfigType } from '../interface';
+
+const propTag = (key: string): SlotConfigType => ({
+  type: 'tag',
+  key,
+  props: { value: key, label: `#${key}` },
+});
+
+const propInput = (key: string, defaultValue: string): SlotConfigType => ({
+  type: 'input',
+  key,
+  props: { defaultValue, placeholder: 'input' },
+});
+
+describe('useSlotConfigState', () => {
+  it('rebuilds map and slotValues from prop on first mount', () => {
+    const initial = [propTag('a'), propInput('b', 'bv')];
+    const { result } = renderHook(({ slotConfig }) => useSlotConfigState(slotConfig), {
+      initialProps: { slotConfig: initial },
+    });
+
+    const [map, api] = result.current;
+    expect(map.get('a')?.key).toBe('a');
+    expect(map.get('b')?.key).toBe('b');
+    expect(api.getSlotValues()).toEqual({ a: 'a', b: 'bv' });
+  });
+
+  it('keeps runtime-inserted entries when slotConfig prop reference changes (the bug)', () => {
+    const { result, rerender } = renderHook(({ slotConfig }) => useSlotConfigState(slotConfig), {
+      initialProps: { slotConfig: [] as SlotConfigType[] },
+    });
+
+    act(() => {
+      result.current[1].mergeSlotConfig([propTag('runtime-1')]);
+    });
+
+    const [mapAfterInsert] = result.current;
+    expect(mapAfterInsert.get('runtime-1')?.key).toBe('runtime-1');
+    expect(result.current[1].getSlotValues()['runtime-1']).toBe('runtime-1');
+
+    // Parent re-render with a fresh `[]` reference — must NOT wipe the runtime entry
+    rerender({ slotConfig: [] });
+
+    const [mapAfterRerender, apiAfterRerender] = result.current;
+    expect(mapAfterRerender.get('runtime-1')?.key).toBe('runtime-1');
+    expect(apiAfterRerender.getSlotValues()['runtime-1']).toBe('runtime-1');
+  });
+
+  it('removes prop-sourced entries that disappear from the new slotConfig', () => {
+    const { result, rerender } = renderHook(({ slotConfig }) => useSlotConfigState(slotConfig), {
+      initialProps: { slotConfig: [propTag('p1'), propTag('p2')] },
+    });
+
+    expect(result.current[0].get('p1')).toBeDefined();
+    expect(result.current[0].get('p2')).toBeDefined();
+
+    rerender({ slotConfig: [propTag('p1')] });
+
+    expect(result.current[0].get('p1')).toBeDefined();
+    expect(result.current[0].get('p2')).toBeUndefined();
+    expect(result.current[1].getSlotValues()).toEqual({ p1: 'p1' });
+  });
+
+  it('clear() resets map, slotValues, and runtime-keys bookkeeping', () => {
+    const { result, rerender } = renderHook(({ slotConfig }) => useSlotConfigState(slotConfig), {
+      initialProps: { slotConfig: [propTag('p1')] },
+    });
+
+    act(() => {
+      result.current[1].mergeSlotConfig([propTag('runtime-1')]);
+    });
+    expect(result.current[0].size).toBe(2);
+
+    act(() => {
+      result.current[1].clear();
+    });
+    expect(result.current[0].size).toBe(0);
+    expect(result.current[1].getSlotValues()).toEqual({});
+
+    // After clear, a parent re-render must not resurrect the previously-runtime key
+    rerender({ slotConfig: [propTag('p1')] });
+    expect(result.current[0].get('runtime-1')).toBeUndefined();
+    expect(result.current[0].get('p1')).toBeDefined();
+  });
+
+  it('preserves runtime slotValues edits across prop reference changes', () => {
+    const { result, rerender } = renderHook(({ slotConfig }) => useSlotConfigState(slotConfig), {
+      initialProps: { slotConfig: [] as SlotConfigType[] },
+    });
+
+    act(() => {
+      result.current[1].mergeSlotConfig([propInput('runtime-input', 'initial')]);
+    });
+    expect(result.current[1].getSlotValues()['runtime-input']).toBe('initial');
+
+    act(() => {
+      result.current[1].setSlotValues((prev) => ({ ...prev, 'runtime-input': 'user-typed' }));
+    });
+    expect(result.current[1].getSlotValues()['runtime-input']).toBe('user-typed');
+
+    rerender({ slotConfig: [] });
+
+    expect(result.current[1].getSlotValues()['runtime-input']).toBe('user-typed');
+  });
+
+  it('lets runtime entries survive a prop briefly declaring then removing the same key', () => {
+    // Collision contract: runtime wins over a prop "drive-by". Pins the chosen semantics.
+    const { result, rerender } = renderHook(({ slotConfig }) => useSlotConfigState(slotConfig), {
+      initialProps: { slotConfig: [] as SlotConfigType[] },
+    });
+
+    act(() => {
+      result.current[1].mergeSlotConfig([propTag('x')]);
+    });
+    expect(result.current[0].get('x')).toBeDefined();
+
+    rerender({ slotConfig: [propTag('x')] });
+    expect(result.current[0].get('x')).toBeDefined();
+
+    rerender({ slotConfig: [] });
+    expect(result.current[0].get('x')).toBeDefined();
+  });
+});

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -111,7 +111,14 @@ const SlotTextArea = React.forwardRef<SlotTextAreaRef>((_, ref) => {
   // ============================ State =============================
   const [
     slotConfigMap,
-    { getSlotValues, setSlotValues, getNodeInfo, mergeSlotConfig, getNodeTextValue },
+    {
+      getSlotValues,
+      setSlotValues,
+      getNodeInfo,
+      mergeSlotConfig,
+      getNodeTextValue,
+      clear: clearSlotConfigState,
+    },
   ] = useSlotConfigState(slotConfig);
   const [slotPlaceholders, setSlotPlaceholders] = useState<Map<string, React.ReactNode>>(new Map());
   const [skillPlaceholders, setSkillPlaceholders] = useState<React.ReactNode>(null);
@@ -861,9 +868,8 @@ const SlotTextArea = React.forwardRef<SlotTextAreaRef>((_, ref) => {
     editableDom.innerHTML = '';
     skillRef.current = null;
     skillDomRef.current = null;
-    slotConfigMap.clear();
+    clearSlotConfigState();
     insertSkill();
-    setSlotValues({});
     lastSelectionRef.current = null;
     slotDomMap?.current?.clear();
     onInternalInput(null as unknown as React.FormEvent<HTMLDivElement>);

--- a/packages/x/components/sender/hooks/use-slot-config-state.ts
+++ b/packages/x/components/sender/hooks/use-slot-config-state.ts
@@ -73,18 +73,33 @@ const useSlotConfigState = (
     mergeSlotConfig: (newSlotConfig: SlotConfigType[]) => void;
     getNodeInfo: (targetNode: HTMLElement) => NodeInfo | null;
     getNodeTextValue: (node: Node) => string;
+    clear: () => void;
   },
 ] => {
   const [state, _setState] = useState<SlotValues>({});
   const stateRef = useRef<SlotValues>(state);
   const slotConfigMapRef = useRef<Map<string, SlotConfigType>>(new Map());
+  // Track keys inserted at runtime via mergeSlotConfig so the slotConfig effect below
+  // can preserve them when the prop reference changes (e.g. parent re-renders with an
+  // inline `[]`); otherwise ref.insert(...) entries silently disappear from getValue().
+  //
+  // Grows monotonically until clear(); intentional, the residual cost is one string
+  // per ever-inserted key.
+  const runtimeKeysRef = useRef<Set<string>>(new Set());
 
   // 初始化 slotConfig
   useEffect(() => {
     if (!slotConfig) return;
-    slotConfigMapRef.current.clear();
+    slotConfigMapRef.current.forEach((_, key) => {
+      if (!runtimeKeysRef.current.has(key)) slotConfigMapRef.current.delete(key);
+    });
+
     buildSlotConfigMap(slotConfig, slotConfigMapRef.current);
+
     const newValues = buildSlotValues(slotConfig);
+    runtimeKeysRef.current.forEach((key) => {
+      if (key in stateRef.current) newValues[key] = stateRef.current[key];
+    });
     _setState(newValues);
     stateRef.current = newValues;
   }, [slotConfig]);
@@ -98,13 +113,22 @@ const useSlotConfigState = (
   const mergeSlotConfig = useCallback((newSlotConfig: SlotConfigType[]) => {
     const newValues = buildSlotValues(newSlotConfig);
 
-    // 更新配置映射
     newSlotConfig.forEach((node) => {
-      if (node.key) slotConfigMapRef.current.set(node.key, node);
+      if (node.key) {
+        slotConfigMapRef.current.set(node.key, node);
+        runtimeKeysRef.current.add(node.key);
+      }
     });
 
     _setState((prev) => ({ ...prev, ...newValues }));
     stateRef.current = { ...stateRef.current, ...newValues };
+  }, []);
+
+  const clear = useCallback(() => {
+    slotConfigMapRef.current.clear();
+    runtimeKeysRef.current.clear();
+    _setState({});
+    stateRef.current = {};
   }, []);
 
   const getNodeInfo = useCallback(
@@ -162,6 +186,7 @@ const useSlotConfigState = (
       mergeSlotConfig,
       getNodeInfo,
       getNodeTextValue,
+      clear,
     },
   ];
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #1899

### 💡 Background and Solution

`Sender`'s `useSlotConfigState` ran a `useEffect([slotConfig])` that unconditionally called `slotConfigMap.clear()` and rebuilt from the prop, also wiping any slots that had been added at runtime via `ref.insert(...)` (these go through `mergeSlotConfig` and share the same map).

For consumers passing an inline `slotConfig={[]}` (or any computed / non-stable reference), every parent re-render produced a fresh prop reference and triggered the effect. The runtime-inserted DOM nodes stayed visible in the editor, but `getValue().slotConfig` returned `[]` — a silent desync between what the user sees and what `onChange` / `onSubmit` receive.

This PR adds a `runtimeKeysRef` set inside the hook that tracks which keys were added by `mergeSlotConfig`. The effect now removes only entries not in that set before applying the new prop. The same treatment is applied to `slotValues` so user edits on runtime-inserted `input` / `select` / `custom` slots survive prop reference changes. The hook now exposes a `clear()` method so the SlotTextArea-level ref `clear()` can reset bookkeeping in one call.

#### Tests

Hook-level tests added in `__tests__/use-slot-config-state.test.ts` covering:

- baseline: prop-only setup builds map and `slotValues` correctly
- the bug: runtime-inserted entry survives a prop reference change
- prop deletion: removing a key from the prop drops it from the map
- `clear()`: resets map, `slotValues`, and runtime-keys bookkeeping
- runtime `slotValues` edits survive prop reference changes
- collision contract: when the prop briefly declares then removes a runtime-inserted key, the entry stays (runtime wins; semantics pinned by test)

I considered adding a SlotTextArea-level integration test (`ref.insert(...)` → parent re-render → `ref.getValue()` end-to-end) since the bug is framed in DOM / `getValue()` terms. It's achievable but requires non-trivial new mock plumbing — the existing `slot.test` `setupDOMMocks` replaces `window.getSelection` with a hardcoded mock and stubs `range.insertNode` as a no-op, so a faithful test would need a real-ish Selection / Range that both `useCursor` and `range.insertNode` can drive against the actual editor DOM. The existing `slot.test.tsx` exercises `ref.insert` and `ref.getValue` individually; the gap is specifically the rerender-between-insert-and-read scenario, which the hook test pins at the bookkeeping level. Happy to add the integration test in a follow-up if maintainers want it as an additional guardrail.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Sender` runtime-inserted slots being dropped from `getValue().slotConfig` after a parent re-render produced a fresh `slotConfig` prop reference. |
| 🇨🇳 Chinese | 修复 `Sender` 中通过 `ref.insert(...)` 在运行时插入的 slot，在父组件重渲染产生新的 `slotConfig` prop 引用后，从 `getValue().slotConfig` 中静默丢失的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 槽位配置现在能够在组件属性更新时保留运行时注入的条目
  * 新增清除槽位配置状态的功能

* **测试**
  * 新增槽位配置状态行为的全面测试套件，覆盖初始化、运行时修改、属性变更和状态重置等场景

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/x/pull/1900)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->