### PR TITLE
doc(sender): render agent tag label inline

### DIFF
--- a/packages/x/components/sender/demo/agent.tsx
+++ b/packages/x/components/sender/demo/agent.tsx
@@ -256,7 +256,7 @@ const App: React.FC = () => {
         key: `${item.key}_${Date.now()}`,
         props: {
           label: (
-            <Flex gap="small">
+            <Flex style={{ display: 'inline-flex' }} gap="small">
               {icon}
               {label}
             </Flex>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！
-->

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

Agent demo 中，标签内容使用 `Flex` 渲染图标和文本。`Flex` 默认使用块级 `display: flex`，会影响标签内容的行内布局。

将该 demo 中的 `Flex` 设置为 `display: inline-flex`，使图标和文本保持行内布局，同时保留 Flex 的间距和对齐能力。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Improve the Agent demo tag label layout by rendering its icon and text with inline flex. |
| 🇨🇳 中文 | 优化 Agent 演示中标签内容的行内布局。 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 优化文件引用标签的布局呈现，提升标签内容在界面中的显示一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->