### PR TITLE
fix(x-skill): load ora with dynamic import

### DIFF
--- a/packages/x-skill/src/index.ts
+++ b/packages/x-skill/src/index.ts
@@ -10,15 +10,16 @@ import HelpManager from './help';
 import { emojis, getMessage, Language, LocaleMessages, messages } from './locale/index';
 
 type Ora = typeof import('ora').default;
+type OraSpinner = ReturnType<Ora>;
+
+let oraPromise: Promise<Ora> | undefined;
 
 async function loadOra(): Promise<Ora> {
-  // Keep native dynamic import in the CJS build because ora is ESM-only.
-  const loader = new Function('specifier', 'return import(specifier)') as (
-    specifier: string,
-  ) => Promise<typeof import('ora')>;
+  oraPromise ??= (
+    new Function('return import("ora")') as () => Promise<typeof import('ora')>
+  )().then(({ default: ora }) => ora);
 
-  const { default: ora } = await loader('ora');
-  return ora;
+  return oraPromise;
 }
 
 interface SkillConfig {
@@ -201,9 +202,11 @@ class SkillInstaller {
   }
 
   async listVersions(): Promise<void> {
+    let spinner: OraSpinner | undefined;
+
     try {
       const ora = await loadOra();
-      const spinner = ora(
+      spinner = ora(
         this.helpManager.colorize(getMessage('fetchingVersions', this.language), 'cyan'),
       ).start();
       const versions = await this.skillLoader.listVersions();
@@ -224,6 +227,7 @@ class SkillInstaller {
         console.log(`  ${this.helpManager.colorize(version, 'yellow')}${marker}`);
       });
     } catch (error) {
+      spinner?.stop();
       console.error(
         `${this.helpManager.colorize(getMessage('error', this.language), 'red')} ${(error as Error).message}`,
       );

--- a/packages/x-skill/src/index.ts
+++ b/packages/x-skill/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import fs from 'fs';
-import ora from 'ora';
 import os from 'os';
 import path from 'path';
 import ProgressBar from 'progress';
@@ -9,6 +8,18 @@ import readline from 'readline';
 import SkillLoader from './getSkillRepo';
 import HelpManager from './help';
 import { emojis, getMessage, Language, LocaleMessages, messages } from './locale/index';
+
+type Ora = typeof import('ora').default;
+
+async function loadOra(): Promise<Ora> {
+  // Keep native dynamic import in the CJS build because ora is ESM-only.
+  const loader = new Function('specifier', 'return import(specifier)') as (
+    specifier: string,
+  ) => Promise<typeof import('ora')>;
+
+  const { default: ora } = await loader('ora');
+  return ora;
+}
 
 interface SkillConfig {
   targets: {
@@ -191,6 +202,7 @@ class SkillInstaller {
 
   async listVersions(): Promise<void> {
     try {
+      const ora = await loadOra();
       const spinner = ora(
         this.helpManager.colorize(getMessage('fetchingVersions', this.language), 'cyan'),
       ).start();


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

Fixes #1971

### 💡 Background and Solution

`@ant-design/x-skill` builds a CommonJS CLI entry, but `ora@9` is ESM-only. The current top-level static import is transformed into `require('ora')` in the CJS output, causing `ERR_REQUIRE_ESM` when running the CLI.

This PR removes the top-level `ora` import and loads it only when needed through native dynamic import, so the CJS CLI can start normally and the spinner path can still use `ora`.

Verified with:

- `npm run tsc --workspace packages/x-skill`
- `npm run lint --workspace packages/x-skill`
- `npm run compile --workspace packages/x-skill`
- `node packages\x-skill\bin\index.js --help`
- `node packages\x-skill\bin\index.js --list-versions`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix x-skill CLI startup failure caused by loading ESM-only ora from CommonJS output. |
| 🇨🇳 Chinese | 修复 x-skill CLI 在 CommonJS 产物中加载 ESM-only ora 导致的启动失败问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复在部分环境中无法加载版本列表的问题。
  * 改进版本列表加载时的加载指示行为：即使失败也会正确停止加载提示。
  * 提升与现代模块格式的兼容性，确保依赖加载与界面反馈一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->