### PR TITLE
fix(Sender): apply formatResult to content slots

### DIFF
--- a/packages/x/components/sender/__tests__/slot.test.tsx
+++ b/packages/x/components/sender/__tests__/slot.test.tsx
@@ -29,6 +29,13 @@ const contentSlotConfigWithValue: SlotConfigType = {
   props: { defaultValue: 'Content Value', placeholder: 'Enter content 2' },
 };
 
+const contentSlotConfigWithFormatResult: SlotConfigType = {
+  type: 'content',
+  key: 'content-format',
+  props: { defaultValue: 'Content Value', placeholder: 'Enter content' },
+  formatResult: (value: any) => `<${value}>`,
+};
+
 const selectSlotConfig: SlotConfigType = {
   type: 'select',
   key: 'select1',
@@ -280,6 +287,14 @@ describe('Sender Slot Component', () => {
     expect(clearedValue?.value).toBe('');
     expect(clearedValue?.slotConfig).toEqual([]);
     expect(clearedValue?.skill).toBe(undefined);
+  });
+  it('should apply formatResult for content slot value', () => {
+    const ref = createRef<SenderRef>();
+    render(<Sender slotConfig={[contentSlotConfigWithFormatResult]} ref={ref} />);
+
+    const fullValue = ref.current?.getValue();
+    expect(fullValue?.value).toBe('<Content Value>');
+    expect(fullValue?.slotConfig[0].value).toBe('<Content Value>');
   });
   describe('ref insert can be used', () => {
     it('should insert slots default selection range', () => {

--- a/packages/x/components/sender/demo/slot-filling.tsx
+++ b/packages/x/components/sender/demo/slot-filling.tsx
@@ -10,6 +10,7 @@ const otherSlotConfig: SlotConfig = [
     type: 'content',
     key: 'location',
     props: { defaultValue: 'Beijing', placeholder: '[Please enter the location]' },
+    formatResult: (value: any) => `destination ${value} `,
   },
   { type: 'text', value: 'by' },
   {

--- a/packages/x/components/sender/index.en-US.md
+++ b/packages/x/components/sender/index.en-US.md
@@ -121,7 +121,7 @@ type ActionsComponents = {
 | --- | --- | --- | --- | --- |
 | type | Node type, determines the rendering component type, required | 'text' \| 'input' \| 'select' \| 'tag' \| 'content' \| 'custom' | - | 2.0.0 |
 | key | Unique identifier, can be omitted when type is text | string | - | - |
-| formatResult | Format the final result, applies to all slot types (including `content`) | (value: any) => string | - | 2.0.0 |
+| formatResult | Format the final result. Applies to all slot types; for `content` slots, it receives the edited text content. | (value: any) => string | - | 2.0.0 |
 
 ##### text node properties
 

--- a/packages/x/components/sender/index.zh-CN.md
+++ b/packages/x/components/sender/index.zh-CN.md
@@ -123,7 +123,7 @@ type ActionsComponents = {
 | --- | --- | --- | --- | --- |
 | type | 节点类型，决定渲染组件类型，必填 | 'text' \| 'input' \| 'select' \| 'tag' \| 'content' \| 'custom' | - | 2.0.0 |
 | key | 唯一标识，type 为 text 时可省略 | string | - | - |
-| formatResult | 格式化最终结果，对所有词槽类型（含 `content`）生效 | (value: any) => string | - | 2.0.0 |
+| formatResult | 格式化最终结果，对所有词槽类型生效；用于 `content` 词槽时，接收编辑后的文本内容。 | (value: any) => string | - | 2.0.0 |
 
 ##### text 节点属性
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #1956

### 💡 Background and Solution

Sender slot mode already supports `formatResult`, but content slots returned editable DOM text directly when collecting the final value, so `formatResult` was skipped for content slots.

This change applies `formatResult` to content slot text when generating `getValue().value` and the returned slot config value.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Sender content slots now respect `formatResult` when producing the final value. |
| 🇨🇳 Chinese | Sender 的 content 类型词槽在生成最终内容时支持 `formatResult`。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - `content` 词槽支持通过 `formatResult` 处理编辑后的文本，并返回格式化结果。
  - 格式化后的内容会同步反映在发送值和词槽值中。
- **文档**
  - 更新中英文说明，明确 `formatResult` 在 `content` 词槽中的使用方式。
- **示例**
  - 补充内容词槽格式化结果的示例配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->