### PR TITLE
fix(x-markdown): avoid jank when initial streaming output is non-streaming

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/Renderer.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Renderer.test.ts
@@ -1390,4 +1390,21 @@ describe('Renderer', () => {
       createElementSpy.mockClear();
     });
   });
+
+  describe('SSR / no DOM safety', () => {
+    it('returns null from processHtml when DOMPurify.sanitize is unavailable', () => {
+      const renderer = new Renderer({ components: { 'custom-tag': MockComponent } });
+      const originalSanitize = DOMPurify.sanitize;
+      // Simulate a server environment without a DOM, where DOMPurify's default
+      // export has no `sanitize` method.
+      (DOMPurify as any).sanitize = undefined;
+      try {
+        expect(renderer.processHtml('<custom-tag>content</custom-tag>')).toBeNull();
+        // render() delegates to processHtml and must not throw either.
+        expect(renderer.render('<p>hello</p>')).toBeNull();
+      } finally {
+        (DOMPurify as any).sanitize = originalSanitize;
+      }
+    });
+  });
 });

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -121,6 +121,13 @@ class Renderer {
   }
 
   public processHtml(htmlString: string): React.ReactNode {
+    // SSR / no DOM: DOMPurify needs a DOM to sanitize, so its default export has no
+    // `sanitize` method when there is no `window` (e.g. server pre-render). Skip rendering
+    // here and let the client hydrate, matching the pre-streaming-refactor server behavior.
+    if (typeof DOMPurify.sanitize !== 'function') {
+      return null;
+    }
+
     const unclosedTags = this.detectUnclosedTags(htmlString);
     const cidRef = { current: 0, tagIndexes: {} };
 

--- a/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
@@ -243,8 +243,9 @@ const useStreaming = (
 ) => {
   const { streaming, components = {} } = config || {};
   const { hasNextChunk: enableCache = false, incompleteMarkdownComponentMap } = streaming || {};
+  const [streamingOutput, setStreamingOutput] = useState('');
   // Non-streaming: seed output with full input so the first paint renders complete content and avoids layout jitter.
-  const [output, setOutput] = useState(!enableCache && typeof input === 'string' ? input : '');
+  const output = enableCache ? streamingOutput : (typeof input === 'string' ? input : '');
   const cacheRef = useRef<StreamCache>(getInitialCache());
 
   const handleIncompleteMarkdown = useCallback(
@@ -282,7 +283,7 @@ const useStreaming = (
   const processStreaming = useCallback(
     (text: string): void => {
       if (!text) {
-        setOutput('');
+        setStreamingOutput('');
         cacheRef.current = getInitialCache();
         return;
       }
@@ -323,7 +324,7 @@ const useStreaming = (
       }
 
       const incompletePlaceholder = handleIncompleteMarkdown(cache);
-      setOutput(cache.completeMarkdown + (incompletePlaceholder || ''));
+      setStreamingOutput(cache.completeMarkdown + (incompletePlaceholder || ''));
     },
     [handleIncompleteMarkdown],
   );
@@ -331,11 +332,13 @@ const useStreaming = (
   useEffect(() => {
     if (typeof input !== 'string') {
       console.error(`X-Markdown: input must be string, not ${typeof input}.`);
-      setOutput('');
+      setStreamingOutput('');
       return;
     }
 
-    enableCache ? processStreaming(input) : setOutput(input);
+    if (enableCache) {
+      processStreaming(input);
+    }
   }, [input, enableCache, processStreaming]);
 
   return output;

--- a/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
@@ -243,7 +243,8 @@ const useStreaming = (
 ) => {
   const { streaming, components = {} } = config || {};
   const { hasNextChunk: enableCache = false, incompleteMarkdownComponentMap } = streaming || {};
-  const [output, setOutput] = useState('');
+  // Non-streaming: seed output with full input so the first paint renders complete content and avoids layout jitter.
+  const [output, setOutput] = useState(!enableCache && typeof input === 'string' ? input : '');
   const cacheRef = useRef<StreamCache>(getInitialCache());
 
   const handleIncompleteMarkdown = useCallback(

--- a/packages/x-markdown/tests/setup.ts
+++ b/packages/x-markdown/tests/setup.ts
@@ -58,9 +58,57 @@ export function fillWindowEnv(window: Window | DOMWindow) {
   });
 }
 
+/**
+ * happy-dom (>= 20.10.x) regression: the `nodeName` getter on `Node.prototype`
+ * returns '' for element instances (the working getter lives on
+ * `Element.prototype`). DOMPurify reads `nodeName` through the `Node.prototype`
+ * getter — per the DOM spec, `nodeName` is defined on `Node` — so every element
+ * is seen as an unknown tag and stripped while its text content is kept. This
+ * makes XMarkdown render only the inner text (no <p>/<div>/<h*> wrappers, raw
+ * HTML dropped). Restore a spec-correct getter on `Node.prototype` so DOMPurify
+ * (and any other consumer) reads the real node name.
+ */
+function fixNodeNameGetter() {
+  if (typeof Node === 'undefined' || !Node.prototype || typeof document === 'undefined') {
+    return;
+  }
+  const desc = Object.getOwnPropertyDescriptor(Node.prototype, 'nodeName');
+  const probe = document.createElement('div');
+  // Only patch when the Node.prototype getter is actually broken.
+  if (!desc?.get || desc.get.call(probe) === 'DIV') {
+    return;
+  }
+  Object.defineProperty(Node.prototype, 'nodeName', {
+    configurable: true,
+    get(this: Node): string {
+      switch (this.nodeType) {
+        case 1: // ELEMENT_NODE
+          return (this as Element).tagName;
+        case 3: // TEXT_NODE
+          return '#text';
+        case 8: // COMMENT_NODE
+          return '#comment';
+        case 4: // CDATA_SECTION_NODE
+          return '#cdata-section';
+        case 7: // PROCESSING_INSTRUCTION_NODE
+          return (this as ProcessingInstruction).target;
+        case 9: // DOCUMENT_NODE
+          return '#document';
+        case 10: // DOCUMENT_TYPE_NODE
+          return (this as DocumentType).name;
+        case 11: // DOCUMENT_FRAGMENT_NODE
+          return '#document-fragment';
+        default:
+          return (this as Element).tagName || '';
+      }
+    },
+  });
+}
+
 /* eslint-disable global-require */
 if (typeof window !== 'undefined') {
   fillWindowEnv(window);
+  fixNodeNameGetter();
 }
 
 global.requestAnimationFrame = global.requestAnimationFrame || global.setTimeout;

--- a/packages/x/components/bubble/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/packages/x/components/bubble/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4021,11 +4021,9 @@ exports[`renders components/bubble/demo/markdown.tsx extend context correctly 1`
             <div
               class="x-markdown"
             >
-              <blockquote>
-                <p>
-                  Render as markdown content to show rich text!
-                </p>
-              </blockquote>
+              <p>
+                Render as markdown content to show rich text!
+              </p>
               <p>
                 Link: 
                 <a

--- a/packages/x/components/bubble/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/x/components/bubble/__tests__/__snapshots__/demo.test.ts.snap
@@ -2088,7 +2088,23 @@ exports[`renders components/bubble/demo/markdown.tsx correctly 1`] = `
         >
           <article
             class="ant-typography css-var-_R_0_"
-          />
+          >
+            <div
+              class="x-markdown"
+            >
+              <p>
+                Render as markdown content to show rich text!
+              </p>
+              <p>
+                Link: 
+                <a
+                  href="https://x.ant.design"
+                >
+                  Ant Design X
+                </a>
+              </p>
+            </div>
+          </article>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[English Template / 英文模板](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 1. 描述相关需求的来源，如相关的 issue 讨论链接。
> 2. 例如 close #xxxx、 fix #xxxx

无

### 💡 需求背景和解决方案

> 1. 要解决的具体问题。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及UI/交互变动建议提供截图或 GIF。

非流式输出时，即直接渲染某些 markdown ，当前会因为 output 先 空字符串，然后 useEffect 之后才会变为 input ，导致页面跳动，尤其有 多个markdown 或者 markdown 内容较多时比较明显。当前修改为初始化时非流式输出，直接渲染 input

### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://x.ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     avoid jank when initial streaming output is non-streaming    |
| 🇨🇳 中文 |     优化非流式输出渲染延迟问题     |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug修复**
  * 优化了初始渲染：在禁用流式缓存时，首屏直接显示输入内容，减少布局抖动并提升首屏稳定性。
  * 改进了流式输出行为：启用缓存时流式结果会及时更新；接收到空文本时会清空显示，避免残留内容。
  * 修复了测试环境下的 DOM 行为回归，恢复对节点名称的正确识别，防止 HTML 处理库错误移除合法标签。
* **兼容性**
  * 增加服务端/无 DOM 场景保护：在缺少 DOMPurify 时跳过预渲染并返回空，避免 SSR 抛错。
* **新增测试**
  * 增加 SSR / 无 DOM 安全性测试，确保在无 sanitize 时安全返回。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->