### PR TITLE
fix(x): refresh FileCard.List scroll ping state on items change

### DIFF
--- a/packages/x/components/file-card/List.tsx
+++ b/packages/x/components/file-card/List.tsx
@@ -65,7 +65,7 @@ const List: React.FC<FileCardListProps> = (props) => {
     [`${prefixCls}-rtl`]: direction === 'rtl',
   });
 
-  const checkPing = () => {
+  const checkPing = React.useCallback(() => {
     const containerEle = containerRef.current;
 
     if (!containerEle) {
@@ -82,7 +82,7 @@ const List: React.FC<FileCardListProps> = (props) => {
       setPingStart(containerEle.scrollTop !== 0);
       setPingEnd(containerEle.scrollHeight - containerEle.clientHeight !== containerEle.scrollTop);
     }
-  };
+  }, [overflow]);
 
   React.useLayoutEffect(() => {
     if (!overflow || overflow === 'wrap') {
@@ -96,7 +96,7 @@ const List: React.FC<FileCardListProps> = (props) => {
     return () => {
       window.cancelAnimationFrame(frameId);
     };
-  }, [list, overflow]);
+  }, [list, overflow, checkPing]);
 
   const onScrollOffset = (offset: -1 | 1) => {
     const containerEle = containerRef.current;

--- a/packages/x/components/file-card/List.tsx
+++ b/packages/x/components/file-card/List.tsx
@@ -84,6 +84,20 @@ const List: React.FC<FileCardListProps> = (props) => {
     }
   };
 
+  React.useLayoutEffect(() => {
+    if (!overflow || overflow === 'wrap') {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      checkPing();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [list, overflow]);
+
   const onScrollOffset = (offset: -1 | 1) => {
     const containerEle = containerRef.current;
 

--- a/packages/x/components/file-card/List.tsx
+++ b/packages/x/components/file-card/List.tsx
@@ -65,7 +65,7 @@ const List: React.FC<FileCardListProps> = (props) => {
     [`${prefixCls}-rtl`]: direction === 'rtl',
   });
 
-  const checkPing = React.useCallback(() => {
+  const checkPing = () => {
     const containerEle = containerRef.current;
 
     if (!containerEle) {
@@ -82,7 +82,7 @@ const List: React.FC<FileCardListProps> = (props) => {
       setPingStart(containerEle.scrollTop !== 0);
       setPingEnd(containerEle.scrollHeight - containerEle.clientHeight !== containerEle.scrollTop);
     }
-  }, [overflow]);
+  };
 
   React.useLayoutEffect(() => {
     if (!overflow || overflow === 'wrap') {
@@ -96,7 +96,7 @@ const List: React.FC<FileCardListProps> = (props) => {
     return () => {
       window.cancelAnimationFrame(frameId);
     };
-  }, [list, overflow, checkPing]);
+  }, [list, overflow]);
 
   const onScrollOffset = (offset: -1 | 1) => {
     const containerEle = containerRef.current;

--- a/packages/x/components/file-card/__tests__/index.test.tsx
+++ b/packages/x/components/file-card/__tests__/index.test.tsx
@@ -29,7 +29,7 @@ jest.mock('@rc-component/resize-observer', () => {
           ]);
         }, 0);
       }
-    }, [onResize, disabled]);
+    }, []);
 
     return children;
   };
@@ -215,6 +215,60 @@ it('should handle onClick', () => {
 
 // List 组件测试
 describe('FileCard.List', () => {
+  it('should refresh scrollX ping state when items update without remount', async () => {
+    const initialItems = [{ name: 'short-name.txt' }];
+    const nextItems = [
+      { name: 'very-long-file-name1.txt' },
+      { name: 'very-long-file-name2.txt' },
+      { name: 'very-long-file-name3.txt' },
+    ];
+
+    const { container, rerender } = render(
+      <div style={{ width: '150px' }}>
+        <FileCard.List items={initialItems} overflow="scrollX" />
+      </div>,
+    );
+
+    const scrollContainer = container.querySelector('.ant-file-card-list-content');
+    expect(scrollContainer).toBeTruthy();
+
+    Object.defineProperty(scrollContainer, 'scrollLeft', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(scrollContainer, 'clientWidth', {
+      value: 150,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(scrollContainer, 'scrollWidth', {
+      value: 150,
+      writable: true,
+      configurable: true,
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ant-file-card-list-overflow-ping-end')).toBeFalsy();
+    });
+
+    Object.defineProperty(scrollContainer, 'scrollWidth', {
+      value: 420,
+      writable: true,
+      configurable: true,
+    });
+
+    rerender(
+      <div style={{ width: '150px' }}>
+        <FileCard.List items={nextItems} overflow="scrollX" />
+      </div>,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('.ant-file-card-list-overflow-ping-end')).toBeTruthy();
+    });
+  });
+
   it('should render file list', () => {
     const { container } = render(
       <FileCard.List


### PR DESCRIPTION
## 🤔 This is a ...

- [x] 🐞 Bug fix

## 🔗 Related issue link

Closes #1911

## 💡 Background and solution

### Problem

When `Attachments` uses `overflow="scrollX"` and `items` are updated from outside (i.e. not via the component's internal upload flow), the prev/next scroll buttons fail to appear even though the content overflows. Users currently have to change the component `key` to force a remount to "wake up" the buttons.

### Root cause

In `file-card/List.tsx`, `checkPing()` (which toggles `pingStart`/`pingEnd` to show the scroll buttons) is only triggered by:
- the container's `onScroll`, and
- `ResizeObserver` on the scroll container.

The `ResizeObserver` wraps the `overflow-x: auto` scroll container itself. When `items` grow, the container's `clientWidth` stays the same and only the inner `scrollWidth` increases, so `ResizeObserver` does not fire and no scroll happens. As a result `checkPing()` is never called and the buttons stay hidden. This is the gap left by #1578.

### Solution

Add a `useLayoutEffect` that re-runs `checkPing()` (via `requestAnimationFrame`, scheduled after DOM layout) whenever the rendered `list` or `overflow` mode changes. This covers the controlled `items`-update case that `ResizeObserver` misses, without affecting `wrap` mode.

## 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Attachments` / `FileCard.List` scroll buttons not showing under `overflow="scrollX"` when `items` are updated externally. |
| 🇨🇳 Chinese | 修复 `Attachments` / `FileCard.List` 在 `overflow="scrollX"` 下，通过外部更新 `items` 时左右滚动按钮不显示的问题。 |

## ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

## Tests

Added a regression test in `file-card/__tests__/index.test.tsx`: `should refresh scrollX ping state when items update without remount`. Verified it fails without the fix and passes with it. Full `file-card` + `attachments` suites pass (80 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了文件卡片列表在启用滚动模式时的边界检测与可滚动状态更新，避免无谓刷新并提升稳定性与性能。
  * 在不使用换行布局时更准确地维持左右/上下可滚动边界状态，减少渲染时钟回调残留。

* **Tests**
  * 更新并新增滚动场景测试与相关 mock，验证容器尺寸或内容变化时边界检测与可见性标记的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->