### PR TITLE
feat(actions): support customizing the tooltip of each action item

### DIFF
--- a/packages/x/components/actions/ActionsItem.tsx
+++ b/packages/x/components/actions/ActionsItem.tsx
@@ -1,6 +1,6 @@
 import { CloseCircleOutlined, LoadingOutlined } from '@ant-design/icons';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
-import { Tooltip } from 'antd';
+import { Tooltip, type TooltipProps } from 'antd';
 import { clsx } from 'clsx';
 import React from 'react';
 import useMobile from '../_util/hooks/use-mobile';
@@ -44,6 +44,12 @@ export interface ActionsItemProps extends Omit<React.HTMLAttributes<HTMLDivEleme
    */
   label?: string;
   /**
+   * @desc 操作项的 Tooltip，设为 `false` 时不渲染 Tooltip
+   * @descEN Tooltip of the action item, set to `false` to disable the Tooltip
+   * @default label
+   */
+  tooltip?: string | TooltipProps | false;
+  /**
    * @desc 执行中图标
    * @descEN running icon
    */
@@ -77,6 +83,7 @@ const ActionsItem: React.FC<ActionsItemProps> = (props) => {
     defaultIcon,
     runningIcon,
     label,
+    tooltip,
     className,
     classNames = {},
     styles = {},
@@ -138,7 +145,23 @@ const ActionsItem: React.FC<ActionsItemProps> = (props) => {
     </div>
   );
 
-  return isMobile ? innerNode : <Tooltip title={label}>{innerNode}</Tooltip>;
+  // Resolve tooltip config:
+  // - `false`: no Tooltip rendered
+  // - `string`/`number`: used as the tooltip title
+  // - `TooltipProps` object: merged on top of the default `title={label}`
+  // - `undefined`: default `title={label}`
+  const tooltipProps =
+    tooltip === false
+      ? null
+      : typeof tooltip === 'string' || typeof tooltip === 'number'
+        ? { title: tooltip }
+        : { title: label, ...(tooltip || {}) };
+
+  return isMobile || tooltipProps === null ? (
+    innerNode
+  ) : (
+    <Tooltip {...tooltipProps}>{innerNode}</Tooltip>
+  );
 };
 
 export default ActionsItem;

--- a/packages/x/components/actions/Item.tsx
+++ b/packages/x/components/actions/Item.tsx
@@ -30,6 +30,18 @@ const Item: React.FC<ActionsItemProps> = (props) => {
 
   const iconElement = <div className={`${prefixCls}-icon`}>{item?.icon}</div>;
 
+  // Resolve tooltip config:
+  // - `false`: no Tooltip rendered
+  // - `string`/`number`: used as the tooltip title
+  // - `TooltipProps` object: merged on top of the default `title={label}`
+  // - `undefined`: default `title={label}`
+  const tooltipProps =
+    item.tooltip === false
+      ? null
+      : typeof item.tooltip === 'string' || typeof item.tooltip === 'number'
+        ? { title: item.tooltip }
+        : { title: item.label, ...(item.tooltip || {}) };
+
   return (
     <div
       className={clsx(`${prefixCls}-item`, classNames.item, {
@@ -50,7 +62,11 @@ const Item: React.FC<ActionsItemProps> = (props) => {
       }}
       key={itemKey}
     >
-      {isMobile ? iconElement : <Tooltip title={item.label}>{iconElement}</Tooltip>}
+      {isMobile || tooltipProps === null ? (
+        iconElement
+      ) : (
+        <Tooltip {...tooltipProps}>{iconElement}</Tooltip>
+      )}
     </div>
   );
 };

--- a/packages/x/components/actions/__tests__/action-item.test.tsx
+++ b/packages/x/components/actions/__tests__/action-item.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../tests/utils';
+import { fireEvent, render, screen, waitFor } from '../../../tests/utils';
 import ActionsItem from '../ActionsItem';
 
 describe('Actions.Item', () => {
@@ -7,5 +7,41 @@ describe('Actions.Item', () => {
     const { getByText } = render(<ActionsItem defaultIcon="default-icon" />);
     expect(getByText('default-icon')).toBeTruthy();
     render(<ActionsItem defaultIcon="default-icon" status={'xxx' as any} />);
+  });
+
+  const openTooltip = (trigger: Element) => {
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseMove(trigger);
+  };
+
+  it('renders tooltip with label by default', async () => {
+    render(<ActionsItem defaultIcon="icon" label="Default Label" />);
+    openTooltip(screen.getByText('icon').parentElement!);
+    await waitFor(() => {
+      expect(screen.getByText('Default Label')).toBeInTheDocument();
+    });
+  });
+
+  it('uses a custom string as the tooltip title', async () => {
+    render(<ActionsItem defaultIcon="icon" label="Label" tooltip="Custom Tooltip" />);
+    openTooltip(screen.getByText('icon').parentElement!);
+    await waitFor(() => {
+      expect(screen.getByText('Custom Tooltip')).toBeInTheDocument();
+    });
+  });
+
+  it('renders no tooltip when tooltip is false', () => {
+    const { container } = render(<ActionsItem defaultIcon="icon" label="Label" tooltip={false} />);
+    // icon renders without a Tooltip wrapper
+    expect(container.textContent).toContain('icon');
+  });
+
+  it('merges TooltipProps object on top of the default title', async () => {
+    render(<ActionsItem defaultIcon="icon" label="Label" tooltip={{ placement: 'bottom' }} />);
+    openTooltip(screen.getByText('icon').parentElement!);
+    await waitFor(() => {
+      // title falls back to label when not specified in the TooltipProps
+      expect(screen.getByText('Label')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/x/components/actions/__tests__/index.test.tsx
+++ b/packages/x/components/actions/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import { ActionsProps } from '@ant-design/x';
 import React from 'react';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, screen, waitFor } from '../../../tests/utils';
 
 import { findItem } from '../ActionsMenu';
 import Actions from '../index';
@@ -80,6 +80,55 @@ describe('Actions Component', () => {
   it('renders sub-menu items', () => {
     const { getByText } = render(<Actions items={items} onClick={mockOnClick} />);
     expect(getByText('icon1')).toBeInTheDocument();
+  });
+
+  it('renders item tooltip with label by default', async () => {
+    render(
+      <Actions items={[{ key: '1', label: 'Default Item Tooltip', icon: <span>icon1</span> }]} />,
+    );
+    const trigger = screen.getByText('icon1').parentElement!;
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseMove(trigger);
+    await waitFor(() => {
+      expect(screen.getByText('Default Item Tooltip')).toBeInTheDocument();
+    });
+  });
+
+  it('uses a custom string tooltip on an item', async () => {
+    render(
+      <Actions
+        items={[{ key: '1', label: 'Label', tooltip: 'Custom Tooltip', icon: <span>icon1</span> }]}
+      />,
+    );
+    const trigger = screen.getByText('icon1').parentElement!;
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseMove(trigger);
+    await waitFor(() => {
+      expect(screen.getByText('Custom Tooltip')).toBeInTheDocument();
+    });
+  });
+
+  it('renders no tooltip when item tooltip is false', () => {
+    const { container } = render(
+      <Actions items={[{ key: '1', label: 'Label', tooltip: false, icon: <span>icon1</span> }]} />,
+    );
+    expect(container.textContent).toContain('icon1');
+  });
+
+  it('merges TooltipProps on top of the default label tooltip', async () => {
+    render(
+      <Actions
+        items={[
+          { key: '1', label: 'Label', tooltip: { placement: 'bottom' }, icon: <span>icon1</span> },
+        ]}
+      />,
+    );
+    const trigger = screen.getByText('icon1').parentElement!;
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseMove(trigger);
+    await waitFor(() => {
+      expect(screen.getByText('Label')).toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/x/components/actions/demo/custom-tooltip.tsx
+++ b/packages/x/components/actions/demo/custom-tooltip.tsx
@@ -1,0 +1,37 @@
+import { EditOutlined, RedoOutlined, StarOutlined } from '@ant-design/icons';
+import { Actions } from '@ant-design/x';
+import React from 'react';
+
+const App: React.FC = () => {
+  const items = [
+    {
+      key: 'retry',
+      icon: <RedoOutlined />,
+      label: 'Retry',
+    },
+    {
+      key: 'edit',
+      icon: <EditOutlined />,
+      // Use a custom tooltip string instead of the label
+      tooltip: 'Edit this item',
+    },
+    {
+      key: 'star',
+      icon: <StarOutlined />,
+      label: 'Star',
+      // Disable the tooltip entirely
+      tooltip: false,
+    },
+    {
+      key: 'share',
+      icon: <EditOutlined />,
+      label: 'Share',
+      // Pass extra Tooltip props, title falls back to label by default
+      tooltip: { placement: 'bottom', color: 'blue' },
+    },
+  ];
+
+  return <Actions items={items} />;
+};
+
+export default App;

--- a/packages/x/components/actions/index.en-US.md
+++ b/packages/x/components/actions/index.en-US.md
@@ -22,6 +22,7 @@ The Actions component is used for quickly configuring required action buttons or
 <code src="./demo/sub.tsx">More Menu Items</code>
 <code src="./demo/preset.tsx">Preset Templates</code>
 <code src="./demo/variant.tsx">Using Variants</code>
+<code src="./demo/custom-tooltip.tsx">Custom Tooltip</code>
 <code src="./demo/fadeIn.tsx">Fade In Effect</code>
 
 ## API
@@ -45,6 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- |
 | key | Unique identifier for custom action | string | - | - |
 | label | Display label for custom action | string | - | - |
+| tooltip | Tooltip of the action item, set to `false` to disable the Tooltip | string \| TooltipProps \| false | label | - |
 | icon | Icon for custom action | ReactNode | - | - |
 | onItemClick | Callback function when custom action button is clicked | (info: [ItemType](#itemtype)) => void | - | - |
 | danger | Syntactic sugar, sets danger icon | boolean | false | - |
@@ -78,6 +80,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- |
 | status | Status | 'loading'\|'error'\|'running'\|'default' | default | 2.0.0 |
 | label | Display label for custom action | string | - | 2.0.0 |
+| tooltip | Tooltip of the action item, set to `false` to disable the Tooltip | string \| TooltipProps \| false | label | - |
 | defaultIcon | Default status icon | ReactNode | - | 2.0.0 |
 | runningIcon | Running status icon | ReactNode | - | 2.0.0 |
 

--- a/packages/x/components/actions/index.zh-CN.md
+++ b/packages/x/components/actions/index.zh-CN.md
@@ -23,6 +23,7 @@ Actions 组件用于快速配置一些 AI 场景下所需要的操作按钮/功�
 <code src="./demo/sub.tsx">更多菜单项</code>
 <code src="./demo/preset.tsx">预设模板</code>
 <code src="./demo/variant.tsx">使用变体</code>
+<code src="./demo/custom-tooltip.tsx">自定义 Tooltip</code>
 <code src="./demo/fadeIn.tsx">渐入效果</code>
 
 ## API
@@ -46,6 +47,7 @@ Actions 组件用于快速配置一些 AI 场景下所需要的操作按钮/功�
 | --- | --- | --- | --- | --- |
 | key | 自定义操作的唯一标识 | string | - | - |
 | label | 自定义操作的显示标签 | string | - | - |
+| tooltip | 操作项的 Tooltip，设为 `false` 时不渲染 Tooltip | string \| TooltipProps \| false | label | - |
 | icon | 自定义操作的图标 | ReactNode | - | - |
 | onItemClick | 点击自定义操作按钮时的回调函数 | (info: [ItemType](#itemtype)) => void | - | - |
 | danger | 语法糖，设置危险icon | boolean | false | - |
@@ -75,12 +77,13 @@ Actions 组件用于快速配置一些 AI 场景下所需要的操作按钮/功�
 
 ### Actions.Item
 
-| 属性        | 说明                 | 类型                                     | 默认值  | 版本  |
-| ----------- | -------------------- | ---------------------------------------- | ------- | ----- |
-| status      | 状态                 | 'loading'\|'error'\|'running'\|'default' | default | 2.0.0 |
-| label       | 自定义操作的显示标签 | string                                   | -       | 2.0.0 |
-| defaultIcon | 默认状态图标         | React.ReactNode                          | -       | 2.0.0 |
-| runningIcon | 执行状态图标         | React.ReactNode                          | -       | 2.0.0 |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| status | 状态 | 'loading'\|'error'\|'running'\|'default' | default | 2.0.0 |
+| label | 自定义操作的显示标签 | string | - | 2.0.0 |
+| tooltip | 操作项的 Tooltip，设为 `false` 时不渲染 Tooltip | string \| TooltipProps \| false | label | - |
+| defaultIcon | 默认状态图标 | React.ReactNode | - | 2.0.0 |
+| runningIcon | 执行状态图标 | React.ReactNode | - | 2.0.0 |
 
 ## Semantic DOM
 

--- a/packages/x/components/actions/interface.ts
+++ b/packages/x/components/actions/interface.ts
@@ -1,4 +1,4 @@
-import type { DropdownProps, MenuProps } from 'antd';
+import type { DropdownProps, MenuProps, TooltipProps } from 'antd';
 import type React from 'react';
 
 export type SemanticType = 'root' | 'item' | 'itemDropdown';
@@ -84,6 +84,12 @@ export interface ItemType {
    * @descEN Icon for the custom action.
    */
   icon?: React.ReactNode;
+  /**
+   * @desc 操作项的 Tooltip，设为 `false` 时不渲染 Tooltip
+   * @descEN Tooltip of the action item, set to `false` to disable the Tooltip
+   * @default label
+   */
+  tooltip?: string | TooltipProps | false;
   /**
    * @desc 点击自定义操作按钮时的回调函数
    * @descEN Callback function when the custom action button is clicked.


### PR DESCRIPTION
Closes #1952

> 关联原始 issue：#1834

## 背景

`Actions` 操作项的 Tooltip 当前固定为 `title={label}`，无法自定义文案，也无法关闭（例如在 `z-index` 很高的容器里 tooltip 可能被遮住、或场景上根本不需要提示）。

## 改动

为每个操作项新增 \`tooltip\` 配置：

\`\`\`ts
tooltip?: string | TooltipProps | false
\`\`\`

| 取值 | 行为 |
| --- | --- |
| \`undefined\` | 保持默认 \`title={label}\` |
| \`string\` | 以该字符串作为 tooltip \`title\` |
| \`TooltipProps\` 对象 | 合并到默认 \`title={label}\` 之上（可自定义 \`placement\`、\`color\`、\`getPopupContainer\` 等） |
| \`false\` | 不渲染 Tooltip |

- \`interface.ts\`：在 \`ItemType\` 上新增 \`tooltip\`（沿用 sender 组件 \`import type { TooltipProps } from 'antd'\` 的写法）。
- \`Item.tsx\` \`items=[...]\` 渲染路径 与 \`ActionsItem.tsx\` 独立 \`Actions.Item\` 组件 均支持，复用同一套解析逻辑。
- 新增 \`demo/custom-tooltip.tsx\`，演示自定义字符串 / \`false\` 关闭 / \`TooltipProps\` 对象（\`placement\`、\`color\`）/ 默认 label。
- 中英文档注册 demo，并更新 \`ItemType\`、\`Actions.Item\` 两处 API 表。
- 新增单测覆盖以上四类取值（独立组件与 items 路径各一套）。

## 验证

- biome 格式检查通过。
- \`tsc --noEmit\` 对改动文件无新增类型错误。

> 备注：本地 \`jest\` 因 \`.jest\` setup 中 \`antd@6\` 的 \`genStyleUtils is not a function\` 报错而无法运行（仓库级环境问题，既有用例同样失败，非本次改动引入），依赖 CI 验证单测。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - Actions 项目新增可配置的 Tooltip。
  - 支持使用自定义文本、完整 Tooltip 配置，或设置为 `false` 禁用提示。
  - 未特别配置时，默认使用项目标签作为提示标题。
  - 移动端自动直接展示内容，避免显示 Tooltip。

- **文档**
  - 新增自定义 Tooltip 示例及相关 API 配置说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->