### PR TITLE
site: hide focus outline on Components Overview search input

### DIFF
--- a/packages/x/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/packages/x/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -47,6 +47,10 @@ const useStyle = createStyles(({ token, css }) => ({
     .anticon-search {
       color: ${token.colorTextDisabled};
     }
+    &:focus-visible,
+    &:has(input:focus-visible) {
+      outline: none !important;
+    }
   `,
   componentsOverviewContent: css`
     &:empty:after {


### PR DESCRIPTION
## 背景

antd 在 [ant-design/ant-design#58250](https://github.com/ant-design/ant-design/pull/58250) 中为 `variant="borderless"` 的输入类组件补充了 `focus-visible` outline。组件总览页顶部搜索框采用无边框设计，升级到包含该改动的 antd 版本后会出现与页面设计不一致的蓝色轮廓。

该问题在 antd 站点已通过 [ant-design/ant-design#58483](https://github.com/ant-design/ant-design/pull/58483) 修复，X 站点使用了相同的组件总览实现，因此同步对应覆盖样式。

## 改动

- 在组件总览搜索框自身获得 `focus-visible` 时移除 outline
- 在内部 input 获得 `focus-visible` 时移除外层 outline
- 覆盖范围仅限组件总览页搜索框，不改变组件库公开行为

## 验证

- `git diff --check` 通过
- antd lint 通过，无 deprecated、a11y、usage 或 performance 问题
- 未启动站点或运行项目测试（仅站点样式修改）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 优化组件总览搜索框的键盘聚焦样式，提升焦点状态下的视觉一致性。
  * 抑制默认焦点轮廓，避免出现不协调的聚焦外观。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->