### PR TITLE
feat(code-highlighter): add showLineNumber / wrapLongLines / showCopyButton props

### DIFF
--- a/packages/x/components/code-highlighter/CodeHighlighter.tsx
+++ b/packages/x/components/code-highlighter/CodeHighlighter.tsx
@@ -71,6 +71,9 @@ const CodeHighlighter = React.forwardRef<HTMLDivElement, CodeHighlighterProps>((
     style = {},
     highlightProps,
     prismLightMode = true,
+    showLineNumber,
+    wrapLongLines,
+    showCopyButton = true,
     ...restProps
   } = props;
 
@@ -141,7 +144,7 @@ const CodeHighlighter = React.forwardRef<HTMLDivElement, CodeHighlighterProps>((
           >
             {lang}
           </span>
-          <Actions.Copy text={children} />
+          {showCopyButton ? <Actions.Copy text={children} /> : null}
         </div>
       );
     }
@@ -160,6 +163,8 @@ const CodeHighlighter = React.forwardRef<HTMLDivElement, CodeHighlighterProps>((
     <Highlighter
       language={lang}
       wrapLines={true}
+      showLineNumbers={showLineNumber}
+      wrapLongLines={wrapLongLines}
       style={customOneLight}
       codeTagProps={{ style: { background: 'transparent' } }}
       {...highlightProps}

--- a/packages/x/components/code-highlighter/__tests__/index.test.tsx
+++ b/packages/x/components/code-highlighter/__tests__/index.test.tsx
@@ -522,4 +522,82 @@ describe('CodeHighlighter', () => {
       process.env.NODE_ENV = originalEnv;
     });
   });
+
+  describe('flexible config', () => {
+    it('should show line numbers when showLineNumber is true', async () => {
+      const { container } = render(
+        <CodeHighlighter lang="javascript" showLineNumber>
+          {`console.log("test");`}
+        </CodeHighlighter>,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('pre')).toBeInTheDocument();
+      });
+      expect(container.querySelector('.linenumber')).toBeInTheDocument();
+    });
+
+    it('should not show line numbers by default', async () => {
+      const { container } = render(
+        <CodeHighlighter lang="javascript">{`console.log("test");`}</CodeHighlighter>,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('pre')).toBeInTheDocument();
+      });
+      expect(container.querySelector('.linenumber')).not.toBeInTheDocument();
+    });
+
+    it('should pass wrapLongLines to SyntaxHighlighter', async () => {
+      const { container } = render(
+        <CodeHighlighter lang="javascript" wrapLongLines>
+          {`console.log("test");`}
+        </CodeHighlighter>,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('code')).toBeInTheDocument();
+      });
+      // wrapLongLines sets whiteSpace: pre-wrap on the rendered code element
+      expect(container.querySelector('code')?.style.whiteSpace).toBe('pre-wrap');
+    });
+
+    it('should show copy button by default', async () => {
+      const { container } = render(
+        <CodeHighlighter lang="javascript">{`console.log("test");`}</CodeHighlighter>,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('.ant-codeHighlighter-header')).toBeInTheDocument();
+      });
+      expect(
+        container.querySelector('.ant-codeHighlighter-header .ant-actions-copy'),
+      ).toBeInTheDocument();
+    });
+
+    it('should hide copy button when showCopyButton is false', async () => {
+      const { container } = render(
+        <CodeHighlighter lang="javascript" showCopyButton={false}>
+          {`console.log("test");`}
+        </CodeHighlighter>,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('.ant-codeHighlighter-header')).toBeInTheDocument();
+      });
+      expect(
+        container.querySelector('.ant-codeHighlighter-header .ant-actions-copy'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not affect custom header when showCopyButton is false', async () => {
+      const { container } = render(
+        <CodeHighlighter
+          lang="javascript"
+          showCopyButton={false}
+          header={<div className="myCustomHeader">custom</div>}
+        >
+          {`console.log("test");`}
+        </CodeHighlighter>,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('.myCustomHeader')).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/packages/x/components/code-highlighter/demo/flexible-config.tsx
+++ b/packages/x/components/code-highlighter/demo/flexible-config.tsx
@@ -1,0 +1,53 @@
+import { CodeHighlighter } from '@ant-design/x';
+import React from 'react';
+
+const App: React.FC = () => {
+  const code = `import React from 'react';
+import { Button } from 'antd';
+
+const App = () => (
+  <div>
+    <Button type="primary">Primary Button</Button>
+  </div>
+);
+
+export default App;`;
+
+  const longLineCode = `const aVeryLongVariableName = someFunction(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+console.log(aVeryLongVariableName);`;
+
+  return (
+    <div>
+      <h3 style={{ marginBottom: 8 }}>显示行号</h3>
+      <p style={{ marginBottom: 8, color: '#666' }}>
+        通过 <code>showLineNumber</code> 显示代码行号。
+      </p>
+      <CodeHighlighter lang="javascript" showLineNumber>
+        {code}
+      </CodeHighlighter>
+
+      <h3 style={{ margin: '8px 0' }}>自动换行</h3>
+      <p style={{ marginBottom: 8, color: '#666' }}>
+        通过 <code>wrapLongLines</code> 让超长行自动换行，无需横向滚动。
+      </p>
+      <CodeHighlighter lang="javascript" wrapLongLines>
+        {longLineCode}
+      </CodeHighlighter>
+
+      <h3 style={{ margin: '8px 0' }}>隐藏复制按钮</h3>
+      <p style={{ marginBottom: 8, color: '#666' }}>
+        通过 <code>showCopyButton={'{false}'}</code> 隐藏默认 Header 中的复制按钮。
+      </p>
+      <CodeHighlighter lang="javascript" showCopyButton={false}>
+        {code}
+      </CodeHighlighter>
+
+      <h3 style={{ margin: '8px 0' }}>组合使用</h3>
+      <CodeHighlighter lang="javascript" showLineNumber wrapLongLines showCopyButton={false}>
+        {longLineCode}
+      </CodeHighlighter>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/x/components/code-highlighter/index.en-US.md
+++ b/packages/x/components/code-highlighter/index.en-US.md
@@ -22,6 +22,7 @@ The CodeHighlighter component is used in scenarios where you need to display cod
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/custom-header.tsx">Custom Header</code>
+<code src="./demo/flexible-config.tsx">Flexible Config</code>
 <code src="./demo/with-xmarkdown.tsx">With XMarkdown</code>
 
 ## API
@@ -38,6 +39,9 @@ For common properties, refer to: [Common Properties](/docs/react/common-props).
 | className | Style class name | `string` |  |
 | classNames | Style class names | `string` | - |
 | highlightProps | Code highlighting configuration | [`highlightProps`](https://github.com/react-syntax-highlighter/react-syntax-highlighter?tab=readme-ov-file#props) | - |
+| showLineNumber | Whether to show line numbers | `boolean` | `false` |
+| wrapLongLines | Whether to wrap long lines | `boolean` | `false` |
+| showCopyButton | Whether to show the copy button, only works with the default header | `boolean` | `true` |
 | prismLightMode | Whether to use Prism light mode to automatically load language support based on lang prop for smaller bundle size | `boolean` | `true` |
 
 ### CodeHighlighterRef

--- a/packages/x/components/code-highlighter/index.zh-CN.md
+++ b/packages/x/components/code-highlighter/index.zh-CN.md
@@ -23,6 +23,7 @@ CodeHighlighter 组件用于需要展示带有语法高亮的代码片段的场�
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本</code>
 <code src="./demo/custom-header.tsx">自定义 Header</code>
+<code src="./demo/flexible-config.tsx">灵活配置</code>
 <code src="./demo/with-xmarkdown.tsx">配合 XMarkdown</code>
 
 ## API
@@ -37,6 +38,9 @@ CodeHighlighter 组件用于需要展示带有语法高亮的代码片段的场�
 | children | 代码内容 | `string` | - |
 | header | 头部内容，为 `false` 时不显示头部 | `React.ReactNode \| (() => React.ReactNode \| false) \| false` | - |
 | highlightProps | 代码高亮配置，透传给 react-syntax-highlighter | [`SyntaxHighlighterProps`](https://github.com/react-syntax-highlighter/react-syntax-highlighter?tab=readme-ov-file#props) | - |
+| showLineNumber | 是否显示行号 | `boolean` | `false` |
+| wrapLongLines | 是否自动换行 | `boolean` | `false` |
+| showCopyButton | 是否显示复制按钮，仅在默认 header 下生效 | `boolean` | `true` |
 | prismLightMode | 是否使用 Prism 轻量模式，根据 `lang` 自动按需加载语言支持以减少打包体积 | `boolean` | `true` |
 
 ### CodeHighlighterRef

--- a/packages/x/components/code-highlighter/interface.ts
+++ b/packages/x/components/code-highlighter/interface.ts
@@ -36,6 +36,24 @@ export interface CodeHighlighterProps
    */
   highlightProps?: Partial<SyntaxHighlighterProps>;
   /**
+   * @desc 是否显示行号
+   * @descEN Whether to show line numbers
+   * @default false
+   */
+  showLineNumber?: boolean;
+  /**
+   * @desc 是否自动换行
+   * @descEN Whether to wrap long lines
+   * @default false
+   */
+  wrapLongLines?: boolean;
+  /**
+   * @desc 是否显示复制按钮，仅在默认 header 下生效
+   * @descEN Whether to show the copy button, only works with the default header
+   * @default true
+   */
+  showCopyButton?: boolean;
+  /**
    * @desc 语义化结构 className
    * @descEN Semantic structure class names
    */


### PR DESCRIPTION
Closes #1951

> 关联原始 issue：#1647

## 背景

`CodeHighlighter` 当前只能通过 `highlightProps` 透传 `react-syntax-highlighter` 的配置，缺少几个常用开关的显式入口(`showLineNumbers` / `wrapLongLines`)，以及无法单独关闭默认 header 里的复制按钮。

## 改动

在 `CodeHighlighterProps` 上新增 3 个配置项，并按需透传给 `react-syntax-highlighter`（复制按钮在组件内自行控制）：

| 属性 | 说明 | 类型 | 默认值 |
| --- | --- | --- | --- |
| `showLineNumber` | 是否显示行号 | `boolean` | `false` |
| `wrapLongLines` | 是否自动换行 | `boolean` | `false` |
| `showCopyButton` | 是否显示复制按钮，仅在默认 header 下生效 | `boolean` | `true` |

- `interface.ts`：补充 props 定义（含 `@default`）。
- `CodeHighlighter.tsx`：`showLineNumbers` / `wrapLongLines` 透传给 `SyntaxHighlighter`；默认 header 的 `Actions.Copy` 根据 `showCopyButton` 条件渲染（自定义 header 不受影响）。
- 新增 `demo/flexible-config.tsx`，演示三个开关及组合使用。
- 中英文 API 文档（`index.zh-CN.md` / `index.en-US.md`）注册 demo 并更新 API 表格。
- 新增单元测试覆盖三个开关。

> 说明：`highlightProps` 仍保留为 escape hatch，沿用既有 spread 顺序——传 `highlightProps.showLineNumbers` 会覆盖 `showLineNumber`，与现有 `wrapLines={true}` 被 `highlightProps` 覆盖的行为保持一致。

## 验证

- biome 格式检查通过。
- 单测断言已对照 `react-syntax-highlighter@15.6.6` 源码核实：行号渲染为 `<span class=\"linenumber\">`，`wrapLongLines` 设置 `<code>` 的 `whiteSpace: pre-wrap`。

> 备注：与 #1945（语言注册/样式）同改了 code-highlighter，如已合入我会 rebase 处理冲突。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 代码高亮组件支持配置是否显示行号、是否自动换行，以及是否显示复制按钮。
  * 复制按钮默认显示，并可按需隐藏。
  * 新增灵活配置示例，展示多种组合用法。

* **文档**
  * 补充新增配置项、默认值及使用说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->