### PR TITLE
fix(site): fix token color preview popover

### DIFF
--- a/packages/x/.dumi/theme/builtins/ColorChunk/index.tsx
+++ b/packages/x/.dumi/theme/builtins/ColorChunk/index.tsx
@@ -43,19 +43,19 @@ const ColorChunk: React.FC<React.PropsWithChildren<ColorChunkProps>> = (props) =
   if (enablePopover) {
     dotNode = (
       <Popover
+        destroyOnHidden
         placement="left"
         content={<div hidden />}
         styles={{
-          body: {
+          container: {
             backgroundColor: dotColor,
             width: 120,
             height: 120,
             borderRadius: theme.borderRadiusLG,
           },
           root: {
-            '--antd-arrow-background-color': dotColor,
-            backgroundColor: 'transparent',
-          } as React.CSSProperties,
+            '--ant-tooltip-arrow-background-color': dotColor,
+          },
         }}
       >
         {dotNode}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other

### 🔗 Related Issues

- Reference implementation and visual comparison: ant-design/ant-design#57912

### 💡 Background and Solution

The component token table and global token table share the local ColorChunk builtin to render color default values and their hover previews.

After upgrading to Ant Design 6, ColorChunk still uses the legacy Popover body semantic slot and the deprecated arrow background CSS variable. As a result, the preview container and arrow do not consistently render with the token color when hovering over a color default value.

This change aligns ColorChunk with the current Popover semantic API:

- Replace the legacy body style slot with container.
- Use --ant-tooltip-arrow-background-color for the popup arrow.
- Enable destroyOnHidden so stale preview DOM is removed after closing.

The change only affects the documentation site. It does not change the published component runtime or public API.

Before: the hover preview container or arrow can display an incorrect background color.

After: both the preview container and arrow use the actual token color in theme and global token tables.

### ✅ Verification

- npm run tsc --workspace packages/x
- npm run site --workspace packages/x

Both commands completed successfully.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fixed incorrect color previews when hovering over theme and global token default values. |
| 🇨🇳 Chinese | 修复主题变量和全局变量默认值的颜色悬浮预览显示异常。 |