### PR TITLE
fix: suppress Sender borderless focus outline

### DIFF
--- a/packages/x/components/sender/style/index.ts
+++ b/packages/x/components/sender/style/index.ts
@@ -129,6 +129,11 @@ const genSenderStyle: GenerateStyle<SenderToken> = (token) => {
         alignSelf: 'center',
         caretColor: token.colorPrimary,
         fontSize: token.fontSize,
+        [`&${antCls}-input-borderless`]: {
+          '&:focus-visible, &:has(input:focus-visible), &:has(textarea:focus-visible)': {
+            outline: 'none',
+          },
+        },
       },
       // ============================ Actions ============================
       [`${componentCls}-actions-list`]: {

--- a/packages/x/components/sender/style/slot-textarea.ts
+++ b/packages/x/components/sender/style/slot-textarea.ts
@@ -6,6 +6,7 @@ const genSlotTextAreaStyle: GenerateStyle<SenderToken> = (token) => {
   const { componentCls, antCls, calc } = token;
   const slotCls = `${componentCls}-slot`;
   const antInputCls = `${antCls}-input`;
+  const antInputBorderlessCls = `${antInputCls}-borderless`;
   const antDropdownCls = `${antCls}-dropdown-trigger`;
   const slotInputCls = `${componentCls}-slot-input`;
   const slotSelectCls = `${componentCls}-slot-select`;
@@ -47,6 +48,11 @@ const genSlotTextAreaStyle: GenerateStyle<SenderToken> = (token) => {
         fontSize: 'inherit',
         lineHeight: 'inherit',
         position: 'relative',
+        [`&${antInputBorderlessCls}`]: {
+          '&:focus-visible, &:has(input:focus-visible), &:has(textarea:focus-visible)': {
+            outline: 'none',
+          },
+        },
         '&::placeholder': {
           color: token.colorTextSlotPlaceholder,
           fontSize: 'inherit',


### PR DESCRIPTION
### 背景

ant-design/ant-design#58250 在 antd 侧为 borderless 输入类组件补充了 focus-visible outline，用于改善普通无边框输入控件的键盘焦点可见性。

Ant Design X 的 Sender 内部会使用 antd 的 `Input.TextArea` 和词槽 `Input`，并统一设置为 `variant="borderless"`，但 Sender 本身已经有独立的容器、阴影和输入区域视觉。升级到包含该 antd 改动的版本后，Sender 内部输入在聚焦时会出现一条蓝色内部描边，和 Sender 设计不一致。

### 修改

- 在 Sender 主输入 `.ant-sender-input.ant-input-borderless` 范围内去掉 antd 新增的 focus outline。
- 在 Sender 词槽输入 `.ant-sender-slot-input.ant-input-borderless` 范围内同步去掉该 focus outline。
- 覆盖只限定在 Sender 私有 class 下，不影响项目中其他 antd borderless 输入组件。

### 影响

该改动恢复 Sender 现有视觉表现，避免 antd borderless focus outline 穿透到 Sender 内部输入区域。普通 antd Input/Select 等 borderless 场景仍保留 antd 侧的无障碍焦点样式。

### 验证

- `npm run lint:style --workspace packages/x`
- `npm test --workspace packages/x -- sender/__tests__/index.test.tsx sender/__tests__/slot.test.tsx --runInBand`
- `antd lint packages/x/components/sender/style/index.ts --format json`
- `antd lint packages/x/components/sender/style/slot-textarea.ts --format json`
- 本地浏览器验证 Sender textarea 和 slot input 聚焦后 `outlineStyle` 均为 `none`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了发送框的无边框输入样式在聚焦时的显示，避免出现默认聚焦外轮廓。
  * 当输入框、文本域或其内部元素处于键盘聚焦状态时，自动隐藏 `outline`，视觉更统一。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->