### PR TITLE
fix(markdown): avoid parsing currency as LaTeX

### DIFF
--- a/packages/x-markdown/src/plugins/Latex/__tests__/index.test.tsx
+++ b/packages/x-markdown/src/plugins/Latex/__tests__/index.test.tsx
@@ -17,6 +17,43 @@ describe('LaTeX Plugin', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it.each([
+    'Downgrade Max ($100) to Pro ($20)',
+    '把 Max 5x（$100）降级到 Pro（$20）',
+    'The items cost $10, $20, and $30, respectively.',
+  ])('should not interpret currency amounts as LaTeX: %s', (content) => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container } = render(
+      <XMarkdown config={{ extensions: latexPlugin() }}>{`**${content}**`}</XMarkdown>,
+    );
+
+    expect(container.querySelector('.katex')).not.toBeInTheDocument();
+    expect(container.querySelector('strong')).toHaveTextContent(content);
+    expect(warnSpy.mock.calls.flat().join(' ')).not.toContain('unicodeTextInMathMode');
+    warnSpy.mockRestore();
+  });
+
+  it('should still render formulas that start with a number', () => {
+    const { container } = render(
+      <XMarkdown config={{ extensions: latexPlugin() }}>{'$2x + 1$'}</XMarkdown>,
+    );
+
+    expect(container.querySelector('.katex')).toBeInTheDocument();
+  });
+
+  it.each([
+    '$ x$',
+    '$x $',
+    '$x$2',
+  ])('should follow single-dollar delimiter rules: %s', (content) => {
+    const { container } = render(
+      <XMarkdown config={{ extensions: latexPlugin() }}>{content}</XMarkdown>,
+    );
+
+    expect(container.querySelector('.katex')).not.toBeInTheDocument();
+    expect(container).toHaveTextContent(content);
+  });
+
   it('should render inline LaTeX with $$\n..\n$$ syntax', () => {
     const { container } = render(
       <XMarkdown config={{ extensions: latexPlugin() }}>

--- a/packages/x-markdown/src/plugins/Latex/__tests__/index.test.tsx
+++ b/packages/x-markdown/src/plugins/Latex/__tests__/index.test.tsx
@@ -33,6 +33,19 @@ describe('LaTeX Plugin', () => {
     warnSpy.mockRestore();
   });
 
+  // An escaped `\$` inside a formula must not be treated as the closing delimiter.
+  it.each([
+    '$\\text{\\$100}$',
+    '$\\text{\\$x}$',
+  ])('should support escaped dollar signs inside formulas: %s', (content) => {
+    const { container } = render(
+      <XMarkdown config={{ extensions: latexPlugin() }}>{content}</XMarkdown>,
+    );
+
+    expect(container.querySelector('.katex')).toBeInTheDocument();
+    expect(container.querySelector('.katex-error')).not.toBeInTheDocument();
+  });
+
   it('should still render formulas that start with a number', () => {
     const { container } = render(
       <XMarkdown config={{ extensions: latexPlugin() }}>{'$2x + 1$'}</XMarkdown>,

--- a/packages/x-markdown/src/plugins/Latex/__tests__/index.test.tsx
+++ b/packages/x-markdown/src/plugins/Latex/__tests__/index.test.tsx
@@ -41,9 +41,12 @@ describe('LaTeX Plugin', () => {
     expect(container.querySelector('.katex')).toBeInTheDocument();
   });
 
+  // Behavior change: `$ x $` used to render as math and no longer does. This is
+  // the Pandoc rule that makes currency detection possible at all.
   it.each([
     '$ x$',
     '$x $',
+    '$ x $',
     '$x$2',
   ])('should follow single-dollar delimiter rules: %s', (content) => {
     const { container } = render(
@@ -52,6 +55,30 @@ describe('LaTeX Plugin', () => {
 
     expect(container.querySelector('.katex')).not.toBeInTheDocument();
     expect(container).toHaveTextContent(content);
+  });
+
+  // The spacing rules apply to `$...$` only; `$$...$$` is unambiguous and keeps
+  // rendering padded content exactly as before.
+  it.each([
+    '$$ x $$',
+    '$$ \\frac{a}{b} $$',
+  ])('should exempt $$ from the single-dollar spacing rules: %s', (content) => {
+    const { container } = render(
+      <XMarkdown config={{ extensions: latexPlugin() }}>{content}</XMarkdown>,
+    );
+
+    expect(container.querySelector('.katex')).toBeInTheDocument();
+  });
+
+  // Known limitation: the Pandoc rules are positional, not semantic. Prose that
+  // happens to satisfy them — nothing but non-space between the delimiters and a
+  // non-digit after the closing `$` — is still parsed as math.
+  it('does not catch currency that satisfies the Pandoc rules', () => {
+    const { container } = render(
+      <XMarkdown config={{ extensions: latexPlugin() }}>{'价格 $5和$X 的对比'}</XMarkdown>,
+    );
+
+    expect(container.querySelector('.katex')).toBeInTheDocument();
   });
 
   it('should render inline LaTeX with $$\n..\n$$ syntax', () => {

--- a/packages/x-markdown/src/plugins/Latex/index.ts
+++ b/packages/x-markdown/src/plugins/Latex/index.ts
@@ -3,8 +3,8 @@ import type { TokenizerAndRendererExtension } from 'marked';
 
 import 'katex/dist/katex.min.css';
 
-const inlineRuleNonStandard =
-  /^(?:\${1,2}([^$]{1,10000}?)\${1,2}|\\\(([\s\S]{1,10000}?)\\\)|\\\[((?:\\.|[^\\]){1,10000}?)\\\])/;
+const inlineDollarRule = /^(\${1,2})([^$]{1,10000}?)\1/;
+const inlineRuleNonStandard = /^(?:\\\(([\s\S]{1,10000}?)\\\)|\\\[((?:\\.|[^\\]){1,10000}?)\\\])/;
 const blockRule =
   /^(\${1,2})\n([\s\S]{1,10000}?)\n\1(?:\s*(?:\n|$))|^\\\[((?:\\.|[^\\]){1,10000}?)\\\]/;
 
@@ -28,6 +28,14 @@ function replaceAlign(text: string) {
   return text ? text.replace(/\{align\*\}/g, '{aligned}') : text;
 }
 
+// Follow Pandoc's single-dollar delimiter rules to avoid parsing currency as math.
+function isValidInlineDollarMatch(match: RegExpMatchArray, src: string) {
+  const [, delimiter, text] = match;
+  if (delimiter === '$$') return true;
+
+  return !/^\s|\s$/.test(text) && !/^\d/.test(src.slice(match[0].length));
+}
+
 function createRenderer(options: KatexOptions, newlineAfter: boolean) {
   return (token: Token) =>
     katex.renderToString(token.text, {
@@ -49,15 +57,19 @@ function inlineKatex(renderer: Render, replaceAlignStart: boolean) {
       return indices.length > 0 ? Math.min(...indices) : undefined;
     },
     tokenizer(src: string) {
-      const match = src.match(inlineRuleNonStandard);
+      const dollarMatch = src.match(inlineDollarRule);
+      if (dollarMatch && !isValidInlineDollarMatch(dollarMatch, src)) return;
+
+      const nonStandardMatch = src.match(inlineRuleNonStandard);
+      const match = dollarMatch || nonStandardMatch;
       if (!match) return;
 
-      const rawText = match[1] || match[2] || match[3] || '';
+      const rawText = dollarMatch?.[2] || nonStandardMatch?.[1] || nonStandardMatch?.[2] || '';
       const text = replaceAlignStart ? replaceAlign(rawText.trim()) : rawText.trim();
 
       // 对于 \[...\] 语法，如果内容包含换行，标记为块级公式
       // 注意：换行检测必须在 trim 之前进行
-      const isBracketSyntax = match[3] !== undefined;
+      const isBracketSyntax = nonStandardMatch?.[2] !== undefined;
       const hasNewline = rawText.includes('\n');
 
       return {

--- a/packages/x-markdown/src/plugins/Latex/index.ts
+++ b/packages/x-markdown/src/plugins/Latex/index.ts
@@ -3,7 +3,7 @@ import type { TokenizerAndRendererExtension } from 'marked';
 
 import 'katex/dist/katex.min.css';
 
-const inlineDollarRule = /^(\${1,2})([^$]{1,10000}?)\1/;
+const inlineDollarRule = /^(\${1,2})((?:\\.|[^\\$]){1,10000}?)\1/;
 const inlineRuleNonStandard = /^(?:\\\(([\s\S]{1,10000}?)\\\)|\\\[((?:\\.|[^\\]){1,10000}?)\\\])/;
 const blockRule =
   /^(\${1,2})\n([\s\S]{1,10000}?)\n\1(?:\s*(?:\n|$))|^\\\[((?:\\.|[^\\]){1,10000}?)\\\]/;


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

No existing issue or pull request matched this bug.

### 💡 Background and Solution

The built-in `x-markdown` LaTeX tokenizer currently treats any text between two `$` characters as math. Prose containing multiple currency amounts, such as `Downgrade Max ($100) to Pro ($20)`, is therefore rendered as KaTeX. CJK prose also causes repeated `unicodeTextInMathMode` warnings because natural-language text is passed into KaTeX math mode.

This change:

- separates dollar-delimited math from `\(...\)` and `\[...\]` parsing;
- requires matching `$`/`$$` delimiter lengths;
- applies Pandoc-compatible rules to single-dollar math: no whitespace immediately inside the delimiters, and no digit immediately after the closing `$`;
- preserves valid numeric-leading formulas such as `$2x + 1$` and all existing double-dollar behavior;
- adds English, CJK, multiple-price, delimiter-boundary, and warning regression coverage.

Validation:

- `npm exec --workspace packages/x-markdown -- jest --config .jest.js --runInBand --no-cache` — 7 suites, 338 tests, 28 snapshots passed.
- `npm run tsc --workspace packages/x-markdown` — passed.
- `npm exec --workspace packages/x-markdown -- biome check src/plugins/Latex/index.ts src/plugins/Latex/__tests__/index.test.tsx` — passed.
- Full package `biome lint` remains blocked by two pre-existing `noDangerouslySetInnerHtml` errors in benchmark-only `MarkdownRenderer.tsx`; neither file is touched by this PR.

Reference: Pandoc's `tex_math_dollars` delimiter rules: https://pandoc.org/demo/example26.html

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Prevent currency amounts in prose from being interpreted as LaTeX formulas. Single-dollar math now follows Pandoc's delimiter rules, so `$ x $` (padded with spaces) and `$x$2` no longer render as math; `$$...$$` is unaffected. |
| 🇨🇳 Chinese | 修复正文中的美元金额被误识别为 LaTeX 公式的问题。行内单美元公式改为遵循 Pandoc 定界符规则，`$ x $`（首尾带空格）与 `$x$2` 不再渲染为公式；`$$...$$` 不受影响。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化行内 LaTeX 公式识别，避免将货币金额误渲染为数学公式。
  * 支持公式内部的转义美元符号及以数字开头的公式正常渲染。
  * 按规范过滤空格位置不当或缺少有效边界的单美元分隔符。
  * 保持双美元、括号定界及块级公式的正常解析。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
