### PR TITLE
fix(suggestion): preserve space input in editable triggers

### DIFF
--- a/packages/x/components/suggestion/__tests__/index.test.tsx
+++ b/packages/x/components/suggestion/__tests__/index.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
+import Sender, { type SenderProps } from '../../sender';
 import Suggestion, { type SuggestionProps } from '../index';
 
 describe('Suggestion Component', () => {
@@ -82,6 +83,42 @@ describe('Suggestion Component', () => {
     onOpenChange.mockReset();
     fireEvent.keyDown(container.querySelector('input')!, { key: 'Delete' });
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('should not prevent Space input whether the popup is closed or open', () => {
+    const items = [{ label: 'Suggestion 1', value: 'suggestion1' }];
+    const { container } = render(<MockSuggestion items={items} />);
+    const input = container.querySelector('input')!;
+
+    expect(fireEvent.keyDown(input, { key: ' ' })).toBe(true);
+
+    fireEvent.keyDown(input, { key: '/' });
+    expect(screen.getByText('Suggestion 1')).toBeInTheDocument();
+    expect(fireEvent.keyDown(input, { key: ' ' })).toBe(true);
+  });
+
+  it.each<[name: string, senderProps: SenderProps, targetSelector: string]>([
+    ['textarea', {}, 'textarea'],
+    [
+      'input slot',
+      { slotConfig: [{ type: 'input', key: 'input' }] },
+      'input[data-slot-input="input"]',
+    ],
+    [
+      'contenteditable slot',
+      { slotConfig: [{ type: 'content', key: 'content' }] },
+      '[data-slot-key="content"][contenteditable="true"]',
+    ],
+  ])('should preserve Space input in a Sender %s', (_, senderProps, targetSelector) => {
+    const items = [{ label: 'Suggestion 1', value: 'suggestion1' }];
+    const { container } = render(
+      <Suggestion items={items} open>
+        {({ onKeyDown }) => <Sender {...senderProps} onKeyDown={onKeyDown} />}
+      </Suggestion>,
+    );
+    const target = container.querySelector<HTMLElement>(targetSelector)!;
+
+    expect(fireEvent.keyDown(target, { key: ' ' })).toBe(true);
   });
 
   it('open controlled', () => {

--- a/packages/x/components/suggestion/__tests__/useActive.test.tsx
+++ b/packages/x/components/suggestion/__tests__/useActive.test.tsx
@@ -270,6 +270,70 @@ describe('useActive', () => {
       const [activePaths] = result.current;
       expect(activePaths).toEqual([]);
     });
+
+    const dispatchSpace = (
+      target: HTMLElement,
+      options: { open?: boolean; altKey?: boolean; ctrlKey?: boolean; metaKey?: boolean } = {},
+    ) => {
+      const items: SuggestionItem[] = [{ label: 'Item 1', value: 'item1' }];
+      const stopPropagation = jest.fn();
+      const preventDefault = jest.fn();
+      const { open = true, ...modifiers } = options;
+      const { result } = renderHook(() => useActive(items, open, false, jest.fn()));
+
+      act(() =>
+        result.current[1]({
+          key: ' ',
+          target,
+          stopPropagation,
+          preventDefault,
+          ...modifiers,
+        } as any),
+      );
+
+      return { preventDefault, stopPropagation };
+    };
+
+    it.each([true, false])(
+      'should stop plain Space propagation from an editable target when open is %s',
+      (open) => {
+        const { preventDefault, stopPropagation } = dispatchSpace(
+          document.createElement('textarea'),
+          { open },
+        );
+
+        expect(stopPropagation).toHaveBeenCalledTimes(1);
+        expect(preventDefault).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should stop plain Space propagation from a contenteditable target', () => {
+      const target = document.createElement('div');
+      Object.defineProperty(target, 'isContentEditable', { value: true });
+
+      expect(dispatchSpace(target).stopPropagation).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['Alt', { altKey: true }],
+      ['Control', { ctrlKey: true }],
+      ['Meta', { metaKey: true }],
+    ])('should not stop %s+Space propagation', (_, modifiers) => {
+      expect(
+        dispatchSpace(document.createElement('textarea'), modifiers).stopPropagation,
+      ).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['button', document.createElement('button')],
+      ['button input', Object.assign(document.createElement('input'), { type: 'button' })],
+      ['checkbox input', Object.assign(document.createElement('input'), { type: 'checkbox' })],
+      ['number input', Object.assign(document.createElement('input'), { type: 'number' })],
+      ['readonly input', Object.assign(document.createElement('input'), { readOnly: true })],
+      ['disabled textarea', Object.assign(document.createElement('textarea'), { disabled: true })],
+    ])('should not stop Space propagation from a %s', (_, target) => {
+      expect(dispatchSpace(target).stopPropagation).not.toHaveBeenCalled();
+    });
   });
 
   describe('RTL mode', () => {

--- a/packages/x/components/suggestion/useActive.ts
+++ b/packages/x/components/suggestion/useActive.ts
@@ -2,6 +2,24 @@ import { useEvent } from '@rc-component/util';
 import React from 'react';
 import type { SuggestionItem } from '.';
 
+const TEXT_INPUT_TYPES = new Set(['email', 'password', 'search', 'tel', 'text', 'url']);
+
+const isEditableTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (target instanceof HTMLInputElement) {
+    return TEXT_INPUT_TYPES.has(target.type) && !target.disabled && !target.readOnly;
+  }
+
+  if (target instanceof HTMLTextAreaElement) {
+    return !target.disabled && !target.readOnly;
+  }
+
+  return target.isContentEditable;
+};
+
 /**
  * Since Cascader not support ref active, we use `value` to mock the active item.
  */
@@ -58,6 +76,10 @@ export default function useActive(
   };
 
   const onKeyDown: React.KeyboardEventHandler = useEvent((e) => {
+    if (e.key === ' ' && !e.altKey && !e.ctrlKey && !e.metaKey && isEditableTarget(e.target)) {
+      e.stopPropagation();
+    }
+
     if (!open) {
       return;
     }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #1873

### 💡 Background and Solution

When `Suggestion` wraps `Sender`, the editable control is rendered inside the `Cascader` trigger. Space key events can continue to the Cascader/rc-select keyboard handler, where Space is treated as a dropdown control key and its default behavior is prevented. As a result, the Sender cannot insert a space.

This PR adds a deliberately scoped compatibility fix in `Suggestion`:

- stop plain Space from propagating when the real event target is an editable text input, textarea, or `contenteditable` element;
- do not call `preventDefault()`, so native space insertion is preserved;
- exclude disabled/read-only controls, non-text input types, and Alt/Ctrl/Meta shortcuts;
- keep the existing arrow, Enter, and Escape navigation behavior unchanged.

**This is not the root-cause fix in Cascader/rc-select.** The underlying issue is that rc-select infers editability from its own mode and `showSearch` state instead of inspecting the actual event target inside a custom trigger. Fixing that behavior upstream requires a separate rc-select change and the subsequent Cascader/antd dependency release chain. This local guard resolves #1873 without waiting for that chain and can be reconsidered after an upstream fix is available.

Regression coverage includes the popup-open and popup-closed paths, the default Sender textarea, input slots, contenteditable slots, modifier shortcuts, and non-editable controls.

### ✅ Validation

- `npx jest --config .jest.js components/suggestion/__tests__/useActive.test.tsx components/suggestion/__tests__/index.test.tsx --runInBand --coverage=false --no-cache`
  - 2 suites passed, 45 tests passed, 1 snapshot passed.
- `npx biome check packages/x/components/suggestion/useActive.ts packages/x/components/suggestion/__tests__/useActive.test.tsx packages/x/components/suggestion/__tests__/index.test.tsx`
  - Passed.
- `npm run lint:script --workspace packages/x`
  - Checked 540 files; passed with one existing unrelated warning in `sender/hooks/use-speech.ts`.
- `npx size-limit packages/x/dist/antdx.min.js --limit '520 KiB'`
  - 523.25 kB brotlied, under the 532.48 kB limit.
- Local browser verification: with the suggestion popup open, typing `/` followed by Space produces `"/ "`.

Local full `tsc` and declaration generation are currently blocked by four unrelated existing errors in `components/attachments/index.tsx` and `components/file-card/components/ImageLoading.tsx`; the focused type/lint/test paths for this change pass.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Suggestion preventing spaces from being entered in an editable Sender. |
| 🇨🇳 Chinese | 修复 Suggestion 包裹可编辑 Sender 时无法输入空格的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复建议菜单使用期间空格键输入被错误拦截的问题。
  * 在文本框、文本域和可编辑内容区域中，按下未带修饰键的空格时可正常输入，同时避免触发不必要的事件冒泡。
  * 禁用、只读控件及带 Alt、Control 或 Meta 修饰键的空格操作保持原有行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->