### PR TITLE
docs: fix outdated type name in Prompts API table

### DIFF
--- a/packages/x/components/prompts/index.en-US.md
+++ b/packages/x/components/prompts/index.en-US.md
@@ -32,22 +32,22 @@ The Prompts component is used to display a predefined set of questions or sugges
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | classNames | Custom style class names for different parts of each prompt item. | Record<SemanticType, string> | - | - |
-| items | List containing multiple prompt items. | PromptProps[] | - | - |
+| items | List containing multiple prompt items. | PromptsItemType[] | - | - |
 | prefixCls | Prefix for style class names. | string | - | - |
 | rootClassName | Style class name for the root node. | string | - | - |
 | styles | Custom styles for different parts of each prompt item. | Record<SemanticType, React.CSSProperties> | - | - |
 | title | Title displayed at the top of the prompt list. | React.ReactNode | - | - |
 | vertical | When set to `true`, the Prompts will be arranged vertically. | boolean | `false` | - |
 | wrap | When set to `true`, the Prompts will automatically wrap. | boolean | `false` | - |
-| onItemClick | Callback function when a prompt item is clicked. | (info: { data: PromptProps }) => void | - | - |
+| onItemClick | Callback function when a prompt item is clicked. | (info: { data: PromptsItemType }) => void | - | - |
 | fadeIn | Fade in effect | boolean | - | - |
 | fadeInLeft | Fade left in effect | boolean | - | - |
 
-### PromptProps
+### PromptsItemType
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| children | Nested child prompt items. | PromptProps[] | - | - |
+| children | Nested child prompt items. | PromptsItemType[] | - | - |
 | description | Prompt description providing additional information. | React.ReactNode | - | - |
 | disabled | When set to `true`, click events are disabled. | boolean | `false` | - |
 | icon | Prompt icon displayed on the left side of the prompt item. | React.ReactNode | - | - |

--- a/packages/x/components/prompts/index.zh-CN.md
+++ b/packages/x/components/prompts/index.zh-CN.md
@@ -35,27 +35,27 @@ Prompts 组件用于显示一组与当前上下文相关的预定义的问题或
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | classNames | 自定义样式类名，用于各个提示项的不同部分 | Record<SemanticType, string> | - | - |
-| items | 包含多个提示项的列表 | PromptProps[] | - | - |
+| items | 包含多个提示项的列表 | PromptsItemType[] | - | - |
 | prefixCls | 样式类名的前缀 | string | - | - |
 | rootClassName | 根节点的样式类名 | string | - | - |
 | styles | 自定义样式，用于各个提示项的不同部分 | Record<SemanticType, React.CSSProperties> | - | - |
 | title | 显示在提示列表顶部的标题 | React.ReactNode | - | - |
 | vertical | 设置为 `true` 时, 提示列表将垂直排列 | boolean | `false` | - |
 | wrap | 设置为 `true` 时, 提示列表将自动换行 | boolean | `false` | - |
-| onItemClick | 提示项被点击时的回调函数 | (info: { data: PromptProps }) => void | - | - |
+| onItemClick | 提示项被点击时的回调函数 | (info: { data: PromptsItemType }) => void | - | - |
 | fadeIn | 渐入效果 | boolean | - | - |
 | fadeInLeft | 从左到右渐入效果 | boolean | - | - |
 
-### PromptProps
+### PromptsItemType
 
-| 属性        | 说明                         | 类型            | 默认值  | 版本 |
-| ----------- | ---------------------------- | --------------- | ------- | ---- |
-| children    | 嵌套的子提示项               | PromptProps[]   | -       | -    |
-| description | 提示描述提供额外的信息       | React.ReactNode | -       | -    |
-| disabled    | 设置为 `true` 时禁用点击事件 | boolean         | `false` | -    |
-| icon        | 提示图标显示在提示项的左侧   | React.ReactNode | -       | -    |
-| key         | 唯一标识用于区分每个提示项   | string          | -       | -    |
-| label       | 提示标签显示提示的主要内容   | React.ReactNode | -       | -    |
+| 属性        | 说明                         | 类型              | 默认值  | 版本 |
+| ----------- | ---------------------------- | ----------------- | ------- | ---- |
+| children    | 嵌套的子提示项               | PromptsItemType[] | -       | -    |
+| description | 提示描述提供额外的信息       | React.ReactNode   | -       | -    |
+| disabled    | 设置为 `true` 时禁用点击事件 | boolean           | `false` | -    |
+| icon        | 提示图标显示在提示项的左侧   | React.ReactNode   | -       | -    |
+| key         | 唯一标识用于区分每个提示项   | string            | -       | -    |
+| label       | 提示标签显示提示的主要内容   | React.ReactNode   | -       | -    |
 
 ## Semantic DOM
 


### PR DESCRIPTION
## 🤔 This is a ...

- [x] 📝 Site / documentation improvement

## 🔗 Related issue link

Closes #1863

## 💡 Background and solution

The `Prompts` API documentation still referenced the old type name `PromptProps`, which has been renamed to `PromptsItemType` in the source (`components/prompts/index.tsx`).

Updated both the Chinese (`index.zh-CN.md`) and English (`index.en-US.md`) docs:
- `items` column: `PromptProps[]` → `PromptsItemType[]`
- `onItemClick` column: `(info: { data: PromptProps }) => void` → `(info: { data: PromptsItemType }) => void`
- The `### PromptProps` sub-section (incl. `children` type) → `### PromptsItemType`

> Note: the issue suggested the name `PromptItemType`, but the actual exported type is `PromptsItemType` (with the `s`), which is what this PR uses.

## 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix outdated type name `PromptProps` in the `Prompts` API docs (renamed to `PromptsItemType`). |
| 🇨🇳 Chinese | 修复 `Prompts` 文档中过时的类型名 `PromptProps`（已重命名为 `PromptsItemType`）。 |

## ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档更新**
  * 完善了 Prompts 组件的 API 文档定义，优化了类型系统的一致性和准确性。中英文文档已同步更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->