### PR TITLE
fix(x-markdown): render placeholder for inline construct after list marker

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/streaming-list-inline.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__tests__/streaming-list-inline.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { useStreaming } from '../hooks';
+import type { XMarkdownProps } from '../interface';
+
+// Regression for #1988: an inline construct (link / image / inline code) that
+// starts immediately after a list marker used to be committed as raw markdown,
+// because the list recognizer only handed over to inline code (backticks).
+// GFM task markers ([ ]/[x]/[X]) must still render as list text, not links.
+
+const TestComponent = ({
+  input,
+  config,
+}: {
+  input: string;
+  config?: { streaming: XMarkdownProps['streaming']; components?: XMarkdownProps['components'] };
+}) => <div>{useStreaming(input, config)}</div>;
+
+const withPlaceholders = {
+  streaming: { hasNextChunk: true as const },
+  components: {
+    'incomplete-link': () => null,
+    'incomplete-image': () => null,
+    'incomplete-inline-code': () => null,
+  },
+};
+
+const raw = (s: string) => encodeURIComponent(s);
+
+const expectOutput = (input: string, output: string) => {
+  const { container } = render(<TestComponent input={input} config={withPlaceholders} />);
+  expect(container.textContent).toBe(output);
+};
+
+describe('#1988 inline construct right after a list marker', () => {
+  it('renders a link placeholder for a list item (the reported bug)', () => {
+    expectOutput('- [text](htt', `- <incomplete-link data-raw="${raw('[text](htt')}" />`);
+  });
+
+  it('renders an image placeholder for a list item (no orphaned "!")', () => {
+    expectOutput('- ![alt](htt', `- <incomplete-image data-raw="${raw('![alt](htt')}" />`);
+  });
+
+  it('still hands over to inline code (existing behavior)', () => {
+    expectOutput('- `code', `- <incomplete-inline-code data-raw="${raw('`code')}" />`);
+  });
+
+  describe('GFM task lists must NOT become link placeholders', () => {
+    it('empty task marker', () => expectOutput('- [ ]', '- [ ]'));
+    it('checked task marker', () => expectOutput('- [x]', '- [x]'));
+    it('uppercase checked marker', () => expectOutput('- [X]', '- [X]'));
+    it('task marker with text', () => expectOutput('- [ ] buy milk', '- [ ] buy milk'));
+  });
+
+  describe('no regression', () => {
+    it('plain list item', () => expectOutput('- plain text', '- plain text'));
+    it('bare link (no list) still works', () =>
+      expectOutput('[text](htt', `<incomplete-link data-raw="${raw('[text](htt')}" />`));
+  });
+});

--- a/packages/x-markdown/src/XMarkdown/__tests__/streaming-list-inline.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__tests__/streaming-list-inline.test.tsx
@@ -46,10 +46,37 @@ describe('#1988 inline construct right after a list marker', () => {
   });
 
   describe('GFM task lists must NOT become link placeholders', () => {
-    it('empty task marker', () => expectOutput('- [ ]', '- [ ]'));
-    it('checked task marker', () => expectOutput('- [x]', '- [x]'));
-    it('uppercase checked marker', () => expectOutput('- [X]', '- [X]'));
-    it('task marker with text', () => expectOutput('- [ ] buy milk', '- [ ] buy milk'));
+    // A settled task marker is "[ ]/[x]/[X]" followed by whitespace, so these
+    // commit as plain list text rather than handing over as a link.
+    it('empty task marker with text', () => expectOutput('- [ ] buy milk', '- [ ] buy milk'));
+    it('checked task marker with text', () => expectOutput('- [x] done', '- [x] done'));
+    it('uppercase checked marker with text', () => expectOutput('- [X] done', '- [X] done'));
+    it('task marker followed by a trailing space', () => expectOutput('- [ ] ', '- [ ] '));
+
+    // A bare marker ("- [x]" with nothing after the "]") is ambiguous mid-stream:
+    // it may still become a task item ("- [x] text") or a link ("- [x](url)"), so
+    // it is held pending until the next char decides. This blank is transient and
+    // resolves once streaming completes (hasNextChunk is false -> raw input).
+    it('bare marker is held pending mid-stream', () => expectOutput('- [x]', ''));
+    it('bare marker renders once streaming completes', () => {
+      const done = {
+        streaming: { hasNextChunk: false as const },
+        components: withPlaceholders.components,
+      };
+      const { container } = render(<TestComponent input="- [x]" config={done} />);
+      expect(container.textContent).toBe('- [x]');
+    });
+  });
+
+  describe('#1988 single-char-label links after a marker (CodeRabbit)', () => {
+    // "[x](url)" is a link whose label happens to be "x" — it must NOT be swallowed
+    // by the task-marker rule. Verified for lower/upper/space labels.
+    it('checked-looking label is a link', () =>
+      expectOutput('- [x](htt', `- <incomplete-link data-raw="${raw('[x](htt')}" />`));
+    it('uppercase-looking label is a link', () =>
+      expectOutput('- [X](htt', `- <incomplete-link data-raw="${raw('[X](htt')}" />`));
+    it('space-looking label is a link', () =>
+      expectOutput('- [ ](htt', `- <incomplete-link data-raw="${raw('[ ](htt')}" />`));
   });
 
   describe('no regression', () => {

--- a/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
@@ -111,13 +111,34 @@ const tokenRecognizerMap: Partial<Record<StreamCacheTokenType, Recognizer>> = {
   [StreamCacheTokenType.List]: {
     tokenType: StreamCacheTokenType.List,
     isStartOfToken: (markdown: string) => /^[-+*]/.test(markdown),
-    isStreamingValid: (markdown: string) =>
-      STREAM_INCOMPLETE_REGEX.list.some((re) => re.test(markdown)),
-    // On backtick after list, commit only the prefix; treat the rest as inline code.
+    isStreamingValid: (markdown: string) => {
+      if (STREAM_INCOMPLETE_REGEX.list.some((re) => re.test(markdown))) return true;
+      // Keep the list token pending through an inline construct that starts right
+      // after the marker, so its own recognizer can take over once confirmed.
+      // GFM task markers ([ ]/[x]/[X]) never contain "](" and are committed as text.
+      const rest = markdown.match(/^[-+*]\s{1,3}([\s\S]*)$/)?.[1];
+      if (rest === undefined) return false;
+      if (rest === '!') return true; // may still become an image "!["
+      if (rest.startsWith('![')) return false; // image confirmed -> hand over
+      if (rest.startsWith('[')) {
+        if (/^\[[ xX]\]/.test(rest)) return false; // task marker formed -> commit as text
+        return !/\]\(/.test(rest); // link confirmed once "](" appears -> hand over
+      }
+      return false;
+    },
+    // When the list marker is immediately followed by another inline construct,
+    // commit only the marker prefix and let the rest be re-recognized (handover).
     getCommitPrefix: (pending: string) => {
       const listPrefix = pending.match(/^([-+*]\s{0,3})/)?.[1];
-      const rest = listPrefix ? pending.slice(listPrefix.length) : '';
-      return listPrefix && rest.startsWith('`') ? listPrefix : null;
+      if (!listPrefix) return null;
+      const rest = pending.slice(listPrefix.length);
+      if (rest.startsWith('`')) return listPrefix; // inline code
+      if (rest.startsWith('![')) return listPrefix; // image
+      // link: only once clearly a link ("](" present) and not a GFM task marker
+      if (rest.startsWith('[') && /\]\(/.test(rest) && !/^\[[ xX]\]/.test(rest)) {
+        return listPrefix;
+      }
+      return null;
     },
   },
   [StreamCacheTokenType.Table]: {

--- a/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
@@ -121,21 +121,26 @@ const tokenRecognizerMap: Partial<Record<StreamCacheTokenType, Recognizer>> = {
       if (rest === '!') return true; // may still become an image "!["
       if (rest.startsWith('![')) return false; // image confirmed -> hand over
       if (rest.startsWith('[')) {
-        if (/^\[[ xX]\]/.test(rest)) return false; // task marker formed -> commit as text
-        return !/\]\(/.test(rest); // link confirmed once "](" appears -> hand over
+        // A GFM task marker is "[ ]/[x]/[X]" followed by whitespace; "[x](" is a link
+        // whose label is "x". Decide by what follows "]" — not by end-of-buffer, which
+        // during streaming would settle "[x]" before its "(" arrives.
+        if (/^\[[ xX]\]\s/.test(rest)) return false; // settled task marker -> commit as text
+        if (/\]\(/.test(rest)) return false; // link confirmed ("](" present) -> hand over
+        return true; // still ambiguous ("[", "[x]", "[label") -> keep pending
       }
       return false;
     },
     // When the list marker is immediately followed by another inline construct,
     // commit only the marker prefix and let the rest be re-recognized (handover).
+    // The prefix rule mirrors isStreamingValid (requires GFM's trailing whitespace).
     getCommitPrefix: (pending: string) => {
-      const listPrefix = pending.match(/^([-+*]\s{0,3})/)?.[1];
+      const listPrefix = pending.match(/^([-+*]\s{1,3})/)?.[1];
       if (!listPrefix) return null;
       const rest = pending.slice(listPrefix.length);
       if (rest.startsWith('`')) return listPrefix; // inline code
       if (rest.startsWith('![')) return listPrefix; // image
-      // link: only once clearly a link ("](" present) and not a GFM task marker
-      if (rest.startsWith('[') && /\]\(/.test(rest) && !/^\[[ xX]\]/.test(rest)) {
+      // link: "](" present and not a settled GFM task marker
+      if (rest.startsWith('[') && /\]\(/.test(rest) && !/^\[[ xX]\]\s/.test(rest)) {
         return listPrefix;
       }
       return null;


### PR DESCRIPTION
## What & Why

Fixes #1988.

While streaming, an inline construct that starts **immediately after a list marker** was rendered as raw markdown instead of an incomplete-token placeholder:

| input (mid-stream) | before | after |
| --- | --- | --- |
| `- [text](htt` | `- [text](htt` (raw) | `- <incomplete-link … />` |
| `- ![alt](htt` | `- !` + wrong link placeholder | `- <incomplete-image … />` |

### Root cause

In `useStreaming.ts`, once `- ` is seen the **list recognizer** owns the token and keeps appending to `pending`. Its `getCommitPrefix` only handed the buffer over to the **inline-code** recognizer (backtick). For a link/image the buffer stayed a "list" token, failed `isStreamingValid`, and was committed as plain text — so the placeholder was never produced.

### Fix

Extend the list recognizer only:

- `isStreamingValid` keeps the list token *pending* through the ambiguous window right after the marker, then releases it once the construct is **confirmed** (`](` for a link, `![` for an image).
- `getCommitPrefix` commits just the marker prefix (`- `) and hands the rest to the link/image recognizer.

**GFM task markers** (`- [ ]` / `- [x]` / `- [X]`) never contain `](`, so they keep rendering as list text — verified explicitly in the tests. This is the case a naive "hand over on any `[`" would break.

### Tradeoff (worth a maintainer's eye)

For a link inside a list there is now a brief "blank" window from `- [` until `](` arrives (the label is held, not shown as raw). This mirrors how the library already holds an incomplete emphasis in a list (`- **bold` renders nothing until closed), so it is consistent with existing behavior — but flagging it in case a different UX is preferred.

## Scope

- Ordered lists (`1. [text](`) were **not** affected (they don't go through the list recognizer) and continue to work.
- Other markers (`*`, `+`) and indented list items are covered.

## Testing

New `streaming-list-inline.test.tsx` (9 cases). Verified red→green:

- On unmodified source: the link & image cases **fail** (raw output), the other 7 pass.
- With this fix: **9/9 pass**, and the existing `hooks.test.tsx` suite (**96 cases**) stays green — no regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化流式解析：列表标记后紧跟行内链接、图片或行内代码时，不再错误回退显示为原始 Markdown。
  * 改进链接/图片占位符触发时机，避免出现孤立的 `!` 等异常输出。
  * 提升 GFM 任务列表（`[ ]`/`[x]`/`[X]` 及其变体）识别准确性，避免与链接占位符混淆；流式中途的裸任务标记会暂挂，结束后再正确渲染。
* **测试**
  * 新增针对相关回归场景的流式渲染用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->