### PR TITLE
feat(x-markdown): add componentsProps to pass extra props to custom components

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__tests__/index.test.tsx
@@ -176,6 +176,97 @@ describe('XMarkdown', () => {
     expect((container.firstChild as HTMLElement)?.innerHTML).toBe(html);
   });
 
+  describe('componentsProps', () => {
+    it('passes extra props to the matching custom component', () => {
+      let receivedProps: ComponentProps | undefined;
+      const Chart: React.FC<ComponentProps> = (props) => {
+        receivedProps = props;
+        return <span>{String(props.theme)}</span>;
+      };
+      const onSelect = jest.fn();
+      const { container } = render(
+        <XMarkdown
+          content={'<custom-chart data-id="1"></custom-chart>'}
+          components={{ 'custom-chart': Chart }}
+          componentsProps={{ 'custom-chart': { theme: 'dark', onSelect } }}
+        />,
+      );
+
+      expect(container.querySelector('span')?.textContent).toBe('dark');
+      expect(receivedProps?.theme).toBe('dark');
+      expect(receivedProps?.onSelect).toBe(onSelect);
+      expect(receivedProps?.['data-id']).toBe('1');
+      expect(receivedProps?.streamStatus).toBe('done');
+    });
+
+    it('extra props take precedence over parsed HTML attributes', () => {
+      let receivedTitle: unknown;
+      const Widget: React.FC<ComponentProps> = (props) => {
+        receivedTitle = props.title;
+        return <span>widget</span>;
+      };
+      render(
+        <XMarkdown
+          content={'<my-widget title="from-html"></my-widget>'}
+          components={{ 'my-widget': Widget }}
+          componentsProps={{ 'my-widget': { title: 'from-props' } }}
+        />,
+      );
+
+      expect(receivedTitle).toBe('from-props');
+    });
+
+    it('does not leak props into other custom components', () => {
+      let otherProps: ComponentProps | undefined;
+      const Chart: React.FC<ComponentProps> = () => <span>chart</span>;
+      const Other: React.FC<ComponentProps> = (props) => {
+        otherProps = props;
+        return <span>other</span>;
+      };
+      render(
+        <XMarkdown
+          content={'<custom-chart></custom-chart><custom-other></custom-other>'}
+          components={{ 'custom-chart': Chart, 'custom-other': Other }}
+          componentsProps={{ 'custom-chart': { theme: 'dark' } }}
+        />,
+      );
+
+      expect(otherProps?.theme).toBeUndefined();
+    });
+
+    it('keeps the custom component mounted when componentsProps changes', () => {
+      let mountCount = 0;
+      const Widget: React.FC<ComponentProps> = ({ step }) => {
+        React.useEffect(() => {
+          mountCount += 1;
+        }, []);
+        return <span data-step={String(step)}>widget</span>;
+      };
+      const content = 'before <my-widget></my-widget> after';
+      const components = { 'my-widget': Widget };
+      const { container, rerender } = render(
+        <XMarkdown
+          content={content}
+          components={components}
+          componentsProps={{ 'my-widget': { step: 1 } }}
+        />,
+      );
+
+      expect(container.querySelector('[data-step="1"]')).toBeInTheDocument();
+
+      rerender(
+        <XMarkdown
+          content={content}
+          components={components}
+          componentsProps={{ 'my-widget': { step: 2 } }}
+        />,
+      );
+
+      expect(container.querySelector('[data-step="2"]')).toBeInTheDocument();
+      expect(mountCount).toBe(1);
+    });
+  });
+
   it('walkToken', () => {
     const walkTokens = (token: Token) => {
       if (token.type === 'heading') {

--- a/packages/x-markdown/src/XMarkdown/__tests__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__tests__/index.test.tsx
@@ -272,6 +272,25 @@ describe('XMarkdown', () => {
       expect(codeProps?.streamStatus).toBe('done');
     });
 
+    it('does not inherit lang for code without language metadata', () => {
+      const langs: unknown[] = [];
+      const Code: React.FC<ComponentProps> = (props) => {
+        langs.push(props.lang);
+        return <span>code</span>;
+      };
+
+      render(
+        <XMarkdown
+          content={'`inline`\n\n```\nconst a = 1;\n```'}
+          components={{ code: Code }}
+          componentsProps={{ code: { lang: 'spoofed' } }}
+        />,
+      );
+
+      expect(langs.length).toBe(2);
+      expect(langs.every((lang) => lang === undefined)).toBe(true);
+    });
+
     it('merges className from componentsProps with the parsed class attribute', () => {
       let widgetProps: ComponentProps | undefined;
       const Widget: React.FC<ComponentProps> = (props) => {

--- a/packages/x-markdown/src/XMarkdown/__tests__/index.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__tests__/index.test.tsx
@@ -234,6 +234,61 @@ describe('XMarkdown', () => {
       expect(otherProps?.theme).toBeUndefined();
     });
 
+    it('cannot shadow internally computed props', () => {
+      let widgetProps: ComponentProps | undefined;
+      let codeProps: ComponentProps | undefined;
+      const Widget: React.FC<ComponentProps> = (props) => {
+        widgetProps = props;
+        return <span>widget</span>;
+      };
+      const Code: React.FC<ComponentProps> = (props) => {
+        codeProps = props;
+        return <span>code</span>;
+      };
+
+      render(
+        <XMarkdown
+          content={'<my-widget>text</my-widget>'}
+          components={{ 'my-widget': Widget }}
+          streaming={{ hasNextChunk: true }}
+          componentsProps={{
+            'my-widget': { streamStatus: 'spoofed', domNode: 'spoofed', children: 'spoofed' },
+          }}
+        />,
+      );
+      expect(widgetProps?.streamStatus).toBe('done');
+      expect(widgetProps?.domNode).not.toBe('spoofed');
+      expect(widgetProps?.children).not.toBe('spoofed');
+
+      render(
+        <XMarkdown
+          content={'```js\nconst a = 1;\n```'}
+          components={{ code: Code }}
+          componentsProps={{ code: { lang: 'spoofed', block: 'spoofed', streamStatus: 'spoofed' } }}
+        />,
+      );
+      expect(codeProps?.lang).toBe('js');
+      expect(codeProps?.block).toBe(true);
+      expect(codeProps?.streamStatus).toBe('done');
+    });
+
+    it('merges className from componentsProps with the parsed class attribute', () => {
+      let widgetProps: ComponentProps | undefined;
+      const Widget: React.FC<ComponentProps> = (props) => {
+        widgetProps = props;
+        return <span>widget</span>;
+      };
+      render(
+        <XMarkdown
+          content={'<my-widget class="from-html"></my-widget>'}
+          components={{ 'my-widget': Widget }}
+          componentsProps={{ 'my-widget': { className: 'from-props' } }}
+        />,
+      );
+
+      expect(widgetProps?.className).toBe('from-props from-html');
+    });
+
     it('keeps the custom component mounted when componentsProps changes', () => {
       let mountCount = 0;
       const Widget: React.FC<ComponentProps> = ({ step }) => {

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -9,6 +9,7 @@ import { detectUnclosedComponentTags, getTagInstanceId } from './detectUnclosedC
 
 interface RendererOptions {
   components?: XMarkdownProps['components'];
+  componentsProps?: XMarkdownProps['componentsProps'];
   dompurifyConfig?: DOMPurifyConfig;
   streaming?: XMarkdownProps['streaming'];
 }
@@ -199,10 +200,11 @@ class Renderer {
         const props: ComponentProps = {
           domNode,
           streamStatus,
-          key,
           ...attribs,
           ...(attribs.disabled !== undefined && { disabled: true }),
           ...(attribs.checked !== undefined && { checked: true }),
+          ...this.options.componentsProps?.[name],
+          key,
         };
 
         // Handle class and className merging

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -198,12 +198,14 @@ class Renderer {
           ? 'loading'
           : 'done';
         const props: ComponentProps = {
-          domNode,
-          streamStatus,
           ...attribs,
           ...(attribs.disabled !== undefined && { disabled: true }),
           ...(attribs.checked !== undefined && { checked: true }),
           ...this.options.componentsProps?.[name],
+          // Internally computed props are applied last so that neither parsed HTML
+          // attributes nor componentsProps can shadow them.
+          domNode,
+          streamStatus,
           key,
         };
 

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -228,6 +228,10 @@ class Renderer {
           const lang = langFromData || langFromClass;
           if (lang) {
             props.lang = lang;
+          } else {
+            // No language metadata: inline code and unlabeled fences must not inherit a
+            // `lang` from the HTML attributes or componentsProps.
+            delete props.lang;
           }
         }
 

--- a/packages/x-markdown/src/XMarkdown/index.tsx
+++ b/packages/x-markdown/src/XMarkdown/index.tsx
@@ -12,6 +12,7 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
     streaming,
     config,
     components,
+    componentsProps,
     paragraphTag,
     content,
     children,
@@ -91,10 +92,11 @@ const XMarkdown: React.FC<XMarkdownProps> = React.memo((props) => {
     () =>
       new Renderer({
         components: mergedComponents,
+        componentsProps,
         dompurifyConfig,
         streaming,
       }),
-    [mergedComponents, dompurifyConfig, streaming],
+    [mergedComponents, componentsProps, dompurifyConfig, streaming],
   );
 
   const htmlString = useMemo(() => {

--- a/packages/x-markdown/src/XMarkdown/interface.ts
+++ b/packages/x-markdown/src/XMarkdown/interface.ts
@@ -144,6 +144,13 @@ interface XMarkdownProps {
     [tagName: string]: React.ComponentType<ComponentProps> | keyof JSX.IntrinsicElements;
   };
   /**
+   * @description 按标签名向 `components` 中的自定义组件传递额外的 props，使组件引用保持稳定，避免内联函数导致的重复挂载
+   * @description Extra props passed to custom components in `components` by tag name, keeping component references stable and avoiding remounts caused by inline functions
+   */
+  componentsProps?: {
+    [tagName: string]: Record<string, unknown>;
+  };
+  /**
    * @description 流式渲染行为的配置
    * @description Configuration for streaming rendering behavior
    */

--- a/packages/x/docs/x-markdown/components.en-US.md
+++ b/packages/x/docs/x-markdown/components.en-US.md
@@ -31,9 +31,33 @@ import { Mermaid, Think, XMarkdown } from '@ant-design/x';
 | children | Content wrapped in the component, containing the text content of DOM nodes | `React.ReactNode` | - |
 | rest | Component properties, supports all standard HTML attributes (such as `href`, `title`, `className`, etc.) and custom data attributes | `Record<string, any>` | - |
 
+## Passing extra props
+
+Custom components often need business data (theme, callbacks, etc.). Passing it via an inline function creates a new component reference on every render, so React unmounts and remounts the whole subtree — losing internal state and hurting performance in streaming scenarios. Use `componentsProps` to pass extra props while keeping component references stable:
+
+```tsx
+import React from 'react';
+import { XMarkdown } from '@ant-design/x';
+
+// ❌ Inline function: a new component type every render, the subtree is rebuilt
+<XMarkdown
+  components={{
+    'custom-chart': (props) => <CustomChart {...props} theme={theme} onSelect={onSelect} />,
+  }}
+/>;
+
+// ✅ Stable component reference; extra data flows through componentsProps
+<XMarkdown
+  components={{ 'custom-chart': CustomChart }}
+  componentsProps={{ 'custom-chart': { theme, onSelect } }}
+/>;
+```
+
+`componentsProps` is keyed by tag name. Its props are merged with the parsed HTML attributes and passed to the component (`componentsProps` wins on conflicts). When `componentsProps` changes, the component receives a normal props update without being remounted.
+
 ## Best Practices
 
-1. Keep component references stable. Avoid inline function components in `components`.
+1. Keep component references stable. Avoid inline function components in `components`; use `componentsProps` to pass extra data.
 2. Use `streamStatus` to separate loading UI (`loading`) from finalized UI (`done`).
 3. If data depends on complete syntax, fetch or parse after `streamStatus === 'done'`.
 4. Keep custom tags semantically clear and avoid ambiguous mixed Markdown/HTML blocks.

--- a/packages/x/docs/x-markdown/components.en-US.md
+++ b/packages/x/docs/x-markdown/components.en-US.md
@@ -36,7 +36,7 @@ import { Mermaid, Think, XMarkdown } from '@ant-design/x';
 Custom components often need business data (theme, callbacks, etc.). Passing it via an inline function creates a new component reference on every render, so React unmounts and remounts the whole subtree — losing internal state and hurting performance in streaming scenarios. Use `componentsProps` to pass extra props while keeping component references stable:
 
 ```tsx
-import React from 'react';
+import React, { useMemo } from 'react';
 import { XMarkdown } from '@ant-design/x';
 
 // ❌ Inline function: a new component type every render, the subtree is rebuilt
@@ -47,13 +47,19 @@ import { XMarkdown } from '@ant-design/x';
 />;
 
 // ✅ Stable component reference; extra data flows through componentsProps
-<XMarkdown
-  components={{ 'custom-chart': CustomChart }}
-  componentsProps={{ 'custom-chart': { theme, onSelect } }}
-/>;
+const components = { 'custom-chart': CustomChart };
+const componentsProps = useMemo(() => ({ 'custom-chart': { theme, onSelect } }), [theme, onSelect]);
+
+<XMarkdown components={components} componentsProps={componentsProps} />;
 ```
 
-`componentsProps` is keyed by tag name. Its props are merged with the parsed HTML attributes and passed to the component (`componentsProps` wins on conflicts). When `componentsProps` changes, the component receives a normal props update without being remounted.
+`componentsProps` is keyed by tag name. Its props are merged with the parsed HTML attributes and passed to the component:
+
+- On conflict `componentsProps` wins — a `title` in `componentsProps` overrides `title="..."` from the HTML.
+- `className` / `class` is the exception: both sides are concatenated, with the `componentsProps` class name first.
+- Internally computed props — `domNode`, `streamStatus`, `children` (plus `lang` and `block` for `code`) — cannot be overridden and are ignored if present in `componentsProps`.
+
+When `componentsProps` changes, the component receives a normal props update without being remounted. Like `components`, it takes part in the render cache, so **passing an inline object literal invalidates that cache on every render and re-parses the whole tree** — keep the reference stable with `useMemo` as shown above.
 
 ## Best Practices
 

--- a/packages/x/docs/x-markdown/components.zh-CN.md
+++ b/packages/x/docs/x-markdown/components.zh-CN.md
@@ -31,9 +31,33 @@ import { Mermaid, Think, XMarkdown } from '@ant-design/x';
 | children | 包裹在组件中的内容，包含 DOM 节点的文本内容 | `React.ReactNode` | - |
 | rest | 组件属性，支持所有标准 HTML 属性（如 `href`、`title`、`className` 等）和自定义数据属性 | `Record<string, any>` | - |
 
+## 传递额外的 props
+
+自定义组件常常需要接收业务数据（如主题、回调函数等）。如果通过内联函数传递，每次渲染都会产生新的组件引用，导致组件被反复卸载重建，在流式场景下会丢失内部状态并造成明显的性能损耗。使用 `componentsProps` 可以在保持组件引用稳定的同时传入额外的 props：
+
+```tsx
+import React from 'react';
+import { XMarkdown } from '@ant-design/x';
+
+// ❌ 内联函数：每次渲染都是新组件类型，子树整体重建
+<XMarkdown
+  components={{
+    'custom-chart': (props) => <CustomChart {...props} theme={theme} onSelect={onSelect} />,
+  }}
+/>;
+
+// ✅ 组件引用稳定，额外数据通过 componentsProps 传入
+<XMarkdown
+  components={{ 'custom-chart': CustomChart }}
+  componentsProps={{ 'custom-chart': { theme, onSelect } }}
+/>;
+```
+
+`componentsProps` 以标签名为 key，对应的 props 会与解析出的 HTML 属性合并后传给组件（同名时 `componentsProps` 优先）。`componentsProps` 变化时组件只会正常更新 props，不会被重新挂载。
+
 ## 最佳实践
 
-1. 保持组件引用稳定，避免在 `components` 中写内联函数组件。
+1. 保持组件引用稳定，避免在 `components` 中写内联函数组件；需要传递额外数据时使用 `componentsProps`。
 2. 使用 `streamStatus` 区分加载态（`loading`）和完成态（`done`）。
 3. 依赖完整语法的数据解析，尽量在 `streamStatus === 'done'` 后执行。
 4. 自定义标签命名尽量语义化，减少 Markdown 与 HTML 混写歧义。

--- a/packages/x/docs/x-markdown/components.zh-CN.md
+++ b/packages/x/docs/x-markdown/components.zh-CN.md
@@ -36,7 +36,7 @@ import { Mermaid, Think, XMarkdown } from '@ant-design/x';
 自定义组件常常需要接收业务数据（如主题、回调函数等）。如果通过内联函数传递，每次渲染都会产生新的组件引用，导致组件被反复卸载重建，在流式场景下会丢失内部状态并造成明显的性能损耗。使用 `componentsProps` 可以在保持组件引用稳定的同时传入额外的 props：
 
 ```tsx
-import React from 'react';
+import React, { useMemo } from 'react';
 import { XMarkdown } from '@ant-design/x';
 
 // ❌ 内联函数：每次渲染都是新组件类型，子树整体重建
@@ -47,13 +47,19 @@ import { XMarkdown } from '@ant-design/x';
 />;
 
 // ✅ 组件引用稳定，额外数据通过 componentsProps 传入
-<XMarkdown
-  components={{ 'custom-chart': CustomChart }}
-  componentsProps={{ 'custom-chart': { theme, onSelect } }}
-/>;
+const components = { 'custom-chart': CustomChart };
+const componentsProps = useMemo(() => ({ 'custom-chart': { theme, onSelect } }), [theme, onSelect]);
+
+<XMarkdown components={components} componentsProps={componentsProps} />;
 ```
 
-`componentsProps` 以标签名为 key，对应的 props 会与解析出的 HTML 属性合并后传给组件（同名时 `componentsProps` 优先）。`componentsProps` 变化时组件只会正常更新 props，不会被重新挂载。
+`componentsProps` 以标签名为 key，对应的 props 会与解析出的 HTML 属性合并后传给组件。合并规则：
+
+- 同名属性以 `componentsProps` 为准，例如 `componentsProps` 里的 `title` 会覆盖 HTML 上的 `title="..."`。
+- `className` / `class` 是例外，两侧会拼接合并，`componentsProps` 的类名在前。
+- 内部计算的 `domNode`、`streamStatus`、`children`（以及 `code` 组件的 `lang`、`block`）不可覆盖，写进 `componentsProps` 会被忽略。
+
+`componentsProps` 变化时组件只会正常更新 props，不会被重新挂载。但它和 `components` 一样参与渲染缓存，**传内联对象字面量会让缓存每次失效并触发整棵树重新解析**，所以请像上面那样用 `useMemo` 保持引用稳定。
 
 ## 最佳实践
 

--- a/packages/x/docs/x-markdown/examples.en-US.md
+++ b/packages/x/docs/x-markdown/examples.en-US.md
@@ -27,6 +27,7 @@ Use this page to get a minimal setup for rendering LLM Markdown output.
 | content | Markdown content to render | `string` | - |
 | children | Markdown content (use either `content` or `children`) | `string` | - |
 | components | Map HTML nodes to custom React components | `Record<string, React.ComponentType<ComponentProps> \| keyof JSX.IntrinsicElements>` | - |
+| componentsProps | Extra props passed to custom components in `components` by tag name, keeping component references stable and avoiding remounts caused by inline functions | `Record<string, Record<string, unknown>>` | - |
 | streaming | Streaming behavior config | `StreamingOption` | - |
 | config | Marked parse config, applied last and may override built-in renderers | [`MarkedExtension`](https://marked.js.org/using_advanced#options) | `{ gfm: true }` |
 | rootClassName | Extra CSS class for the root element | `string` | - |

--- a/packages/x/docs/x-markdown/examples.zh-CN.md
+++ b/packages/x/docs/x-markdown/examples.zh-CN.md
@@ -27,6 +27,7 @@ packageName: x-markdown
 | content | 需要渲染的 Markdown 内容 | `string` | - |
 | children | Markdown 内容（与 `content` 二选一） | `string` | - |
 | components | 将 HTML 节点映射为自定义 React 组件 | `Record<string, React.ComponentType<ComponentProps> \| keyof JSX.IntrinsicElements>` | - |
+| componentsProps | 按标签名向 `components` 中的自定义组件传递额外 props，保持组件引用稳定，避免内联函数导致的重复挂载 | `Record<string, Record<string, unknown>>` | - |
 | streaming | 流式渲染行为配置 | `StreamingOption` | - |
 | config | Marked 解析配置，后应用且可能覆盖内置 renderer | [`MarkedExtension`](https://marked.js.org/using_advanced#options) | `{ gfm: true }` |
 | rootClassName | 根元素的额外 CSS 类名 | `string` | - |


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/x/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

close #1989

### 💡 Background and Solution

Custom components registered via `components` could only receive extra business data (theme, callbacks, dynamic state, …) through inline wrapper functions:

```tsx
// ❌ New component type on every render → React unmounts/remounts the whole
// subtree, losing internal state and hurting streaming performance
components={{ code: (props) => <CustomCode {...props} {...extraProps} /> }}
```

This PR adds a `componentsProps` option that passes extra props by tag name while keeping component references stable:

```tsx
<XMarkdown
  components={{ 'custom-chart': CustomChart }}
  componentsProps={{ 'custom-chart': { theme, onSelect } }}
/>
```

Design notes:

- The `renderProps` approach suggested in the issue (calling `renderElement(props)` directly instead of `React.createElement`) was intentionally not taken: it would strip custom components of their identity as real React components (hooks would attach to the parent, no reconciliation boundary). `componentsProps` is a purely additive API instead — fully backward compatible.
- Extra props are merged over parsed HTML attributes (`componentsProps` wins on conflicts). This also matters because DOMPurify strips non-standard, non-`data-*` attributes (e.g. `theme`) from raw HTML anyway, so `componentsProps` is the reliable way to pass such data.
- Internally computed fields still win: `children`, and `block` / `streamStatus` / parsed `lang` for `code`, protecting streaming semantics.
- The generated reconciliation key is now always applied last so it can never be clobbered by attributes or extra props.
- When `componentsProps` changes, components receive a normal props update without remounting (covered by a mount-count test).

Only applies to tags registered in `components`; entries for unregistered tags are ignored.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | XMarkdown adds a `componentsProps` option to pass extra props to custom components by tag name, keeping component references stable and avoiding remounts caused by inline functions. |
| 🇨🇳 Chinese | XMarkdown 新增 `componentsProps` 选项，支持按标签名向自定义组件传递额外 props，保持组件引用稳定，避免内联函数导致的重复挂载。 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 `componentsProps` 配置，可按组件标签名向自定义组件传递额外属性。
  * 自定义属性可覆盖同名 HTML 属性，并正确合并 `class`。
  * 内部渲染属性不可被覆盖；更新配置时组件保持挂载。
  * 无语言代码块不会继承额外的语言属性。

* **文档**
  * 补充 `componentsProps` 的使用方式、属性合并规则及最佳实践说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->