### PR TITLE
fix(x-markdown): protect all newlines inside custom tags (#1896)

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
@@ -193,9 +193,9 @@ describe('Parser', () => {
       expect(result).toContain('正文内容开始');
     });
 
-    it('should keep ordered list markup inside custom tags intact when protectAllCustomTagNewlines is enabled', () => {
+    it('should keep ordered list markup inside custom tags intact when disableCustomTagBlockMarkdown is enabled', () => {
       const parser = new Parser({
-        protectAllCustomTagNewlines: true,
+        disableCustomTagBlockMarkdown: true,
         components: { think: 'div' },
       });
       const content =
@@ -210,16 +210,16 @@ describe('Parser', () => {
       expect(result).not.toContain('<li>');
     });
 
-    it('should not turn protected placeholders into markdown emphasis when protectAllCustomTagNewlines is enabled', () => {
+    it('should still parse inline markdown when disableCustomTagBlockMarkdown is enabled', () => {
       const parser = new Parser({
-        protectAllCustomTagNewlines: true,
+        disableCustomTagBlockMarkdown: true,
         components: { think: 'div' },
       });
-      const content = '<think>line a\nline b\nline c</think>tail';
+      const content = '<think>line a\n**bold**\nline c</think>tail';
       const result = parser.parse(content);
 
-      expect(result).toContain('<think>line a\nline b\nline c</think>');
-      expect(result).not.toContain('<strong>');
+      expect(result).toContain('<think>line a\n<strong>bold</strong>\nline c</think>');
+      expect(result).not.toContain('<ol>');
       expect(result).not.toMatch(/X_MD_NL_/);
     });
   });

--- a/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
@@ -178,6 +178,39 @@ describe('Parser', () => {
       const result = parser.parse(content);
       expect(result).toContain('<CustomComponent>Single line content</CustomComponent>');
     });
+
+    it('should keep ordered list markup inside custom tags intact (issue #1896)', () => {
+      const parser = new Parser({
+        protectCustomTagNewlines: true,
+        components: { think: 'div' },
+      });
+      const content =
+        '<think>The user is asking what I can do.\n\nKey capabilities:\n1. one\n2. two\n</think>正文内容开始';
+      const result = parser.parse(content);
+
+      // The closing tag must stay attached to the think component and not be
+      // split into a list item, and the inner content must be fully preserved.
+      expect(result).toContain(
+        '<think>The user is asking what I can do.\n\nKey capabilities:\n1. one\n2. two\n</think>',
+      );
+      expect(result).toContain('正文内容开始');
+      expect(result).not.toContain('<ol>');
+      expect(result).not.toContain('<li>');
+    });
+
+    it('should not turn protected placeholders into markdown emphasis', () => {
+      const parser = new Parser({
+        protectCustomTagNewlines: true,
+        components: { think: 'div' },
+      });
+      const content = '<think>line a\nline b\nline c</think>tail';
+      const result = parser.parse(content);
+
+      expect(result).toContain('<think>line a\nline b\nline c</think>');
+      // Placeholders must be fully restored, leaving no sentinel artifacts.
+      expect(result).not.toContain('<strong>');
+      expect(result).not.toMatch(/X_MD_NL_/);
+    });
   });
 
   describe('escapeHtml', () => {

--- a/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
@@ -179,7 +179,7 @@ describe('Parser', () => {
       expect(result).toContain('<CustomComponent>Single line content</CustomComponent>');
     });
 
-    it('should keep ordered list markup inside custom tags intact (issue #1896)', () => {
+    it('should keep block markdown parsing behavior when only protectCustomTagNewlines is enabled', () => {
       const parser = new Parser({
         protectCustomTagNewlines: true,
         components: { think: 'div' },
@@ -188,8 +188,20 @@ describe('Parser', () => {
         '<think>The user is asking what I can do.\n\nKey capabilities:\n1. one\n2. two\n</think>正文内容开始';
       const result = parser.parse(content);
 
-      // The closing tag must stay attached to the think component and not be
-      // split into a list item, and the inner content must be fully preserved.
+      expect(result).toContain('<ol>');
+      expect(result).toContain('<li>one</li>');
+      expect(result).toContain('正文内容开始');
+    });
+
+    it('should keep ordered list markup inside custom tags intact when protectAllCustomTagNewlines is enabled', () => {
+      const parser = new Parser({
+        protectAllCustomTagNewlines: true,
+        components: { think: 'div' },
+      });
+      const content =
+        '<think>The user is asking what I can do.\n\nKey capabilities:\n1. one\n2. two\n</think>正文内容开始';
+      const result = parser.parse(content);
+
       expect(result).toContain(
         '<think>The user is asking what I can do.\n\nKey capabilities:\n1. one\n2. two\n</think>',
       );
@@ -198,16 +210,15 @@ describe('Parser', () => {
       expect(result).not.toContain('<li>');
     });
 
-    it('should not turn protected placeholders into markdown emphasis', () => {
+    it('should not turn protected placeholders into markdown emphasis when protectAllCustomTagNewlines is enabled', () => {
       const parser = new Parser({
-        protectCustomTagNewlines: true,
+        protectAllCustomTagNewlines: true,
         components: { think: 'div' },
       });
       const content = '<think>line a\nline b\nline c</think>tail';
       const result = parser.parse(content);
 
       expect(result).toContain('<think>line a\nline b\nline c</think>');
-      // Placeholders must be fully restored, leaving no sentinel artifacts.
       expect(result).not.toContain('<strong>');
       expect(result).not.toMatch(/X_MD_NL_/);
     });

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -178,7 +178,7 @@ class Parser {
 
   private protectCustomTags(
     content: string,
-    protectAllNewlines: boolean,
+    disableBlockMarkdown: boolean,
   ): {
     protected: string;
     placeholders: Map<string, string>;
@@ -263,7 +263,7 @@ class Parser {
             result.push(content.slice(lastIndex, startPos));
           }
 
-          if (protectAllNewlines && innerContent.includes('\n')) {
+          if (disableBlockMarkdown && innerContent.includes('\n')) {
             // Neutralize block-level markdown boundaries inside custom tags
             // while still allowing inline markdown to be parsed later.
             const protectedInner = protectNewlines(innerContent);

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -51,6 +51,13 @@ export function escapeHtml(html: string, encode?: boolean) {
 // Symbol to mark tokens for tail injection (avoids property name conflicts)
 const TAIL_MARKER = Symbol('tailMarker');
 
+// Sentinel characters (Unicode Private Use Area) wrapping placeholders for
+// protected newlines inside custom tags. Using PUA characters instead of `__`
+// avoids the placeholder being interpreted as markdown syntax (e.g. `__bold__`).
+const PLACEHOLDER_PREFIX = '\uE000X_MD_NL_';
+const PLACEHOLDER_SUFFIX = '\uE001';
+const PLACEHOLDER_REGEX = /\uE000X_MD_NL_\d+\uE001/g;
+
 // Type for tokens that can be marked for tail injection
 type MarkableToken = Token & { [TAIL_MARKER]?: boolean };
 
@@ -246,10 +253,14 @@ class Parser {
             result.push(content.slice(lastIndex, startPos));
           }
 
-          if (innerContent.includes('\n\n')) {
-            const protectedInner = innerContent.replace(/\n\n/g, () => {
-              const ph = `__X_MD_PLACEHOLDER_${placeholderIndex++}__`;
-              placeholders.set(ph, '\n\n');
+          if (innerContent.includes('\n')) {
+            // Custom tag inner content is treated as opaque text. Protect every
+            // newline (not only blank lines) so that block-level markdown syntax
+            // inside the tag (e.g. ordered/unordered lists, headings) is not parsed
+            // and does not split the custom tag structure.
+            const protectedInner = innerContent.replace(/\n/g, () => {
+              const ph = `${PLACEHOLDER_PREFIX}${placeholderIndex++}${PLACEHOLDER_SUFFIX}`;
+              placeholders.set(ph, '\n');
               return ph;
             });
             result.push(openTag + protectedInner + closeTag);
@@ -273,10 +284,7 @@ class Parser {
     if (placeholders.size === 0) {
       return content;
     }
-    return content.replace(
-      /__X_MD_PLACEHOLDER_\d+__/g,
-      (match) => placeholders.get(match) ?? match,
-    );
+    return content.replace(PLACEHOLDER_REGEX, (match) => placeholders.get(match) ?? match);
   }
 
   /**

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -7,6 +7,7 @@ type ParserOptions = {
   openLinksInNewTab?: boolean;
   components?: XMarkdownProps['components'];
   protectCustomTagNewlines?: boolean;
+  protectAllCustomTagNewlines?: boolean;
   escapeRawHtml?: boolean;
 };
 
@@ -175,7 +176,10 @@ class Parser {
     });
   }
 
-  private protectCustomTags(content: string): {
+  private protectCustomTags(
+    content: string,
+    protectAllNewlines: boolean,
+  ): {
     protected: string;
     placeholders: Map<string, string>;
   } {
@@ -187,6 +191,12 @@ class Parser {
     }
 
     let placeholderIndex = 0;
+    const protectNewlines = (value: string) =>
+      value.replace(/\n/g, () => {
+        const ph = `${PLACEHOLDER_PREFIX}${placeholderIndex++}${PLACEHOLDER_SUFFIX}`;
+        placeholders.set(ph, '\n');
+        return ph;
+      });
     const tagNamePattern = customTagNames
       .map((name) => name.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
       .join('|');
@@ -253,16 +263,17 @@ class Parser {
             result.push(content.slice(lastIndex, startPos));
           }
 
-          if (innerContent.includes('\n')) {
-            // Custom tag inner content is treated as opaque text. Protect every
-            // newline (not only blank lines) so that block-level markdown syntax
-            // inside the tag (e.g. ordered/unordered lists, headings) is not parsed
-            // and does not split the custom tag structure.
-            const protectedInner = innerContent.replace(/\n/g, () => {
-              const ph = `${PLACEHOLDER_PREFIX}${placeholderIndex++}${PLACEHOLDER_SUFFIX}`;
-              placeholders.set(ph, '\n');
-              return ph;
-            });
+          if (protectAllNewlines && innerContent.includes('\n')) {
+            // Treat the entire custom tag body as opaque text.
+            const protectedInner = protectNewlines(innerContent);
+            result.push(openTag + protectedInner + closeTag);
+          } else if (innerContent.includes('\n\n')) {
+            // Preserve the original behavior of only protecting blank-line
+            // paragraph breaks so existing block markdown inside custom tags
+            // keeps rendering unless the stronger flag is enabled.
+            const protectedInner = innerContent.replace(/\n{2,}/g, (newlines) =>
+              protectNewlines(newlines),
+            );
             result.push(openTag + protectedInner + closeTag);
           } else {
             result.push(openTag + innerContent + closeTag);
@@ -346,8 +357,11 @@ class Parser {
     this.injectTail = parseOptions?.injectTail ?? false;
 
     // Protect custom tags if needed
-    if (this.options.protectCustomTagNewlines) {
-      const { protected: protectedContent, placeholders } = this.protectCustomTags(content);
+    if (this.options.protectCustomTagNewlines || this.options.protectAllCustomTagNewlines) {
+      const { protected: protectedContent, placeholders } = this.protectCustomTags(
+        content,
+        !!this.options.protectAllCustomTagNewlines,
+      );
       const parsed = this.markdownInstance.parse(protectedContent) as string;
       return this.restorePlaceholders(parsed, placeholders);
     }

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -7,7 +7,7 @@ type ParserOptions = {
   openLinksInNewTab?: boolean;
   components?: XMarkdownProps['components'];
   protectCustomTagNewlines?: boolean;
-  protectAllCustomTagNewlines?: boolean;
+  disableCustomTagBlockMarkdown?: boolean;
   escapeRawHtml?: boolean;
 };
 
@@ -264,7 +264,8 @@ class Parser {
           }
 
           if (protectAllNewlines && innerContent.includes('\n')) {
-            // Treat the entire custom tag body as opaque text.
+            // Neutralize block-level markdown boundaries inside custom tags
+            // while still allowing inline markdown to be parsed later.
             const protectedInner = protectNewlines(innerContent);
             result.push(openTag + protectedInner + closeTag);
           } else if (innerContent.includes('\n\n')) {
@@ -357,10 +358,10 @@ class Parser {
     this.injectTail = parseOptions?.injectTail ?? false;
 
     // Protect custom tags if needed
-    if (this.options.protectCustomTagNewlines || this.options.protectAllCustomTagNewlines) {
+    if (this.options.protectCustomTagNewlines || this.options.disableCustomTagBlockMarkdown) {
       const { protected: protectedContent, placeholders } = this.protectCustomTags(
         content,
-        !!this.options.protectAllCustomTagNewlines,
+        !!this.options.disableCustomTagBlockMarkdown,
       );
       const parsed = this.markdownInstance.parse(protectedContent) as string;
       return this.restorePlaceholders(parsed, placeholders);

--- a/packages/x-markdown/src/XMarkdown/index.tsx
+++ b/packages/x-markdown/src/XMarkdown/index.tsx
@@ -21,7 +21,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
     openLinksInNewTab,
     dompurifyConfig,
     protectCustomTagNewlines,
-    protectAllCustomTagNewlines,
+    disableCustomTagBlockMarkdown,
     escapeRawHtml,
     debug,
     disableDefaultStyles,
@@ -73,7 +73,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
         openLinksInNewTab,
         components: mergedComponents,
         protectCustomTagNewlines,
-        protectAllCustomTagNewlines,
+        disableCustomTagBlockMarkdown,
         escapeRawHtml,
       }),
     [
@@ -82,7 +82,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
       openLinksInNewTab,
       mergedComponents,
       protectCustomTagNewlines,
-      protectAllCustomTagNewlines,
+      disableCustomTagBlockMarkdown,
       escapeRawHtml,
     ],
   );

--- a/packages/x-markdown/src/XMarkdown/index.tsx
+++ b/packages/x-markdown/src/XMarkdown/index.tsx
@@ -21,6 +21,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
     openLinksInNewTab,
     dompurifyConfig,
     protectCustomTagNewlines,
+    protectAllCustomTagNewlines,
     escapeRawHtml,
     debug,
     disableDefaultStyles,
@@ -72,6 +73,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
         openLinksInNewTab,
         components: mergedComponents,
         protectCustomTagNewlines,
+        protectAllCustomTagNewlines,
         escapeRawHtml,
       }),
     [
@@ -80,6 +82,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
       openLinksInNewTab,
       mergedComponents,
       protectCustomTagNewlines,
+      protectAllCustomTagNewlines,
       escapeRawHtml,
     ],
   );

--- a/packages/x-markdown/src/XMarkdown/interface.ts
+++ b/packages/x-markdown/src/XMarkdown/interface.ts
@@ -192,10 +192,16 @@ interface XMarkdownProps {
   dompurifyConfig?: DOMPurifyConfig;
   /**
    * @description 是否保护自定义标签中的换行符
-   * @description Whether to protect newlines in custom tags
+   * @description Whether to protect blank-line paragraph breaks in custom tags
    * @default false
    */
   protectCustomTagNewlines?: boolean;
+  /**
+   * @description 是否将自定义标签中的所有换行都视为纯文本，避免列表、标题、引用等块级 Markdown 被解析
+   * @description Whether to treat all newlines inside custom tags as plain text so block-level Markdown such as lists, headings, and blockquotes is not parsed
+   * @default false
+   */
+  protectAllCustomTagNewlines?: boolean;
   /**
    * @description 是否将 Markdown 中的原始 HTML 转义为纯文本展示（不解析为真实 HTML），避免 XSS 同时保留内容
    * @description Whether to escape raw HTML in Markdown as plain text (not parsed as real HTML), avoiding XSS while preserving content

--- a/packages/x-markdown/src/XMarkdown/interface.ts
+++ b/packages/x-markdown/src/XMarkdown/interface.ts
@@ -191,17 +191,17 @@ interface XMarkdownProps {
    */
   dompurifyConfig?: DOMPurifyConfig;
   /**
-   * @description 是否保护自定义标签中的换行符
+   * @description 是否保护自定义标签中的空行分段（仅针对空行造成的段落分隔）
    * @description Whether to protect blank-line paragraph breaks in custom tags
    * @default false
    */
   protectCustomTagNewlines?: boolean;
   /**
-   * @description 是否将自定义标签中的所有换行都视为纯文本，避免列表、标题、引用等块级 Markdown 被解析
-   * @description Whether to treat all newlines inside custom tags as plain text so block-level Markdown such as lists, headings, and blockquotes is not parsed
+   * @description 是否禁用自定义标签内的块级 Markdown 解析，避免列表、标题、引用等被解析；行内 Markdown 仍会生效
+   * @description Whether to disable block-level Markdown parsing inside custom tags so lists, headings, and blockquotes are not parsed; inline Markdown still works
    * @default false
    */
-  protectAllCustomTagNewlines?: boolean;
+  disableCustomTagBlockMarkdown?: boolean;
   /**
    * @description 是否将 Markdown 中的原始 HTML 转义为纯文本展示（不解析为真实 HTML），避免 XSS 同时保留内容
    * @description Whether to escape raw HTML in Markdown as plain text (not parsed as real HTML), avoiding XSS while preserving content

--- a/packages/x-skill/skills-zh/x-markdown/reference/API.md
+++ b/packages/x-skill/skills-zh/x-markdown/reference/API.md
@@ -13,7 +13,7 @@
 | openLinksInNewTab | 是否为所有链接添加 `target="_blank"` 并在新标签页打开 | `boolean` | `false` |
 | dompurifyConfig | HTML 净化与 XSS 防护的 DOMPurify 配置 | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
 | protectCustomTagNewlines | 是否保护自定义标签内部的空行分段，避免段落切分破坏标签结构 | `boolean` | `false` |
-| protectAllCustomTagNewlines | 是否将自定义标签内的所有换行都视为纯文本，避免列表、标题、引用等块级 Markdown 被解析 | `boolean` | `false` |
+| disableCustomTagBlockMarkdown | 是否禁用自定义标签内的块级 Markdown 解析，避免列表、标题、引用等被解析；行内 Markdown 仍会生效 | `boolean` | `false` |
 | escapeRawHtml | 是否将 Markdown 中的原始 HTML 转义为纯文本展示（不解析为真实 HTML），用于防 XSS 同时保留内容 | `boolean` | `false` |
 | debug | 是否开启调试模式（显示性能监控浮层） | `boolean` | `false` |
 

--- a/packages/x-skill/skills-zh/x-markdown/reference/API.md
+++ b/packages/x-skill/skills-zh/x-markdown/reference/API.md
@@ -12,7 +12,8 @@
 | prefixCls | 组件节点 CSS 类名前缀 | `string` | - |
 | openLinksInNewTab | 是否为所有链接添加 `target="_blank"` 并在新标签页打开 | `boolean` | `false` |
 | dompurifyConfig | HTML 净化与 XSS 防护的 DOMPurify 配置 | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
-| protectCustomTagNewlines | 是否保留自定义标签内部的换行 | `boolean` | `false` |
+| protectCustomTagNewlines | 是否保护自定义标签内部的空行分段，避免段落切分破坏标签结构 | `boolean` | `false` |
+| protectAllCustomTagNewlines | 是否将自定义标签内的所有换行都视为纯文本，避免列表、标题、引用等块级 Markdown 被解析 | `boolean` | `false` |
 | escapeRawHtml | 是否将 Markdown 中的原始 HTML 转义为纯文本展示（不解析为真实 HTML），用于防 XSS 同时保留内容 | `boolean` | `false` |
 | debug | 是否开启调试模式（显示性能监控浮层） | `boolean` | `false` |
 

--- a/packages/x-skill/skills-zh/x-markdown/reference/EXTENSIONS.md
+++ b/packages/x-skill/skills-zh/x-markdown/reference/EXTENSIONS.md
@@ -62,7 +62,8 @@ import '@ant-design/x-markdown/themes/light.css';
 
 - 保持自定义标签结构完整
 - 除非语法有意为之，否则避免在自定义 HTML 块内部插入多余空行
-- 如果自定义标签内换行需要保留，检查 `protectCustomTagNewlines`
+- 如果只需要保护自定义标签内的空行分段，使用 `protectCustomTagNewlines`
+- 如果希望自定义标签内的所有换行都按纯文本保留，使用 `protectAllCustomTagNewlines`
 
 ## 如何选工具
 

--- a/packages/x-skill/skills-zh/x-markdown/reference/EXTENSIONS.md
+++ b/packages/x-skill/skills-zh/x-markdown/reference/EXTENSIONS.md
@@ -63,7 +63,7 @@ import '@ant-design/x-markdown/themes/light.css';
 - 保持自定义标签结构完整
 - 除非语法有意为之，否则避免在自定义 HTML 块内部插入多余空行
 - 如果只需要保护自定义标签内的空行分段，使用 `protectCustomTagNewlines`
-- 如果希望自定义标签内的所有换行都按纯文本保留，使用 `protectAllCustomTagNewlines`
+- 如果希望禁用自定义标签内的块级 Markdown 解析，同时保留行内 Markdown，使用 `disableCustomTagBlockMarkdown`
 
 ## 如何选工具
 

--- a/packages/x-skill/skills/x-markdown/reference/API.md
+++ b/packages/x-skill/skills/x-markdown/reference/API.md
@@ -12,7 +12,8 @@
 | prefixCls | CSS class name prefix for component nodes | `string` | - |
 | openLinksInNewTab | Add `target="_blank"` to all links so they open in a new tab | `boolean` | `false` |
 | dompurifyConfig | DOMPurify config for HTML sanitization and XSS protection | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
-| protectCustomTagNewlines | Whether to preserve newlines inside custom tags | `boolean` | `false` |
+| protectCustomTagNewlines | Whether to protect blank-line paragraph breaks inside custom tags so paragraph splitting does not break the tag structure | `boolean` | `false` |
+| protectAllCustomTagNewlines | Whether to treat all newlines inside custom tags as plain text so lists, headings, blockquotes, and other block Markdown are not parsed | `boolean` | `false` |
 | escapeRawHtml | Escape raw HTML in Markdown as plain text (do not parse as real HTML), to prevent XSS while keeping content visible | `boolean` | `false` |
 | debug | Enable debug mode (performance overlay) | `boolean` | `false` |
 

--- a/packages/x-skill/skills/x-markdown/reference/API.md
+++ b/packages/x-skill/skills/x-markdown/reference/API.md
@@ -13,7 +13,7 @@
 | openLinksInNewTab | Add `target="_blank"` to all links so they open in a new tab | `boolean` | `false` |
 | dompurifyConfig | DOMPurify config for HTML sanitization and XSS protection | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
 | protectCustomTagNewlines | Whether to protect blank-line paragraph breaks inside custom tags so paragraph splitting does not break the tag structure | `boolean` | `false` |
-| protectAllCustomTagNewlines | Whether to treat all newlines inside custom tags as plain text so lists, headings, blockquotes, and other block Markdown are not parsed | `boolean` | `false` |
+| disableCustomTagBlockMarkdown | Whether to disable block Markdown parsing inside custom tags so lists, headings, blockquotes, and other block Markdown are not parsed; inline Markdown still works | `boolean` | `false` |
 | escapeRawHtml | Escape raw HTML in Markdown as plain text (do not parse as real HTML), to prevent XSS while keeping content visible | `boolean` | `false` |
 | debug | Enable debug mode (performance overlay) | `boolean` | `false` |
 

--- a/packages/x-skill/skills/x-markdown/reference/EXTENSIONS.md
+++ b/packages/x-skill/skills/x-markdown/reference/EXTENSIONS.md
@@ -62,7 +62,8 @@ For customization:
 
 - Keep custom tag blocks well formed.
 - Avoid stray blank lines inside custom HTML blocks unless the syntax is intentional.
-- If newlines inside custom tags matter, review `protectCustomTagNewlines`.
+- If only blank-line paragraph breaks inside custom tags need protection, use `protectCustomTagNewlines`.
+- If all newlines inside custom tags should stay as plain text, use `protectAllCustomTagNewlines`.
 
 ## Pick the Right Tool
 

--- a/packages/x-skill/skills/x-markdown/reference/EXTENSIONS.md
+++ b/packages/x-skill/skills/x-markdown/reference/EXTENSIONS.md
@@ -63,7 +63,7 @@ For customization:
 - Keep custom tag blocks well formed.
 - Avoid stray blank lines inside custom HTML blocks unless the syntax is intentional.
 - If only blank-line paragraph breaks inside custom tags need protection, use `protectCustomTagNewlines`.
-- If all newlines inside custom tags should stay as plain text, use `protectAllCustomTagNewlines`.
+- If block Markdown inside custom tags should be disabled while inline Markdown still works, use `disableCustomTagBlockMarkdown`.
 
 ## Pick the Right Tool
 

--- a/packages/x/docs/x-markdown/examples.en-US.md
+++ b/packages/x/docs/x-markdown/examples.en-US.md
@@ -37,7 +37,7 @@ Use this page to get a minimal setup for rendering LLM Markdown output.
 | openLinksInNewTab | Add `target="_blank"` to all links so they open in a new tab | `boolean` | `false` |
 | dompurifyConfig | DOMPurify config for HTML sanitization and XSS protection | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
 | protectCustomTagNewlines | Whether to protect blank-line paragraph breaks inside custom tags so paragraph splitting does not break the tag structure | `boolean` | `false` |
-| protectAllCustomTagNewlines | Whether to treat all newlines inside custom tags as plain text so lists, headings, blockquotes, and other block Markdown are not parsed | `boolean` | `false` |
+| disableCustomTagBlockMarkdown | Whether to disable block Markdown parsing inside custom tags so lists, headings, blockquotes, and other block Markdown are not parsed; inline Markdown still works | `boolean` | `false` |
 | escapeRawHtml | Escape raw HTML in Markdown as plain text (do not parse as real HTML), to prevent XSS while keeping content visible | `boolean` | `false` |
 | disableDefaultStyles | Disable built-in default styles for tags. Pass `true` to disable all, or an array to disable specific tags (e.g. `['ul', 'ol', 'li']`), useful to prevent default styles from polluting elements inside custom components | `boolean \| Array<'p' \| 'ul' \| 'ol' \| 'li' \| 'pre' \| 'code' \| 'table' \| 'th' \| 'td' \| 'img' \| 'hr'>` | `false` |
 | debug | Enable debug mode (performance overlay) | `boolean` | `false` |

--- a/packages/x/docs/x-markdown/examples.en-US.md
+++ b/packages/x/docs/x-markdown/examples.en-US.md
@@ -36,7 +36,8 @@ Use this page to get a minimal setup for rendering LLM Markdown output.
 | prefixCls | CSS class name prefix for component nodes | `string` | - |
 | openLinksInNewTab | Add `target="_blank"` to all links so they open in a new tab | `boolean` | `false` |
 | dompurifyConfig | DOMPurify config for HTML sanitization and XSS protection | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
-| protectCustomTagNewlines | Whether to preserve newlines inside custom tags | `boolean` | `false` |
+| protectCustomTagNewlines | Whether to protect blank-line paragraph breaks inside custom tags so paragraph splitting does not break the tag structure | `boolean` | `false` |
+| protectAllCustomTagNewlines | Whether to treat all newlines inside custom tags as plain text so lists, headings, blockquotes, and other block Markdown are not parsed | `boolean` | `false` |
 | escapeRawHtml | Escape raw HTML in Markdown as plain text (do not parse as real HTML), to prevent XSS while keeping content visible | `boolean` | `false` |
 | disableDefaultStyles | Disable built-in default styles for tags. Pass `true` to disable all, or an array to disable specific tags (e.g. `['ul', 'ol', 'li']`), useful to prevent default styles from polluting elements inside custom components | `boolean \| Array<'p' \| 'ul' \| 'ol' \| 'li' \| 'pre' \| 'code' \| 'table' \| 'th' \| 'td' \| 'img' \| 'hr'>` | `false` |
 | debug | Enable debug mode (performance overlay) | `boolean` | `false` |

--- a/packages/x/docs/x-markdown/examples.zh-CN.md
+++ b/packages/x/docs/x-markdown/examples.zh-CN.md
@@ -36,7 +36,8 @@ packageName: x-markdown
 | prefixCls | 组件节点 CSS 类名前缀 | `string` | - |
 | openLinksInNewTab | 是否为所有链接添加 `target="_blank"` 并在新标签页打开 | `boolean` | `false` |
 | dompurifyConfig | HTML 净化与 XSS 防护的 DOMPurify 配置 | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
-| protectCustomTagNewlines | 是否保留自定义标签内部的换行 | `boolean` | `false` |
+| protectCustomTagNewlines | 是否保护自定义标签内部的空行分段，避免段落切分破坏标签结构 | `boolean` | `false` |
+| protectAllCustomTagNewlines | 是否将自定义标签内的所有换行都视为纯文本，避免列表、标题、引用等块级 Markdown 被解析 | `boolean` | `false` |
 | escapeRawHtml | 是否将 Markdown 中的原始 HTML 转义为纯文本展示（不解析为真实 HTML），用于防 XSS 同时保留内容 | `boolean` | `false` |
 | disableDefaultStyles | 是否关闭内置标签的默认样式。`true` 关闭全部，数组按标签关闭（如 `['ul', 'ol', 'li']`），用于避免默认样式污染自定义组件内部元素 | `boolean \| Array<'p' \| 'ul' \| 'ol' \| 'li' \| 'pre' \| 'code' \| 'table' \| 'th' \| 'td' \| 'img' \| 'hr'>` | `false` |
 | debug | 是否开启调试模式（显示性能监控浮层） | `boolean` | `false` |

--- a/packages/x/docs/x-markdown/examples.zh-CN.md
+++ b/packages/x/docs/x-markdown/examples.zh-CN.md
@@ -37,7 +37,7 @@ packageName: x-markdown
 | openLinksInNewTab | 是否为所有链接添加 `target="_blank"` 并在新标签页打开 | `boolean` | `false` |
 | dompurifyConfig | HTML 净化与 XSS 防护的 DOMPurify 配置 | [`DOMPurify.Config`](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) | - |
 | protectCustomTagNewlines | 是否保护自定义标签内部的空行分段，避免段落切分破坏标签结构 | `boolean` | `false` |
-| protectAllCustomTagNewlines | 是否将自定义标签内的所有换行都视为纯文本，避免列表、标题、引用等块级 Markdown 被解析 | `boolean` | `false` |
+| disableCustomTagBlockMarkdown | 是否禁用自定义标签内的块级 Markdown 解析，避免列表、标题、引用等被解析；行内 Markdown 仍会生效 | `boolean` | `false` |
 | escapeRawHtml | 是否将 Markdown 中的原始 HTML 转义为纯文本展示（不解析为真实 HTML），用于防 XSS 同时保留内容 | `boolean` | `false` |
 | disableDefaultStyles | 是否关闭内置标签的默认样式。`true` 关闭全部，数组按标签关闭（如 `['ul', 'ol', 'li']`），用于避免默认样式污染自定义组件内部元素 | `boolean \| Array<'p' \| 'ul' \| 'ol' \| 'li' \| 'pre' \| 'code' \| 'table' \| 'th' \| 'td' \| 'img' \| 'hr'>` | `false` |
 | debug | 是否开启调试模式（显示性能监控浮层） | `boolean` | `false` |


### PR DESCRIPTION
## 🤔 This is a ...
- [x] 🐞 Bug fix

## 🔗 Related issue link
Closes #1896

## 💡 Background and solution
自定义标签（如 `<think>`）的内部内容应作为不透明文本处理，但原保护逻辑只转义了空行（`\n\n`）。当内部出现「单换行 + 块级 markdown 语法」（有序/无序列表、标题）时，marked 仍会解析这些语法，导致自定义标签结构被拆散（例如闭合标签 `</think>` 被并入 `<li>`）。

修复：
- 保护自定义标签内的**每一个**换行，而非仅空行。
- 占位符改用 Unicode 私有区（PUA）哨兵字符，避免与相邻文本组成 `__...__` 被误解析为 markdown 加粗。

## 📝 Changelog
- 修复自定义标签内含列表/标题等块级语法时被错误解析、结构被拆断的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增配置 disableCustomTagBlockMarkdown：可在自定义标签内禁用块级 Markdown（保留行内 Markdown）。
* **Bug Fixes**
  * 改进自定义标签的换行保护与占位符恢复，减少因换行导致的列表/段落解析异常。
* **Tests**
  * 新增测试，覆盖不同配置下自定义标签中换行、列表和行内 Markdown 的行为。
* **Documentation**
  * 更新 API 与扩展文档，明确两种换行保护策略及使用说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->