### PR TITLE
fix(x-markdown): support animation inside custom components

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/Renderer.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Renderer.test.ts
@@ -2,6 +2,7 @@ import DOMPurify from 'dompurify';
 import React from 'react';
 import Renderer from '../core/Renderer';
 
+import AnimationText from '../AnimationText';
 // Mock React components for testing
 const MockComponent: React.FC<any> = (props) => {
   return React.createElement('div', props);
@@ -1513,6 +1514,154 @@ describe('Renderer', () => {
 
       // Verify that createElement was called (meaning the renderer processed the HTML)
       expect(createElementSpy).toHaveBeenCalled();
+
+      createElementSpy.mockRestore();
+    });
+  });
+
+  describe('animateInsideComponents', () => {
+    it('should skip AnimationText inside custom components by default', () => {
+      const CustomComponent: React.FC<any> = (props) => React.createElement('div', props);
+
+      const renderer = new Renderer({
+        components: { 'custom-wrapper': CustomComponent },
+        streaming: {
+          enableAnimation: true,
+          animationConfig: { fadeDuration: 100, easing: 'ease-in' },
+        },
+      });
+
+      const createElementSpy = jest.spyOn(React, 'createElement');
+
+      const html = '<custom-wrapper>text inside custom</custom-wrapper>';
+      renderer.processHtml(html);
+
+      // AnimationText should NOT be called for text inside custom components
+      const animationCalls = createElementSpy.mock.calls.filter(
+        (call) => call[0] === AnimationText,
+      );
+      expect(animationCalls).toHaveLength(0);
+
+      createElementSpy.mockRestore();
+    });
+
+    it('should use AnimationText inside custom components when animateInsideComponents is true', () => {
+      const CustomComponent: React.FC<any> = (props) => React.createElement('div', props);
+
+      const renderer = new Renderer({
+        components: { 'custom-wrapper': CustomComponent },
+        streaming: {
+          enableAnimation: true,
+          animationConfig: { fadeDuration: 100, easing: 'ease-in' },
+          animateInsideComponents: true,
+        },
+      });
+
+      const createElementSpy = jest.spyOn(React, 'createElement');
+
+      const html = '<custom-wrapper>text inside custom</custom-wrapper>';
+      renderer.processHtml(html);
+
+      // AnimationText SHOULD be called for text inside custom components
+      const animationCalls = createElementSpy.mock.calls.filter(
+        (call) => call[0] === AnimationText,
+      );
+      expect(animationCalls).toHaveLength(1);
+      expect(animationCalls[0][1]).toEqual(
+        expect.objectContaining({
+          text: 'text inside custom',
+        }),
+      );
+
+      createElementSpy.mockRestore();
+    });
+
+    it('should not affect text nodes outside custom components', () => {
+      const CustomComponent: React.FC<any> = (props) => React.createElement('div', props);
+
+      const renderer = new Renderer({
+        components: { 'custom-wrapper': CustomComponent },
+        streaming: {
+          enableAnimation: true,
+          animationConfig: { fadeDuration: 100, easing: 'ease-in' },
+          animateInsideComponents: true,
+        },
+      });
+
+      const createElementSpy = jest.spyOn(React, 'createElement');
+
+      // Text both inside and outside custom components
+      const html = '<p>outer text</p><custom-wrapper>inner text</custom-wrapper>';
+      renderer.processHtml(html);
+
+      const animationCalls = createElementSpy.mock.calls.filter(
+        (call) => call[0] === AnimationText,
+      );
+
+      // Both text nodes should be wrapped with AnimationText
+      expect(animationCalls).toHaveLength(2);
+      expect(animationCalls[0][1]).toEqual(
+        expect.objectContaining({ text: 'outer text' }),
+      );
+      expect(animationCalls[1][1]).toEqual(
+        expect.objectContaining({ text: 'inner text' }),
+      );
+
+      createElementSpy.mockRestore();
+    });
+
+    it('should work with nested custom components', () => {
+      const OuterComponent: React.FC<any> = (props) => React.createElement('div', props);
+      const InnerComponent: React.FC<any> = (props) => React.createElement('span', props);
+
+      const renderer = new Renderer({
+        components: {
+          'outer-comp': OuterComponent,
+          'inner-comp': InnerComponent,
+        },
+        streaming: {
+          enableAnimation: true,
+          animationConfig: { fadeDuration: 100, easing: 'ease-in' },
+          animateInsideComponents: true,
+        },
+      });
+
+      const createElementSpy = jest.spyOn(React, 'createElement');
+
+      const html = '<outer-comp><inner-comp>nested text</inner-comp></outer-comp>';
+      renderer.processHtml(html);
+
+      const animationCalls = createElementSpy.mock.calls.filter(
+        (call) => call[0] === AnimationText,
+      );
+      expect(animationCalls).toHaveLength(1);
+      expect(animationCalls[0][1]).toEqual(
+        expect.objectContaining({ text: 'nested text' }),
+      );
+
+      createElementSpy.mockRestore();
+    });
+
+    it('should not enable animation when enableAnimation is false even with animateInsideComponents', () => {
+      const CustomComponent: React.FC<any> = (props) => React.createElement('div', props);
+
+      const renderer = new Renderer({
+        components: { 'custom-wrapper': CustomComponent },
+        streaming: {
+          enableAnimation: false,
+          animateInsideComponents: true,
+        },
+      });
+
+      const createElementSpy = jest.spyOn(React, 'createElement');
+
+      const html = '<custom-wrapper>text inside custom</custom-wrapper>';
+      renderer.processHtml(html);
+
+      const animationCalls = createElementSpy.mock.calls.filter(
+        (call) => call[0] === AnimationText,
+      );
+      expect(animationCalls).toHaveLength(0);
 
       createElementSpy.mockRestore();
     });

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -179,10 +179,15 @@ class Renderer {
       // Check if it's a text node with data
       const isValidTextNode =
         domNode.type === 'text' && domNode.data && Renderer.NON_WHITESPACE_REGEX.test(domNode.data);
-      // Skip animation for text nodes inside custom components to preserve their internal structure
-      const parentTagName = (domNode.parent as Element)?.name;
-      const isParentCustomComponent = parentTagName && this.options.components?.[parentTagName];
-      const shouldReplaceText = enableAnimation && isValidTextNode && (!isParentCustomComponent || animateInsideComponents);
+
+      let shouldReplaceText = false;
+      if (enableAnimation && isValidTextNode) {
+        const parentTagName = (domNode.parent as Element)?.name;
+        const isParentCustomComponent =
+          parentTagName &&
+          Object.prototype.hasOwnProperty.call(this.options.components || {}, parentTagName);
+        shouldReplaceText = !isParentCustomComponent || !!animateInsideComponents;
+      }
       if (shouldReplaceText) {
         return React.createElement(AnimationText, { text: domNode.data, key, animationConfig });
       }

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -172,7 +172,7 @@ class Renderer {
     unclosedTags: Set<string> | undefined,
     cidRef: { current: number; tagIndexes: Record<string, number> },
   ) {
-    const { enableAnimation, animationConfig } = this.options.streaming || {};
+    const { enableAnimation, animationConfig, animateInsideComponents } = this.options.streaming || {};
     return (domNode: DOMNode) => {
       const key = `x-markdown-component-${cidRef.current++}`;
 
@@ -182,7 +182,7 @@ class Renderer {
       // Skip animation for text nodes inside custom components to preserve their internal structure
       const parentTagName = (domNode.parent as Element)?.name;
       const isParentCustomComponent = parentTagName && this.options.components?.[parentTagName];
-      const shouldReplaceText = enableAnimation && isValidTextNode && !isParentCustomComponent;
+      const shouldReplaceText = enableAnimation && isValidTextNode && (!isParentCustomComponent || animateInsideComponents);
       if (shouldReplaceText) {
         return React.createElement(AnimationText, { text: domNode.data, key, animationConfig });
       }

--- a/packages/x-markdown/src/XMarkdown/interface.ts
+++ b/packages/x-markdown/src/XMarkdown/interface.ts
@@ -80,6 +80,12 @@ interface StreamingOption {
       string
     >
   >;
+  /**
+   * @description 是否在自定义组件内部也启用文字淡入动画
+   * @description Whether to enable text fade-in animation inside custom components
+   * @default false
+   */
+  animateInsideComponents?: boolean;
 }
 
 type StreamStatus = 'loading' | 'done';


### PR DESCRIPTION
Close #1950
 
## 问题
XMarkdown 的 `streaming.enableAnimation` 开启后，当文字节点的父节点是自定义组件（通过 `components` 属性传入）时，动画会被跳过，文字不出现淡入效果。
 


修改内容
interface.ts：在 StreamingOption 中新增 animateInsideComponents?: boolean 开关，默认 false（向后兼容）
Renderer.ts：修改 shouldReplaceText 判断条件为 (!isParentCustomComponent || animateInsideComponents)
Renderer.test.ts：新增 5 个单测
使用方式

<XMarkdown
  content={content}
  streaming={{
    enableAnimation: true,
    animateInsideComponents: true,
    animationConfig: { fadeDuration: 600, easing: 'ease-in-out' },
  }}
  components={{
    p: ({ children, ...rest }) => <p {...rest}>{children}</p>,
  }}
/>
根因在 `Renderer.ts` 中：
```ts
const shouldReplaceText = enableAnimation && isValidTextNode && !isParentCustomComponent;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增流式渲染配置 `animateInsideComponents`，可控制自定义组件内部文本是否启用淡入动画。
  * 当开启 `enableAnimation` 时，自定义组件内外文本可按配置分别触发动画。
* **Bug Fixes**
  * 修正自定义组件内部文本的动画触发逻辑：未启用 `animateInsideComponents` 时不动画。
* **测试**
  * 增加对组件内外与嵌套场景下动画触发与调用次数的覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->