### PR TITLE
fix: cache chat provider with useRef in x-conversations demos (#1833)

### DIFF
--- a/packages/x/docs/x-sdk/demos/x-conversations/async-defaultMessages.tsx
+++ b/packages/x/docs/x-sdk/demos/x-conversations/async-defaultMessages.tsx
@@ -55,11 +55,12 @@ const App = () => {
 
   // 提供者缓存：为每个会话缓存独立的聊天提供者实例
   // Provider cache: cache independent chat provider instances for each conversation
-  const providerCaches = new Map<string, DeepSeekChatProvider>();
+  const providerCachesRef = useRef(new Map<string, DeepSeekChatProvider>());
 
   // 提供者工厂：根据会话key创建或获取对应的聊天提供者
   // Provider factory: create or get corresponding chat provider based on conversation key
   const providerFactory = (conversationKey: string) => {
+    const providerCaches = providerCachesRef.current;
     if (!providerCaches.get(conversationKey)) {
       providerCaches.set(
         conversationKey,

--- a/packages/x/docs/x-sdk/demos/x-conversations/with-x-chat.tsx
+++ b/packages/x/docs/x-sdk/demos/x-conversations/with-x-chat.tsx
@@ -71,11 +71,12 @@ const App = () => {
 
   // 提供者缓存：为每个会话缓存独立的聊天提供者实例
   // Provider cache: cache independent chat provider instances for each conversation
-  const providerCaches = new Map<string, DeepSeekChatProvider>();
+  const providerCachesRef = useRef(new Map<string, DeepSeekChatProvider>());
 
   // 提供者工厂：根据会话key创建或获取对应的聊天提供者
   // Provider factory: create or get corresponding chat provider based on conversation key
   const providerFactory = (conversationKey: string) => {
+    const providerCaches = providerCachesRef.current;
     if (!providerCaches.get(conversationKey)) {
       providerCaches.set(
         conversationKey,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #1833

### 💡 Background and Solution

In the `with-x-chat` and `async-defaultMessages` demos under `x-conversations`, the provider cache `Map` was created **inside the component function body**:

```tsx
const providerCaches = new Map<string, DeepSeekChatProvider>();
```

Since this runs on every render, the `Map` is re-created each time and never actually caches anything — `providerFactory(activeConversationKey)` returns a **brand-new provider instance on every render**.

This breaks aborting a streaming response:

1. A request is started and `run()` on provider-A; the streaming response is in flight.
2. While streaming, `setMessages` keeps triggering re-renders, which rebuild a new provider-B. Internally `useXChat` updates `requestHandlerRef.current = provider?.request` to point at provider-B.
3. provider-B's request is `manual` and has **never been run**, so its `abortController` is still `undefined` (it is only created inside `init()` on `run()`).
4. Clicking "stop" calls `abort()` → `this.abortController.abort()` on provider-B → throws a `TypeError`, and the actually in-flight provider-A request is **never aborted**.

**Fix:** persist the cache with `useRef` so the provider instance stays stable across renders, matching the existing correct `session-key` demo:

```tsx
const providerCachesRef = useRef(new Map<string, DeepSeekChatProvider>());

const providerFactory = (conversationKey: string) => {
  const providerCaches = providerCachesRef.current;
  // ...
};
```

**Verification:** reproduced locally with a unit test driving real `useXChat` + `DefaultChatProvider` — the buggy version rebuilds the provider after a re-render, making `abort()` throw and leaving the in-flight request uncancelled; the fixed version keeps the provider reference stable, `abort()` does not throw and correctly cancels the in-flight request. The repro test relied on internal implementation details and is not included in this PR.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix x-conversations demos so the chat provider is cached with `useRef` instead of being re-created on every render, preventing abort from failing on an in-flight streaming response. |
| 🇨🇳 Chinese | 修复 x-conversations 示例：使用 `useRef` 缓存 chat provider，避免每次渲染重建实例，从而修复流式响应进行中点击停止时中止失败的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 性能优化

* 改进了对话会话中聊天提供商的缓存机制，确保提供商实例得以复用，减少不必要的重新创建，提升应用性能表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->