### PR TITLE
fix(x-markdown): eliminate O(N²) code-block scan freezing streaming of long content

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/hooks.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__tests__/hooks.test.tsx
@@ -1108,4 +1108,52 @@ describe('XMarkdown hooks', () => {
       expect(result.current).toBe('New content completely');
     });
   });
+
+  describe('useStreaming long single-line content (base64 images)', () => {
+    it('should stream a large base64 image without quadratic slowdown', () => {
+      const base64 = 'A'.repeat(300_000);
+      const full = `Here is an image:\n\n![chart](data:image/png;base64,${base64})\n\nDone.`;
+      const chunkSize = 1000;
+
+      const { result, rerender } = renderHook(({ input, config }) => useStreaming(input, config), {
+        initialProps: {
+          input: '',
+          config: { streaming: { hasNextChunk: true } },
+        },
+      });
+
+      const start = performance.now();
+      for (let end = chunkSize; end < full.length + chunkSize; end += chunkSize) {
+        act(() => {
+          rerender({
+            input: full.slice(0, end),
+            config: { streaming: { hasNextChunk: true } },
+          });
+        });
+      }
+      const elapsed = performance.now() - start;
+
+      expect(result.current).toBe(full);
+      expect(elapsed).toBeLessThan(3000);
+    }, 120_000);
+
+    it('should keep fence state correct when a code block follows long content', () => {
+      const base64 = 'B'.repeat(20_000);
+      const full = `![img](data:image/png;base64,${base64})\n\n\`\`\`js\nconst a = 1;\n`;
+
+      const { result, rerender } = renderHook(({ input, config }) => useStreaming(input, config), {
+        initialProps: {
+          input: full.slice(0, 100),
+          config: { streaming: { hasNextChunk: true } },
+        },
+      });
+
+      act(() => {
+        rerender({ input: full, config: { streaming: { hasNextChunk: true } } });
+      });
+
+      // Inside an open fence every char is committed as-is (no token recognition)
+      expect(result.current).toBe(full);
+    });
+  });
 });

--- a/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
@@ -8,6 +8,26 @@ export interface StreamCache {
   token: StreamCacheTokenType;
   processedLength: number;
   completeMarkdown: string;
+  fence: FenceState;
+}
+
+/**
+ * Incremental fenced-code-block state over the processed text, updated in O(1)
+ * per character. Recomputing over the full accumulated text on every character
+ * is O(N²) and freezes the page on long single-line content such as base64
+ * image data URIs.
+ */
+interface FenceState {
+  /** Inside an open fence, considering completed lines only */
+  inFenced: boolean;
+  fenceChar: string;
+  fenceLen: number;
+  /** Leading `/~ run of the current (incomplete) line */
+  lineFenceChar: string;
+  lineFenceLen: number;
+  lineFenceRunEnded: boolean;
+  /** Whether every char after the leading run is whitespace (closing fences allow only whitespace) */
+  lineTailBlank: boolean;
 }
 
 /**
@@ -141,11 +161,22 @@ const recognizeHandlers = Object.values(tokenRecognizerMap).map((rec) => ({
 }));
 
 /* ------------ Utils ------------ */
+const getInitialFenceState = (): FenceState => ({
+  inFenced: false,
+  fenceChar: '',
+  fenceLen: 0,
+  lineFenceChar: '',
+  lineFenceLen: 0,
+  lineFenceRunEnded: false,
+  lineTailBlank: true,
+});
+
 const getInitialCache = (): StreamCache => ({
   pending: '',
   token: StreamCacheTokenType.Text,
   processedLength: 0,
   completeMarkdown: '',
+  fence: getInitialFenceState(),
 });
 
 const commitCache = (cache: StreamCache): void => {
@@ -156,47 +187,51 @@ const commitCache = (cache: StreamCache): void => {
   cache.token = StreamCacheTokenType.Text;
 };
 
-const isInCodeBlock = (text: string, isFinalChunk = false): boolean => {
-  const lines = text.split('\n');
-  let inFenced = false;
-  let fenceChar = '';
-  let fenceLen = 0;
-
-  for (let i = 0; i < lines.length; i++) {
-    const rawLine = lines[i];
-    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
-
-    const match = line.match(/^(`{3,}|~{3,})(.*)$/);
-    if (match) {
-      const fence = match[1];
-      const after = match[2];
-      const char = fence[0];
-      const len = fence.length;
-
-      if (!inFenced) {
-        inFenced = true;
-        fenceChar = char;
-        fenceLen = len;
-      } else {
-        // Check if this is a valid closing fence
-        const isValidEnd = char === fenceChar && len >= fenceLen && /^\s*$/.test(after);
-
-        if (isValidEnd) {
-          // In streaming context, only close if this is the final chunk
-          // or if there are more lines after this fence
-          if (isFinalChunk || i < lines.length - 1) {
-            inFenced = false;
-            fenceChar = '';
-            fenceLen = 0;
-          }
-          // Otherwise, keep the fence open for potential streaming continuation
-        }
+const feedFenceState = (fence: FenceState, char: string): void => {
+  if (char === '\n') {
+    // Line completed: apply it to the fence state, then reset per-line tracking.
+    if (fence.lineFenceLen >= 3) {
+      if (!fence.inFenced) {
+        fence.inFenced = true;
+        fence.fenceChar = fence.lineFenceChar;
+        fence.fenceLen = fence.lineFenceLen;
+      } else if (
+        fence.lineFenceChar === fence.fenceChar &&
+        fence.lineFenceLen >= fence.fenceLen &&
+        fence.lineTailBlank
+      ) {
+        // A closing fence only takes effect once its line is completed by a
+        // newline; while it is still the last partial line the fence stays
+        // open for potential streaming continuation.
+        fence.inFenced = false;
+        fence.fenceChar = '';
+        fence.fenceLen = 0;
       }
     }
+    fence.lineFenceChar = '';
+    fence.lineFenceLen = 0;
+    fence.lineFenceRunEnded = false;
+    fence.lineTailBlank = true;
+    return;
   }
 
-  return inFenced;
+  if (!fence.lineFenceRunEnded) {
+    if (fence.lineFenceLen === 0 && (char === '`' || char === '~')) {
+      fence.lineFenceChar = char;
+      fence.lineFenceLen = 1;
+    } else if (fence.lineFenceLen > 0 && char === fence.lineFenceChar) {
+      fence.lineFenceLen += 1;
+    } else {
+      fence.lineFenceRunEnded = true;
+      fence.lineTailBlank = fence.lineTailBlank && /\s/.test(char);
+    }
+  } else {
+    fence.lineTailBlank = fence.lineTailBlank && /\s/.test(char);
+  }
 };
+
+// An opening fence takes effect as soon as it appears, even on the partial last line.
+const isInCodeBlock = (fence: FenceState): boolean => fence.inFenced || fence.lineFenceLen >= 3;
 
 const sanitizeForURIComponent = (input: string): string => {
   let result = '';
@@ -301,8 +336,8 @@ const useStreaming = (
       cache.processedLength += chunk.length;
       for (const char of chunk) {
         cache.pending += char;
-        const isContentInCodeBlock = isInCodeBlock(cache.completeMarkdown + cache.pending);
-        if (isContentInCodeBlock) {
+        feedFenceState(cache.fence, char);
+        if (isInCodeBlock(cache.fence)) {
           commitCache(cache);
           continue;
         }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

User report: streaming a message containing a large base64 image data URI with the latest `@ant-design/x-markdown` pins the CPU at 100% and freezes the page.

### 💡 Background and Solution

**Root cause** (confirmed from a Chrome Performance trace of the affected app): `useStreaming` calls `isInCodeBlock(cache.completeMarkdown + cache.pending)` for **every streamed character**:

```tsx
for (const char of chunk) {
  cache.pending += char;
  const isContentInCodeBlock = isInCodeBlock(cache.completeMarkdown + cache.pending);
  // ...
}
```

`isInCodeBlock` concatenates the entire accumulated markdown, `split('\n')`s it and runs the fence regex on every line — O(N) work per character, O(N²) per stream. In the trace, `isInCodeBlock` alone accounted for **19.33s** of CPU self time.

A base64 image is the worst case: a single ~600KB data URI is 600K characters on one line, which reproduces a **~19s** main-thread stall. It is not limited to base64 either — ~300KB of ordinary multi-line text takes just as long.

**Fix:** replace the per-character full-text rescan with an incremental fence state machine stored in `StreamCache` and fed one character at a time in O(1) (`feedFenceState`). The exact streaming semantics of the old scanner are preserved:

- an *opening* fence takes effect immediately, even while it is still the partial last line;
- a *closing* fence only takes effect once its line is completed by a newline (kept open for potential streaming continuation);
- closing requires the same fence char, at least the opening run length, and a whitespace-only tail; `\r\n` handled as before.

**Verification:**

- Differential fuzzing: 88,857 random stream prefixes (backtick/tilde fences, CRLF, emoji, mixed markers) compared old vs. new logic char-by-char — zero mismatches.
- Full `x-markdown` suite passes: 331 tests, 28 snapshots; `tsc --noEmit` clean. Rendered output is byte-identical, so this is a pure performance patch — no API or behavior change.
- Benchmark (600KB single-line content, the reported scenario): **19,188ms → 4.8ms**.
- Added a 300KB streaming performance regression test (fails at ~6.3s before the fix, passes well under the 3s budget after) plus a fence-correctness test for code blocks following long content.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `XMarkdown` streaming freezing the page (100% CPU) on long content such as base64 image data URIs, by replacing the per-character O(N²) code-block scan in `useStreaming` with an O(1) incremental fence state machine. |
| 🇨🇳 Chinese | 修复 `XMarkdown` 流式渲染长内容（如 base64 图片 data URI）时 CPU 100%、页面假死的问题：将 `useStreaming` 中每字符 O(N²) 的代码块全文扫描替换为 O(1) 增量围栏状态机。 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 提升长文本流式渲染性能，避免处理超长单行内容时出现明显卡顿或冻结。
  * 优化超长 Base64 图片内容的增量渲染，确保最终显示内容完整准确。

* **Bug 修复**
  * 修复长内容后紧跟代码围栏时，代码块状态可能被错误识别的问题。
  * 确保流式渲染过程中代码块内容保持完整，不受增量处理影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->