### PR TITLE
fix(x-sdk): release XStream reader lock on early loop exit

### DIFF
--- a/packages/x-sdk/src/x-stream/__test__/index.test.ts
+++ b/packages/x-sdk/src/x-stream/__test__/index.test.ts
@@ -144,4 +144,32 @@ describe('XStream', () => {
       }),
     ).toBeInstanceOf(ReadableStream);
   });
+
+  it('releases the reader lock when the consumer breaks out early', async () => {
+    const textEncoder = new TextEncoder();
+    const stream = XStream({
+      readableStream: new ReadableStream({
+        async start(controller) {
+          let i = 0;
+          while (i < 5) {
+            controller.enqueue(textEncoder.encode(`data: ${i}\n\n`));
+            i += 1;
+          }
+          controller.close();
+        },
+      }),
+    });
+
+    // Consume one chunk then break out of the loop early.
+    for await (const value of stream) {
+      expect(value).toEqual({ data: '0' });
+      break;
+    }
+
+    // After an early exit the internal reader's lock must be released so the
+    // stream can be re-acquired (e.g. getReader/cancel) without throwing.
+    expect(stream.locked).toBe(false);
+    // The stream should be cleanly cancellable after the early break.
+    await stream.cancel();
+  });
 });

--- a/packages/x-sdk/src/x-stream/__test__/index.test.ts
+++ b/packages/x-sdk/src/x-stream/__test__/index.test.ts
@@ -169,7 +169,13 @@ describe('XStream', () => {
     // After an early exit the internal reader's lock must be released so the
     // stream can be re-acquired (e.g. getReader/cancel) without throwing.
     expect(stream.locked).toBe(false);
-    // The stream should be cleanly cancellable after the early break.
-    await stream.cancel();
+
+    // The underlying stream should be cancelled, not just have its lock
+    // released — matching the default ReadableStream async iterator semantics
+    // so that any in-flight fetch stops buffering data.
+    const reader = stream.getReader();
+    const { done } = await reader.read();
+    expect(done).toBe(true);
+    reader.releaseLock();
   });
 });

--- a/packages/x-sdk/src/x-stream/index.ts
+++ b/packages/x-sdk/src/x-stream/index.ts
@@ -207,15 +207,21 @@ function XStream<Output = SSEOutput>(options: XStreamOptions<Output>) {
   stream[Symbol.asyncIterator] = async function* () {
     const reader = this.getReader();
 
-    while (true) {
-      const { done, value } = await reader.read();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
 
-      if (done) break;
+        if (done) break;
 
-      if (!value) continue;
+        if (!value) continue;
 
-      // Transformed data through all transform pipes
-      yield value;
+        // Transformed data through all transform pipes
+        yield value;
+      }
+    } finally {
+      // Always release the lock so the stream can be re-acquired or cancelled,
+      // even when the consumer breaks/returns/throws out of the loop early.
+      reader.releaseLock();
     }
   };
 

--- a/packages/x-sdk/src/x-stream/index.ts
+++ b/packages/x-sdk/src/x-stream/index.ts
@@ -207,11 +207,16 @@ function XStream<Output = SSEOutput>(options: XStreamOptions<Output>) {
   stream[Symbol.asyncIterator] = async function* () {
     const reader = this.getReader();
 
+    let completed = false;
+
     try {
       while (true) {
         const { done, value } = await reader.read();
 
-        if (done) break;
+        if (done) {
+          completed = true;
+          break;
+        }
 
         if (!value) continue;
 
@@ -219,6 +224,12 @@ function XStream<Output = SSEOutput>(options: XStreamOptions<Output>) {
         yield value;
       }
     } finally {
+      if (!completed) {
+        // Cancel the underlying stream on early exit (break/return/throw),
+        // matching the default ReadableStream async iterator semantics and
+        // stopping any in-flight fetch from continuing to buffer data.
+        reader.cancel().catch(() => {});
+      }
       // Always release the lock so the stream can be re-acquired or cancelled,
       // even when the consumer breaks/returns/throws out of the loop early.
       reader.releaseLock();


### PR DESCRIPTION
The asyncIterator acquired a reader with getReader() (locking the stream) but never released it, and had no try/finally. When a consumer broke, returned, or threw out of a for-await loop early, the reader's lock leaked and the stream could not be re-acquired or cancelled — the underlying piped stream stayed alive and buffered until it drained naturally.

Wrap the read loop in try/finally and call reader.releaseLock() in finally so the lock is released on both normal completion and early exit.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了在 `for await...of` 中提前 `break/return/throw` 时，`XStream` 读取锁可能未释放导致后续无法正确取消或重新获取的问题。
  * 现在可区分正常结束与中途终止，确保读取完成/取消后始终释放锁并及时停止底层读取。
* **Tests**
  * 新增用例：提前退出后断言 `locked` 恢复，并验证底层读取已结束（读取返回 `done === true`），同时完成锁释放。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->