### PR TITLE
feat(think, thought-chain): support destroyOnHidden

### DIFF
--- a/packages/x/components/think/Think.tsx
+++ b/packages/x/components/think/Think.tsx
@@ -41,6 +41,12 @@ export interface ThinkProps extends Omit<React.HTMLAttributes<HTMLDivElement>, '
   expanded?: boolean;
   onExpand?: (expand: boolean) => void;
   blink?: boolean;
+  /**
+   * @desc 隐藏时是否销毁内容节点
+   * @descEN Whether to destroy content node when hidden
+   * @default true
+   */
+  destroyOnHidden?: boolean;
 }
 
 type ThinkRef = {
@@ -63,6 +69,7 @@ const Think = React.forwardRef<ThinkRef, ThinkProps>((props, ref) => {
     expanded,
     onExpand,
     blink,
+    destroyOnHidden = true,
     ...restProps
   } = props;
 
@@ -147,7 +154,7 @@ const Think = React.forwardRef<ThinkRef, ThinkProps>((props, ref) => {
         </div>
         <RightOutlined className={`${prefixCls}-status-down-icon`} rotate={isExpand ? 90 : 0} />
       </div>
-      <CSSMotion {...collapseMotion} visible={isExpand}>
+      <CSSMotion {...collapseMotion} visible={isExpand} removeOnLeave={destroyOnHidden}>
         {({ className: motionClassName, style }, motionRef) => (
           <div className={motionClassName || ''} ref={motionRef} style={style}>
             <div

--- a/packages/x/components/think/__tests__/index.test.tsx
+++ b/packages/x/components/think/__tests__/index.test.tsx
@@ -91,4 +91,34 @@ describe('Think Component', () => {
     expect(ref.current).not.toBeNull();
     // 如有公开方法可补充断言
   });
+
+  it('Think should remove content from DOM when destroyOnHidden is true and collapsed', async () => {
+    const { container } = render(
+      <Think title="test" destroyOnHidden defaultExpanded={false}>
+        content
+      </Think>,
+    );
+    // collapsed by default, content should not be in DOM
+    expect(container.querySelector('.ant-think-content')).toBeNull();
+    // expand
+    fireEvent.click(container.querySelector('.ant-think-status-wrapper')!);
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-think-content')).toBeTruthy();
+  });
+
+  it('Think should keep content in DOM when destroyOnHidden is false and collapsed', async () => {
+    const { container } = render(
+      <Think title="test" destroyOnHidden={false} defaultExpanded={true}>
+        content
+      </Think>,
+    );
+    // expanded by default
+    expect(container.querySelector('.ant-think-content')).toBeTruthy();
+    // collapse
+    fireEvent.click(container.querySelector('.ant-think-status-wrapper')!);
+    await waitFakeTimer();
+    // content should still be in DOM with leavedClassName
+    expect(container.querySelector('.ant-think-content')).toBeTruthy();
+    expect(container.querySelector('.ant-think-content-hidden')).toBeTruthy();
+  });
 });

--- a/packages/x/components/think/demo/destroyOnHidden.md
+++ b/packages/x/components/think/demo/destroyOnHidden.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+折叠时是否销毁内容节点。
+
+## en-US
+
+Whether to destroy content node when collapsed.

--- a/packages/x/components/think/demo/destroyOnHidden.tsx
+++ b/packages/x/components/think/demo/destroyOnHidden.tsx
@@ -1,0 +1,32 @@
+import { Think } from '@ant-design/x';
+import { Button, Space, Switch } from 'antd';
+import React, { useState } from 'react';
+
+const App: React.FC = () => {
+  const [expanded, setExpanded] = useState(true);
+  const [destroyOnHidden, setDestroyOnHidden] = useState(true);
+
+  return (
+    <Space direction="vertical" size={16}>
+      <Space>
+        <Button onClick={() => setExpanded(!expanded)}>{expanded ? 'Collapse' : 'Expand'}</Button>
+        <Switch
+          checked={destroyOnHidden}
+          onChange={setDestroyOnHidden}
+          checkedChildren="destroyOnHidden"
+          unCheckedChildren="keep"
+        />
+      </Space>
+      <Think
+        title="Deep Thinking"
+        expanded={expanded}
+        onExpand={setExpanded}
+        destroyOnHidden={destroyOnHidden}
+      >
+        This content will be removed from DOM when collapsed and destroyOnHidden is true.
+      </Think>
+    </Space>
+  );
+};
+
+export default App;

--- a/packages/x/components/think/index.en-US.md
+++ b/packages/x/components/think/index.en-US.md
@@ -20,6 +20,7 @@ Used to show deep thinking process.
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/status.tsx">Status</code>
 <code src="./demo/expand.tsx">Expand</code>
+<code src="./demo/destroyOnHidden.tsx">Destroy On Hidden</code>
 
 ## API
 
@@ -39,6 +40,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | expanded | Expand state | boolean | - | - |
 | onExpand | Callback when expand changes | (expand: boolean) => void | - | - |
 | blink | Blink mode | boolean | - | - |
+| destroyOnHidden | Whether to destroy content node when hidden | boolean | true | - |
 
 ## Semantic DOM
 

--- a/packages/x/components/think/index.zh-CN.md
+++ b/packages/x/components/think/index.zh-CN.md
@@ -21,6 +21,7 @@ tag: 2.0.0
 <code src="./demo/basic.tsx">基础用法</code>
 <code src="./demo/status.tsx">设置状态</code>
 <code src="./demo/expand.tsx">是否展开</code>
+<code src="./demo/destroyOnHidden.tsx">折叠时销毁内容</code>
 
 ## API
 
@@ -40,6 +41,7 @@ tag: 2.0.0
 | expanded | 是否展开 | boolean | - | - |
 | onExpand | 展开事件 | (expand: boolean) => void | - | - |
 | blink | 闪动模式 | boolean | - | - |
+| destroyOnHidden | 隐藏时是否销毁内容节点 | boolean | true | - |
 
 ## Semantic DOM
 

--- a/packages/x/components/thought-chain/Node.tsx
+++ b/packages/x/components/thought-chain/Node.tsx
@@ -46,7 +46,18 @@ const ThoughtChainNode: React.FC<ThoughtChainNodeProps> = (props) => {
 
   const { direction } = useXProviderContext();
 
-  const { collapsible, key = id, icon, blink, title, content, footer, status, description } = info;
+  const {
+    collapsible,
+    key = id,
+    icon,
+    blink,
+    title,
+    content,
+    footer,
+    status,
+    description,
+    destroyOnHidden = true,
+  } = info;
 
   // ============================ Style ============================
   const nodeCls = `${prefixCls}-node`;
@@ -101,7 +112,11 @@ const ThoughtChainNode: React.FC<ThoughtChainNodeProps> = (props) => {
         </div>
         {/* Content */}
         {content && (
-          <CSSMotion {...collapseMotion} visible={collapsible ? contentOpen : true}>
+          <CSSMotion
+            {...collapseMotion}
+            visible={collapsible ? contentOpen : true}
+            removeOnLeave={destroyOnHidden}
+          >
             {({ className: motionClassName, style }, motionRef) => (
               <div
                 className={clsx(`${nodeCls}-content`, motionClassName)}

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -235,4 +235,63 @@ describe('ThoughtChain Component', () => {
     const contentEl = container.querySelector('.ant-thought-chain-node-content');
     expect(contentEl).toBeFalsy();
   });
+
+  it('should remove content from DOM when destroyOnHidden is true and collapsed', () => {
+    const { container } = render(
+      <ThoughtChain
+        items={[
+          {
+            key: 'destroy-test',
+            title: 'Collapsible',
+            content: 'Destroyable content',
+            collapsible: true,
+            destroyOnHidden: true,
+          },
+        ]}
+        expandedKeys={[]}
+      />,
+    );
+
+    // Collapsed with destroyOnHidden=true, content node should not exist
+    expect(container.querySelector('.ant-thought-chain-node-content')).toBeFalsy();
+  });
+
+  it('should keep content in DOM when destroyOnHidden is false and collapsed', () => {
+    const { container, rerender } = render(
+      <ThoughtChain
+        items={[
+          {
+            key: 'keep-test',
+            title: 'Collapsible',
+            content: 'Kept content',
+            collapsible: true,
+            destroyOnHidden: false,
+          },
+        ]}
+        expandedKeys={['keep-test']}
+      />,
+    );
+
+    // Expanded, content should exist
+    expect(container.querySelector('.ant-thought-chain-node-content')).toBeTruthy();
+
+    // Collapse
+    rerender(
+      <ThoughtChain
+        items={[
+          {
+            key: 'keep-test',
+            title: 'Collapsible',
+            content: 'Kept content',
+            collapsible: true,
+            destroyOnHidden: false,
+          },
+        ]}
+        expandedKeys={[]}
+      />,
+    );
+
+    // Collapsed with destroyOnHidden=false, content node should still exist
+    expect(container.querySelector('.ant-thought-chain-node-content')).toBeTruthy();
+  });
 });

--- a/packages/x/components/thought-chain/demo/destroyOnHidden.md
+++ b/packages/x/components/thought-chain/demo/destroyOnHidden.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+折叠时是否销毁内容节点。
+
+## en-US
+
+Whether to destroy content node when collapsed.

--- a/packages/x/components/thought-chain/demo/destroyOnHidden.tsx
+++ b/packages/x/components/thought-chain/demo/destroyOnHidden.tsx
@@ -1,0 +1,44 @@
+import type { ThoughtChainProps } from '@ant-design/x';
+import { ThoughtChain } from '@ant-design/x';
+import { Button, Card, Space, Switch } from 'antd';
+import React, { useState } from 'react';
+
+const App: React.FC = () => {
+  const [expandedKeys, setExpandedKeys] = useState<string[]>(['task1']);
+  const [destroyOnHidden, setDestroyOnHidden] = useState(true);
+
+  const items: ThoughtChainProps['items'] = [
+    {
+      key: 'task1',
+      title: 'Collapsible Task',
+      description: 'Content will be removed from DOM when collapsed',
+      collapsible: true,
+      destroyOnHidden,
+      content: 'Task detail content.',
+    },
+    {
+      key: 'task2',
+      title: 'Normal Task',
+      content: 'Task2 content.',
+    },
+  ];
+
+  return (
+    <Card style={{ width: 500 }}>
+      <Space style={{ marginBottom: 16 }}>
+        <Button onClick={() => setExpandedKeys(expandedKeys.includes('task1') ? [] : ['task1'])}>
+          {expandedKeys.includes('task1') ? 'Collapse' : 'Expand'}
+        </Button>
+        <Switch
+          checked={destroyOnHidden}
+          onChange={setDestroyOnHidden}
+          checkedChildren="destroyOnHidden"
+          unCheckedChildren="keep"
+        />
+      </Space>
+      <ThoughtChain items={items} expandedKeys={expandedKeys} onExpand={setExpandedKeys} />
+    </Card>
+  );
+};
+
+export default App;

--- a/packages/x/components/thought-chain/index.en-US.md
+++ b/packages/x/components/thought-chain/index.en-US.md
@@ -23,6 +23,7 @@ tag: 2.0.0
 <code src="./demo/simple.tsx">Simple ThoughtChain</code>
 <code src="./demo/collapsible.tsx" background="grey">Collapsible</code>
 <code src="./demo/controlled-collapsible" background="grey">Controlled Collapsible</code>
+<code src="./demo/destroyOnHidden.tsx" background="grey">Destroy On Hidden</code>
 <code src="./demo/customization.tsx" background="grey">Customization</code>
 <code src="./demo/nested.tsx" background="grey">Nested Usage</code>
 <code src="./demo/single-row.tsx" background="grey">Single Row</code>
@@ -58,6 +59,7 @@ Reference: [Common API](/docs/react/common-props)
 | title | Title of the thought node | React.ReactNode | - | - |
 | collapsible | Whether the thought node is collapsible | boolean | false | - |
 | blink | Blink mode | boolean | - | - |
+| destroyOnHidden | Whether to destroy content node when hidden | boolean | true | - |
 
 ### ThoughtChain.Item
 

--- a/packages/x/components/thought-chain/index.zh-CN.md
+++ b/packages/x/components/thought-chain/index.zh-CN.md
@@ -24,6 +24,7 @@ tag: 2.0.0
 <code src="./demo/simple.tsx">简洁思维链</code>
 <code src="./demo/collapsible.tsx" background="grey">可折叠的</code>
 <code src="./demo/controlled-collapsible" background="grey">受控的折叠</code>
+<code src="./demo/destroyOnHidden.tsx" background="grey">折叠时销毁内容</code>
 <code src="./demo/customization.tsx" background="grey">客制化</code>
 <code src="./demo/nested.tsx" background="grey">嵌套使用</code>
 <code src="./demo/single-row.tsx" background="grey">单行折叠</code>
@@ -59,6 +60,7 @@ tag: 2.0.0
 | title | 思维节点标题 | React.ReactNode | - | - |
 | collapsible | 思维节点是否可折叠 | boolean | false | - |
 | blink | 闪动效果 | boolean | - | - |
+| destroyOnHidden | 隐藏时是否销毁内容节点 | boolean | true | - |
 
 ### ThoughtChain.Item
 

--- a/packages/x/components/thought-chain/interface.ts
+++ b/packages/x/components/thought-chain/interface.ts
@@ -53,6 +53,12 @@ export interface ThoughtChainItemType {
    * @descEN blink
    */
   blink?: boolean;
+  /**
+   * @desc 隐藏时是否销毁内容节点
+   * @descEN Whether to destroy content node when hidden
+   * @default true
+   */
+  destroyOnHidden?: boolean;
 }
 
 export type SemanticType =


### PR DESCRIPTION
## Description

Closes #1954

Add `destroyOnHidden` prop to **Think** and **ThoughtChain** components, allowing users to control whether content DOM nodes are removed from the DOM when the component is collapsed.

## Background

### Current state

After investigating the source code, we found that the original code does not explicitly set `removeOnLeave` on `CSSMotion`. Since `CSSMotion`'s `removeOnLeave` defaults to `true`, content DOM nodes are **already being removed** when collapsed. This means the "DOM not destroyed" behavior described in the issue may have already been resolved in the current version.

This PR is a minor enhancement suggestion: expose `CSSMotion`'s `removeOnLeave` as a user-facing `destroyOnHidden` prop so that users can explicitly opt into either behavior:

- `destroyOnHidden=true` (default): content node is removed from DOM after collapse animation — current behavior, no breaking change
- `destroyOnHidden=false`: content node is kept in DOM with `leavedClassName` for CSS-only hiding — useful for streaming rendering scenarios (#1677) where preserving DOM state is preferred

## Changes

### Think (`packages/x/components/think/`)
- `ThinkProps`: added `destroyOnHidden?: boolean` prop (default: `true`)
- `Think.tsx`: passes `destroyOnHidden` to CSSMotion's `removeOnLeave`

### ThoughtChain (`packages/x/components/thought-chain/`)
- `ThoughtChainItemType`: added `destroyOnHidden?: boolean` prop (default: `true`)
- `Node.tsx`: passes `destroyOnHidden` to CSSMotion's `removeOnLeave`

### Demo
- `think/demo/destroyOnHidden.tsx` — demo with toggle switch
- `thought-chain/demo/destroyOnHidden.tsx` — demo with toggle switch

### Unit Tests
- Think: test that content is removed from DOM when `destroyOnHidden=true`, and kept when `destroyOnHidden=false`
- ThoughtChain: same assertions for collapsible items

### Docs
- Updated `index.zh-CN.md` and `index.en-US.md` for both components

## Checklist
- [x] Demo added
- [x] Unit tests added (assert DOM not present when hidden)
- [x] Documentation updated
- [x] No breaking changes (default value preserves current behavior)