### PR TITLE
feat(x-sdk): add agent interaction commands

### DIFF
--- a/packages/x-sdk/src/agent/command/__test__/commands.test.ts
+++ b/packages/x-sdk/src/agent/command/__test__/commands.test.ts
@@ -1,0 +1,121 @@
+import {
+  AGENT_COMMAND_PROTOCOL,
+  AGENT_COMMAND_PROTOCOL_VERSION,
+  agentCommandTypes,
+  createAgentCommandFactory,
+  getAgentActionKey,
+  getAgentCommandActionKey,
+  getAgentCommandKey,
+  isAgentCommand,
+  isAgentCommandEnvelope,
+} from '..';
+
+describe('agent commands', () => {
+  const factory = createAgentCommandFactory({
+    sessionId: 'session-1',
+    runId: 'run-1',
+    now: () => 100,
+    createCommandId: (type) => `command:${type}`,
+    createIdempotencyKey: (commandId, type) => `${type}:${commandId}:key`,
+  });
+
+  it('creates commands with defaults and explicit envelope options', () => {
+    const retry = factory.create('tool.retry', { toolCallId: 'tool-1' });
+    expect(retry).toEqual({
+      commandProtocol: AGENT_COMMAND_PROTOCOL,
+      commandProtocolVersion: AGENT_COMMAND_PROTOCOL_VERSION,
+      type: 'tool.retry',
+      commandId: 'command:tool.retry',
+      idempotencyKey: 'tool.retry:command:tool.retry:key',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      timestamp: 100,
+      payload: { toolCallId: 'tool-1' },
+    });
+
+    const cancel = factory.create(
+      'run.cancel',
+      { reason: 'stop' },
+      {
+        commandId: 'custom-command',
+        idempotencyKey: 'custom-key',
+        timestamp: 200,
+        meta: { source: 'test' },
+      },
+    );
+    expect(cancel).toMatchObject({
+      commandId: 'custom-command',
+      idempotencyKey: 'custom-key',
+      timestamp: 200,
+      meta: { source: 'test' },
+    });
+
+    const defaultFactory = createAgentCommandFactory({ sessionId: 's', runId: 'r' });
+    expect(defaultFactory.create('run.cancel', {}).commandId).toContain('r:command:');
+  });
+
+  it('validates every command payload and rejects malformed envelopes', () => {
+    const approval = factory.create('approval.resolve', {
+      approvalId: 'approval-1',
+      decision: 'approved',
+      expectedVersion: 1,
+    });
+    const modified = factory.create('approval.resolve', {
+      approvalId: 'approval-1',
+      decision: 'modified',
+      expectedVersion: 'v2',
+    });
+    const retry = factory.create('tool.retry', { toolCallId: 'tool-1' });
+    const cancel = factory.create('run.cancel', { reason: 'done' });
+
+    expect(agentCommandTypes).toEqual(['approval.resolve', 'tool.retry', 'run.cancel']);
+    expect([approval, modified, retry, cancel].every(isAgentCommand)).toBe(true);
+    expect(isAgentCommandEnvelope({ ...approval, meta: { trace: true } })).toBe(true);
+
+    const invalidEnvelopes = [
+      null,
+      [],
+      { ...approval, commandProtocol: 'other' },
+      { ...approval, commandProtocolVersion: '9' },
+      { ...approval, type: 'unknown' },
+      { ...approval, commandId: '' },
+      { ...approval, idempotencyKey: '' },
+      { ...approval, sessionId: '' },
+      { ...approval, runId: '' },
+      { ...approval, timestamp: Number.NaN },
+      { ...approval, payload: [] },
+      { ...approval, meta: [] },
+    ];
+    invalidEnvelopes.forEach((command) => {
+      expect(isAgentCommandEnvelope(command)).toBe(false);
+    });
+
+    expect(isAgentCommand({ ...approval, payload: { ...approval.payload, approvalId: '' } })).toBe(
+      false,
+    );
+    expect(
+      isAgentCommand({ ...approval, payload: { ...approval.payload, decision: 'expired' } }),
+    ).toBe(false);
+    expect(
+      isAgentCommand({ ...approval, payload: { ...approval.payload, expectedVersion: Infinity } }),
+    ).toBe(false);
+    expect(isAgentCommand({ ...retry, payload: { toolCallId: '' } })).toBe(false);
+    expect(isAgentCommand({ ...cancel, payload: { reason: 1 } })).toBe(false);
+    expect(isAgentCommand(factory.create('run.cancel', {}))).toBe(true);
+  });
+
+  it('creates collision-safe command and action keys', () => {
+    const approval = factory.create('approval.resolve', {
+      approvalId: 'approval-1',
+      decision: 'rejected',
+    });
+    const retry = factory.create('tool.retry', { toolCallId: 'tool-1' });
+    const cancel = factory.create('run.cancel', {});
+
+    expect(getAgentCommandKey(approval)).toBe(approval.commandId);
+    expect(getAgentActionKey({ runId: 'run-1', type: 'run.cancel' })).toBe('5:run-1:run.cancel:');
+    expect(getAgentCommandActionKey(approval)).toBe('5:run-1:approval.resolve:approval-1');
+    expect(getAgentCommandActionKey(retry)).toBe('5:run-1:tool.retry:tool-1');
+    expect(getAgentCommandActionKey(cancel)).toBe('5:run-1:run.cancel:');
+  });
+});

--- a/packages/x-sdk/src/agent/command/commands.ts
+++ b/packages/x-sdk/src/agent/command/commands.ts
@@ -1,0 +1,143 @@
+import type { ApprovalDecision } from '../protocol';
+
+export const AGENT_COMMAND_PROTOCOL = 'agent-command' as const;
+export const AGENT_COMMAND_PROTOCOL_VERSION = '0.1' as const;
+
+export type AgentCommandProtocolVersion = typeof AGENT_COMMAND_PROTOCOL_VERSION;
+export type AgentCommandDecision = Exclude<ApprovalDecision, 'expired'>;
+export type AgentCommandMeta = Readonly<Record<string, unknown>>;
+
+export interface AgentCommandPayloadMap {
+  'approval.resolve': {
+    approvalId: string;
+    decision: AgentCommandDecision;
+    data?: unknown;
+    expectedVersion?: string | number;
+  };
+  'tool.retry': {
+    toolCallId: string;
+  };
+  'run.cancel': {
+    reason?: string;
+  };
+}
+
+export type AgentCommandType = keyof AgentCommandPayloadMap;
+
+const agentCommandTypeMap = {
+  'approval.resolve': true,
+  'tool.retry': true,
+  'run.cancel': true,
+} satisfies Record<AgentCommandType, true>;
+
+export const agentCommandTypes = Object.keys(agentCommandTypeMap) as AgentCommandType[];
+
+export interface AgentCommandEnvelope<Type extends AgentCommandType> {
+  commandProtocol: typeof AGENT_COMMAND_PROTOCOL;
+  commandProtocolVersion: AgentCommandProtocolVersion;
+  type: Type;
+  commandId: string;
+  idempotencyKey: string;
+  sessionId: string;
+  runId: string;
+  timestamp: number;
+  payload: AgentCommandPayloadMap[Type];
+  meta?: AgentCommandMeta;
+}
+
+export type AgentCommandOf<Type extends AgentCommandType> = AgentCommandEnvelope<Type>;
+
+export type AgentCommand = {
+  [Type in AgentCommandType]: AgentCommandOf<Type>;
+}[AgentCommandType];
+
+export interface UnknownAgentCommandEnvelope {
+  commandProtocol: typeof AGENT_COMMAND_PROTOCOL;
+  commandProtocolVersion: AgentCommandProtocolVersion;
+  type: AgentCommandType;
+  commandId: string;
+  idempotencyKey: string;
+  sessionId: string;
+  runId: string;
+  timestamp: number;
+  payload: Record<string, unknown>;
+  meta?: AgentCommandMeta;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const hasString = (value: Record<string, unknown>, key: string) =>
+  typeof value[key] === 'string' && value[key] !== '';
+
+export function isAgentCommandEnvelope(value: unknown): value is UnknownAgentCommandEnvelope {
+  if (!isRecord(value)) return false;
+
+  return (
+    value.commandProtocol === AGENT_COMMAND_PROTOCOL &&
+    value.commandProtocolVersion === AGENT_COMMAND_PROTOCOL_VERSION &&
+    typeof value.type === 'string' &&
+    agentCommandTypes.includes(value.type as AgentCommandType) &&
+    hasString(value, 'commandId') &&
+    hasString(value, 'idempotencyKey') &&
+    hasString(value, 'sessionId') &&
+    hasString(value, 'runId') &&
+    typeof value.timestamp === 'number' &&
+    Number.isFinite(value.timestamp) &&
+    isRecord(value.payload) &&
+    (value.meta === undefined || isRecord(value.meta))
+  );
+}
+
+export function isAgentCommand(value: unknown): value is AgentCommand {
+  if (!isAgentCommandEnvelope(value)) return false;
+  const { payload } = value;
+
+  switch (value.type) {
+    case 'approval.resolve':
+      return (
+        hasString(payload, 'approvalId') &&
+        ['approved', 'rejected', 'modified'].includes(payload.decision as string) &&
+        (payload.expectedVersion === undefined ||
+          typeof payload.expectedVersion === 'string' ||
+          (typeof payload.expectedVersion === 'number' && Number.isFinite(payload.expectedVersion)))
+      );
+    case 'tool.retry':
+      return hasString(payload, 'toolCallId');
+    case 'run.cancel':
+      return payload.reason === undefined || typeof payload.reason === 'string';
+  }
+}
+
+export function getAgentCommandKey(command: AgentCommand): string {
+  return command.commandId;
+}
+
+export interface AgentActionKeyOptions {
+  runId: string;
+  type: AgentCommandType;
+  entityId?: string;
+}
+
+export function getAgentActionKey({ runId, type, entityId = '' }: AgentActionKeyOptions): string {
+  return `${runId.length}:${runId}:${type}:${entityId}`;
+}
+
+export function getAgentCommandActionKey(command: AgentCommand): string {
+  switch (command.type) {
+    case 'approval.resolve':
+      return getAgentActionKey({
+        runId: command.runId,
+        type: command.type,
+        entityId: command.payload.approvalId,
+      });
+    case 'tool.retry':
+      return getAgentActionKey({
+        runId: command.runId,
+        type: command.type,
+        entityId: command.payload.toolCallId,
+      });
+    case 'run.cancel':
+      return getAgentActionKey({ runId: command.runId, type: command.type });
+  }
+}

--- a/packages/x-sdk/src/agent/command/factory.ts
+++ b/packages/x-sdk/src/agent/command/factory.ts
@@ -1,0 +1,42 @@
+import type { AgentCommandOf, AgentCommandType } from './commands';
+import { AGENT_COMMAND_PROTOCOL, AGENT_COMMAND_PROTOCOL_VERSION } from './commands';
+import type {
+  AgentCommandFactory,
+  AgentCommandFactoryOptions,
+  CreateAgentCommandOptions,
+} from './types';
+
+let nextCommandId = 0;
+
+export function createAgentCommandFactory(
+  options: AgentCommandFactoryOptions,
+): AgentCommandFactory {
+  const now = options.now ?? Date.now;
+  const createCommandId =
+    options.createCommandId ??
+    ((type: AgentCommandType) => {
+      nextCommandId += 1;
+      return `${options.runId}:command:${nextCommandId}:${type}`;
+    });
+  const createIdempotencyKey =
+    options.createIdempotencyKey ?? ((commandId: string) => `${commandId}:idempotency`);
+
+  return {
+    create(type, payload, commandOptions: CreateAgentCommandOptions = {}) {
+      const commandId = commandOptions.commandId ?? createCommandId(type);
+      const command = {
+        commandProtocol: AGENT_COMMAND_PROTOCOL,
+        commandProtocolVersion: AGENT_COMMAND_PROTOCOL_VERSION,
+        type,
+        commandId,
+        idempotencyKey: commandOptions.idempotencyKey ?? createIdempotencyKey(commandId, type),
+        sessionId: options.sessionId,
+        runId: options.runId,
+        timestamp: commandOptions.timestamp ?? now(),
+        payload,
+      } as AgentCommandOf<typeof type>;
+      if (commandOptions.meta !== undefined) command.meta = commandOptions.meta;
+      return command;
+    },
+  };
+}

--- a/packages/x-sdk/src/agent/command/index.ts
+++ b/packages/x-sdk/src/agent/command/index.ts
@@ -1,0 +1,28 @@
+export type {
+  AgentActionKeyOptions,
+  AgentCommand,
+  AgentCommandDecision,
+  AgentCommandEnvelope,
+  AgentCommandMeta,
+  AgentCommandOf,
+  AgentCommandPayloadMap,
+  AgentCommandProtocolVersion,
+  AgentCommandType,
+  UnknownAgentCommandEnvelope,
+} from './commands';
+export {
+  AGENT_COMMAND_PROTOCOL,
+  AGENT_COMMAND_PROTOCOL_VERSION,
+  agentCommandTypes,
+  getAgentActionKey,
+  getAgentCommandActionKey,
+  getAgentCommandKey,
+  isAgentCommand,
+  isAgentCommandEnvelope,
+} from './commands';
+export { createAgentCommandFactory } from './factory';
+export type {
+  AgentCommandFactory,
+  AgentCommandFactoryOptions,
+  CreateAgentCommandOptions,
+} from './types';

--- a/packages/x-sdk/src/agent/command/types.ts
+++ b/packages/x-sdk/src/agent/command/types.ts
@@ -1,0 +1,29 @@
+import type {
+  AgentCommandMeta,
+  AgentCommandOf,
+  AgentCommandPayloadMap,
+  AgentCommandType,
+} from './commands';
+
+export interface AgentCommandFactoryOptions {
+  sessionId: string;
+  runId: string;
+  now?: () => number;
+  createCommandId?: (type: AgentCommandType) => string;
+  createIdempotencyKey?: (commandId: string, type: AgentCommandType) => string;
+}
+
+export interface CreateAgentCommandOptions {
+  commandId?: string;
+  idempotencyKey?: string;
+  timestamp?: number;
+  meta?: AgentCommandMeta;
+}
+
+export interface AgentCommandFactory {
+  create<Type extends AgentCommandType>(
+    type: Type,
+    payload: AgentCommandPayloadMap[Type],
+    options?: CreateAgentCommandOptions,
+  ): AgentCommandOf<Type>;
+}

--- a/packages/x-sdk/src/agent/index.ts
+++ b/packages/x-sdk/src/agent/index.ts
@@ -1,3 +1,5 @@
+export * from './command';
 export * from './protocol';
 export * from './reducer';
+export * from './selectors';
 export * from './store';

--- a/packages/x-sdk/src/agent/protocol/events.ts
+++ b/packages/x-sdk/src/agent/protocol/events.ts
@@ -87,6 +87,8 @@ export interface AgentEventPayloadMap {
     name: string;
     arguments?: string;
     index?: number;
+    attempt?: number;
+    retryOf?: string;
   };
   'tool.arguments_delta': {
     toolCallId: string;
@@ -113,6 +115,9 @@ export interface AgentEventPayloadMap {
     description?: string;
     risk?: 'low' | 'medium' | 'high' | (string & {});
     data?: unknown;
+    editable?: boolean;
+    expiresAt?: number;
+    version?: string | number;
   };
   'approval.resolved': {
     approvalId: string;
@@ -366,7 +371,10 @@ export function isAgentEvent(value: unknown): value is AgentEvent {
         hasId(payload, 'toolCallId') &&
         hasString(payload, 'name') &&
         hasOptionalString(payload, 'arguments') &&
-        (payload.index === undefined || Number.isInteger(payload.index))
+        (payload.index === undefined || Number.isInteger(payload.index)) &&
+        (payload.attempt === undefined ||
+          (Number.isInteger(payload.attempt) && (payload.attempt as number) >= 1)) &&
+        hasOptionalString(payload, 'retryOf')
       );
     case 'tool.arguments_delta':
       return hasId(payload, 'toolCallId') && typeof payload.delta === 'string';
@@ -382,7 +390,13 @@ export function isAgentEvent(value: unknown): value is AgentEvent {
         hasId(payload, 'approvalId') &&
         hasOptionalString(payload, 'toolCallId') &&
         hasOptionalString(payload, 'description') &&
-        hasOptionalString(payload, 'risk')
+        hasOptionalString(payload, 'risk') &&
+        (payload.editable === undefined || typeof payload.editable === 'boolean') &&
+        (payload.expiresAt === undefined ||
+          (typeof payload.expiresAt === 'number' && Number.isFinite(payload.expiresAt))) &&
+        (payload.version === undefined ||
+          typeof payload.version === 'string' ||
+          (typeof payload.version === 'number' && Number.isFinite(payload.version)))
       );
     case 'approval.resolved':
       return (

--- a/packages/x-sdk/src/agent/reducer/reduceAgentState.ts
+++ b/packages/x-sdk/src/agent/reducer/reduceAgentState.ts
@@ -338,7 +338,7 @@ export function reduceAgentState(state: AgentState, event: AgentEvent): AgentSta
     case 'tool.requested': {
       const missingRun = requireRun(state, event);
       if (missingRun) return missingRun;
-      const { toolCallId, name, index, arguments: args = '' } = event.payload;
+      const { toolCallId, name, index, attempt = 1, retryOf, arguments: args = '' } = event.payload;
       const entityKey = getAgentEntityKey(event.runId, toolCallId);
       if (state.toolCalls[entityKey]) {
         return reject(
@@ -358,6 +358,8 @@ export function reduceAgentState(state: AgentState, event: AgentEvent): AgentSta
             name,
             arguments: args,
             index,
+            attempt,
+            retryOf,
             status: 'pending',
             createdAt: event.timestamp,
             updatedAt: event.timestamp,
@@ -426,7 +428,8 @@ export function reduceAgentState(state: AgentState, event: AgentEvent): AgentSta
     case 'approval.requested': {
       const missingRun = requireRun(state, event);
       if (missingRun) return missingRun;
-      const { approvalId, toolCallId, description, risk, data } = event.payload;
+      const { approvalId, toolCallId, description, risk, data, editable, expiresAt, version } =
+        event.payload;
       const entityKey = getAgentEntityKey(event.runId, approvalId);
       if (state.approvals[entityKey]) {
         return reject(state, event, 'duplicate_entity', `Approval "${approvalId}" already exists.`);
@@ -442,6 +445,9 @@ export function reduceAgentState(state: AgentState, event: AgentEvent): AgentSta
             description,
             risk,
             data,
+            editable,
+            expiresAt,
+            version,
             status: 'waiting',
             createdAt: event.timestamp,
             updatedAt: event.timestamp,

--- a/packages/x-sdk/src/agent/reducer/state.ts
+++ b/packages/x-sdk/src/agent/reducer/state.ts
@@ -71,6 +71,8 @@ export interface AgentToolCallState {
   name: string;
   arguments: string;
   index?: number;
+  attempt?: number;
+  retryOf?: string;
   result?: unknown;
   status: AgentEntityStatus;
   error?: AgentError;
@@ -88,6 +90,9 @@ export interface AgentApprovalState {
   description?: string;
   risk?: string;
   data?: unknown;
+  editable?: boolean;
+  expiresAt?: number;
+  version?: string | number;
   decision?: ApprovalDecision;
   status: AgentEntityStatus;
   createdAt: number;

--- a/packages/x-sdk/src/agent/selectors/__test__/selectors.test.ts
+++ b/packages/x-sdk/src/agent/selectors/__test__/selectors.test.ts
@@ -1,0 +1,85 @@
+import { createAgentEventFactory } from '../../protocol';
+import { createInitialAgentState, getAgentEntityKey, reduceAgentState } from '../../reducer';
+import {
+  selectAgentTimeline,
+  selectApproval,
+  selectRun,
+  selectRunningRuns,
+  selectToolCall,
+} from '..';
+
+describe('agent selectors', () => {
+  function createState() {
+    const first = createAgentEventFactory({ sessionId: 'session-1', runId: 'run-1', now: () => 1 });
+    const second = createAgentEventFactory({
+      sessionId: 'session-1',
+      runId: 'run-2',
+      now: () => 2,
+    });
+    const events = [
+      first.create('run.started', {}),
+      first.create('message.started', { messageId: 'message-1', role: 'assistant', content: 'Hi' }),
+      first.create('reasoning.started', { reasoningId: 'reasoning-1', redacted: true }),
+      first.create('reasoning.delta', { reasoningId: 'reasoning-1', delta: 'secret' }),
+      first.create('tool.requested', { toolCallId: 'tool-1', name: 'search' }),
+      first.create('approval.requested', { approvalId: 'approval-1', description: 'Approve' }),
+      second.create('run.started', {}),
+      second.create('message.started', { messageId: 'message-2', role: 'user', content: 'Other' }),
+    ];
+    return events.reduce(reduceAgentState, createInitialAgentState());
+  }
+
+  it('selects entities and memoizes running runs by session', () => {
+    const state = createState();
+    expect(selectRun(state, 'run-1')).toMatchObject({ id: 'run-1', status: 'running' });
+    expect(selectRun(state, 'missing')).toBeUndefined();
+    expect(selectToolCall(state, { runId: 'run-1', toolCallId: 'tool-1' })).toMatchObject({
+      name: 'search',
+    });
+    expect(selectApproval(state, { runId: 'run-1', approvalId: 'approval-1' })).toMatchObject({
+      status: 'waiting',
+    });
+
+    const first = selectRunningRuns(state, 'session-1');
+    expect(first.map(({ id }) => id)).toEqual(['run-1', 'run-2']);
+    expect(selectRunningRuns(state, 'session-1')).toBe(first);
+    expect(selectRunningRuns(state, 'other')).toEqual([]);
+  });
+
+  it('builds a stable timeline, filters runs and redacts reasoning content', () => {
+    const state = createState();
+    const timeline = selectAgentTimeline(state, { runId: 'run-1' });
+
+    expect(timeline.map(({ kind }) => kind)).toEqual(['message', 'reasoning', 'tool', 'approval']);
+    expect(timeline[1]).toMatchObject({
+      kind: 'reasoning',
+      entity: { content: '', redacted: true },
+    });
+    expect(selectAgentTimeline(state, { runId: 'run-1' })).toBe(timeline);
+    expect(
+      selectAgentTimeline(state, { runId: 'run-1', includeReasoning: false }).map(
+        ({ kind }) => kind,
+      ),
+    ).toEqual(['message', 'tool', 'approval']);
+    expect(selectAgentTimeline(state, { runId: 'run-2' }).map(({ kind }) => kind)).toEqual([
+      'message',
+    ]);
+  });
+
+  it('ignores stale and unsupported order references', () => {
+    const state = createState();
+    const withStaleOrder = {
+      ...state,
+      order: [
+        ...state.order,
+        { kind: 'message' as const, runId: 'run-1', id: 'missing-message' },
+        { kind: 'reasoning' as const, runId: 'run-1', id: 'missing-reasoning' },
+        { kind: 'tool' as const, runId: 'run-1', id: 'missing-tool' },
+        { kind: 'approval' as const, runId: 'run-1', id: 'missing-approval' },
+        { kind: 'task' as const, runId: 'run-1', id: 'missing-task' },
+      ],
+    };
+    expect(selectAgentTimeline(withStaleOrder, { runId: 'run-1' })).toHaveLength(4);
+    expect(withStaleOrder.messages[getAgentEntityKey('run-1', 'missing-message')]).toBeUndefined();
+  });
+});

--- a/packages/x-sdk/src/agent/selectors/entities.ts
+++ b/packages/x-sdk/src/agent/selectors/entities.ts
@@ -1,0 +1,38 @@
+import type { AgentState } from '../reducer';
+import { getAgentEntityKey } from '../reducer';
+
+const runningRunsCache = new WeakMap<
+  AgentState,
+  Map<string, ReturnType<typeof computeRunningRuns>>
+>();
+
+const computeRunningRuns = (state: AgentState, sessionId: string) =>
+  Object.values(state.runs).filter(
+    (run) => run.sessionId === sessionId && run.status === 'running',
+  );
+
+export function selectRun(state: AgentState, runId: string) {
+  return state.runs[runId];
+}
+
+export function selectToolCall(state: AgentState, options: { runId: string; toolCallId: string }) {
+  return state.toolCalls[getAgentEntityKey(options.runId, options.toolCallId)];
+}
+
+export function selectApproval(state: AgentState, options: { runId: string; approvalId: string }) {
+  return state.approvals[getAgentEntityKey(options.runId, options.approvalId)];
+}
+
+export function selectRunningRuns(state: AgentState, sessionId: string) {
+  let stateCache = runningRunsCache.get(state);
+  if (!stateCache) {
+    stateCache = new Map();
+    runningRunsCache.set(state, stateCache);
+  }
+  let runs = stateCache.get(sessionId);
+  if (!runs) {
+    runs = computeRunningRuns(state, sessionId);
+    stateCache.set(sessionId, runs);
+  }
+  return runs;
+}

--- a/packages/x-sdk/src/agent/selectors/index.ts
+++ b/packages/x-sdk/src/agent/selectors/index.ts
@@ -1,0 +1,3 @@
+export { selectApproval, selectRun, selectRunningRuns, selectToolCall } from './entities';
+export type { AgentTimelineEntry, SelectAgentTimelineOptions } from './selectAgentTimeline';
+export { selectAgentTimeline } from './selectAgentTimeline';

--- a/packages/x-sdk/src/agent/selectors/selectAgentTimeline.ts
+++ b/packages/x-sdk/src/agent/selectors/selectAgentTimeline.ts
@@ -1,0 +1,70 @@
+import type {
+  AgentApprovalState,
+  AgentMessageState,
+  AgentReasoningState,
+  AgentState,
+  AgentToolCallState,
+} from '../reducer';
+import { getAgentEntityKey } from '../reducer';
+
+export type AgentTimelineEntry =
+  | { kind: 'message'; entity: AgentMessageState }
+  | { kind: 'reasoning'; entity: AgentReasoningState }
+  | { kind: 'tool'; entity: AgentToolCallState }
+  | { kind: 'approval'; entity: AgentApprovalState };
+
+export interface SelectAgentTimelineOptions {
+  runId: string;
+  includeReasoning?: boolean;
+}
+
+const timelineCache = new WeakMap<AgentState, Map<string, readonly AgentTimelineEntry[]>>();
+
+export function selectAgentTimeline(
+  state: AgentState,
+  { runId, includeReasoning = true }: SelectAgentTimelineOptions,
+): readonly AgentTimelineEntry[] {
+  const cacheKey = `${runId.length}:${runId}:${includeReasoning}`;
+  let stateCache = timelineCache.get(state);
+  const cached = stateCache?.get(cacheKey);
+  if (cached) return cached;
+
+  const entries = state.order.flatMap((reference): AgentTimelineEntry[] => {
+    if (reference.runId !== runId) return [];
+    const entityKey = getAgentEntityKey(reference.runId, reference.id);
+
+    switch (reference.kind) {
+      case 'message': {
+        const entity = state.messages[entityKey];
+        return entity ? [{ kind: 'message', entity }] : [];
+      }
+      case 'reasoning': {
+        if (!includeReasoning) return [];
+        const entity = state.reasoning[entityKey];
+        if (!entity) return [];
+        return [
+          {
+            kind: 'reasoning',
+            entity: entity.redacted ? { ...entity, content: '' } : entity,
+          },
+        ];
+      }
+      case 'tool': {
+        const entity = state.toolCalls[entityKey];
+        return entity ? [{ kind: 'tool', entity }] : [];
+      }
+      case 'approval': {
+        const entity = state.approvals[entityKey];
+        return entity ? [{ kind: 'approval', entity }] : [];
+      }
+      default:
+        return [];
+    }
+  });
+  if (!stateCache) {
+    stateCache = new Map();
+    timelineCache.set(state, stateCache);
+  }
+  stateCache.set(cacheKey, entries);
+  return entries;
+}

--- a/packages/x-sdk/src/chat-providers/AgentProvider.ts
+++ b/packages/x-sdk/src/chat-providers/AgentProvider.ts
@@ -1,3 +1,4 @@
+import type { AgentCommand, AgentCommandType } from '../agent/command';
 import type {
   AgentEvent,
   AgentEventFactory,
@@ -10,7 +11,15 @@ export type AgentTransportKind = 'sse' | 'websocket' | 'async-iterable' | `${str
 export interface AgentProviderCapabilities {
   eventTypes: readonly AgentEventType[];
   transports: readonly AgentTransportKind[];
+  commands?: readonly AgentCommandType[];
+  resumable?: boolean;
   extensions?: Readonly<Record<`${string}.${string}`, unknown>>;
+}
+
+export interface AgentCommandOptions {
+  signal: AbortSignal;
+  initialSequence: number;
+  now?: () => number;
 }
 
 export interface AgentRunOptions {
@@ -41,6 +50,8 @@ export interface AgentProvider<Input, Request, Chunk, Context = unknown> {
   transformChunk(chunk: Chunk, context: Context): readonly AgentEvent[];
   flush(context: Context): readonly AgentEvent[];
   transformError(error: unknown, context: Context): readonly AgentEvent[];
+  classifyError?(error: unknown, context: Context): { retryable: boolean };
+  executeCommand?(command: AgentCommand, options: AgentCommandOptions): AsyncIterable<AgentEvent>;
 }
 
 export interface AgentTransport<Request, Chunk> {
@@ -52,6 +63,15 @@ export interface RunAgentProviderOptions<Input, Request, Chunk, Context> {
   provider: AgentProvider<Input, Request, Chunk, Context>;
   input: Input;
   run: AgentRunOptions;
+  onEvent: (event: AgentEvent) => void;
+}
+
+export interface RunAgentCommandOptions {
+  provider: AgentProvider<any, any, any, any>;
+  command: AgentCommand;
+  signal?: AbortSignal;
+  initialSequence: number;
+  now?: () => number;
   onEvent: (event: AgentEvent) => void;
 }
 

--- a/packages/x-sdk/src/chat-providers/__test__/runAgentCommand.test.ts
+++ b/packages/x-sdk/src/chat-providers/__test__/runAgentCommand.test.ts
@@ -1,0 +1,231 @@
+import type { AgentCommand, AgentEvent } from '../../agent';
+import {
+  AGENT_EVENT_PROTOCOL,
+  AGENT_EVENT_PROTOCOL_VERSION,
+  createAgentCommandFactory,
+  createAgentEventFactory,
+} from '../../agent';
+import type { AgentProvider } from '..';
+import { AgentCommandRunnerError, runAgentCommand } from '..';
+
+const commandFactory = createAgentCommandFactory({
+  sessionId: 'session-1',
+  runId: 'run-1',
+  now: () => 1,
+});
+
+function createProvider(
+  executeCommand?: AgentProvider<never, never, never>['executeCommand'],
+): AgentProvider<never, never, never> {
+  return {
+    id: 'command-provider',
+    protocol: { name: AGENT_EVENT_PROTOCOL, version: AGENT_EVENT_PROTOCOL_VERSION },
+    capabilities: {
+      eventTypes: ['approval.resolved', 'run.cancelled'],
+      transports: ['test.transport'],
+      commands: ['approval.resolve', 'run.cancel'],
+    },
+    transport: { kind: 'test.transport', async *open() {} },
+    createContext() {},
+    start() {
+      return [];
+    },
+    prepareRequest() {
+      throw new Error('not used');
+    },
+    transformChunk() {
+      return [];
+    },
+    flush() {
+      return [];
+    },
+    transformError() {
+      return [];
+    },
+    executeCommand,
+  };
+}
+
+function eventFactory(initialSequence = 2) {
+  return createAgentEventFactory({
+    sessionId: 'session-1',
+    runId: 'run-1',
+    initialSequence,
+    now: () => 10,
+  });
+}
+
+describe('runAgentCommand', () => {
+  it('emits declared command events in sequence', async () => {
+    const events = eventFactory();
+    const provider = createProvider(async function* () {
+      yield events.create('approval.resolved', {
+        approvalId: 'approval-1',
+        decision: 'approved',
+      });
+      yield events.create('run.cancelled', { reason: 'done' });
+    });
+    const emitted: AgentEvent[] = [];
+
+    await runAgentCommand({
+      provider,
+      command: commandFactory.create('approval.resolve', {
+        approvalId: 'approval-1',
+        decision: 'approved',
+      }),
+      initialSequence: 2,
+      now: () => 10,
+      onEvent: (event) => emitted.push(event),
+    });
+
+    expect(emitted.map(({ type, sequence }) => [type, sequence])).toEqual([
+      ['approval.resolved', 3],
+      ['run.cancelled', 4],
+    ]);
+  });
+
+  it('rejects invalid commands, protocols and unsupported capabilities', async () => {
+    const command = commandFactory.create('run.cancel', {});
+    await expect(
+      runAgentCommand({
+        provider: createProvider(async function* () {}),
+        command: { ...command, commandId: '' } as AgentCommand,
+        initialSequence: -1,
+        onEvent: () => {},
+      }),
+    ).rejects.toMatchObject({ code: 'invalid_command' });
+
+    const incompatible = {
+      ...createProvider(async function* () {}),
+      protocol: { name: AGENT_EVENT_PROTOCOL, version: '0.2' },
+    } as unknown as AgentProvider<never, never, never>;
+    await expect(
+      runAgentCommand({
+        provider: incompatible,
+        command,
+        initialSequence: -1,
+        onEvent: () => {},
+      }),
+    ).rejects.toMatchObject({ code: 'protocol_error' });
+
+    const unsupported = createProvider();
+    unsupported.capabilities.commands = [];
+    await expect(
+      runAgentCommand({
+        provider: unsupported,
+        command,
+        initialSequence: -1,
+        onEvent: () => {},
+      }),
+    ).rejects.toEqual(
+      new AgentCommandRunnerError(
+        'unsupported_capability',
+        'Provider "command-provider" does not support command "run.cancel".',
+      ),
+    );
+  });
+
+  it.each([
+    ['invalid event', (event: AgentEvent) => ({ ...event, payload: {} })],
+    ['wrong session', (event: AgentEvent) => ({ ...event, sessionId: 'other' })],
+    ['undeclared type', (event: AgentEvent) => ({ ...event, type: 'task.created' })],
+    ['old sequence', (event: AgentEvent) => ({ ...event, sequence: 2 })],
+  ])('rejects %s from the provider', async (_name, mutate) => {
+    const events = eventFactory();
+    const provider = createProvider(async function* () {
+      yield mutate(
+        events.create('approval.resolved', {
+          approvalId: 'approval-1',
+          decision: 'approved',
+        }),
+      ) as AgentEvent;
+    });
+
+    await expect(
+      runAgentCommand({
+        provider,
+        command: commandFactory.create('approval.resolve', {
+          approvalId: 'approval-1',
+          decision: 'approved',
+        }),
+        initialSequence: 2,
+        onEvent: () => {},
+      }),
+    ).rejects.toMatchObject({ code: 'protocol_error' });
+  });
+
+  it('rethrows consumer failures without wrapping them', async () => {
+    const consumerError = new Error('consumer failed');
+    const events = eventFactory();
+    const provider = createProvider(async function* () {
+      yield events.create('run.cancelled', {});
+    });
+
+    await expect(
+      runAgentCommand({
+        provider,
+        command: commandFactory.create('run.cancel', {}),
+        initialSequence: 2,
+        onEvent: () => {
+          throw consumerError;
+        },
+      }),
+    ).rejects.toBe(consumerError);
+  });
+
+  it('honors aborts before and during command iteration', async () => {
+    const before = new AbortController();
+    before.abort('before');
+    await expect(
+      runAgentCommand({
+        provider: createProvider(async function* () {}),
+        command: commandFactory.create('run.cancel', {}),
+        signal: before.signal,
+        initialSequence: -1,
+        onEvent: () => {},
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    const during = new AbortController();
+    const events = eventFactory(-1);
+    const provider = createProvider(async function* () {
+      yield events.create('approval.resolved', {
+        approvalId: 'approval-1',
+        decision: 'approved',
+      });
+      yield events.create('run.cancelled', {});
+    });
+    await expect(
+      runAgentCommand({
+        provider,
+        command: commandFactory.create('approval.resolve', {
+          approvalId: 'approval-1',
+          decision: 'approved',
+        }),
+        signal: during.signal,
+        initialSequence: -1,
+        onEvent: () => during.abort('during'),
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('propagates provider failures and removes the external abort listener', async () => {
+    const failure = new Error('provider failed');
+    const provider = createProvider(async function* () {
+      yield await Promise.reject(failure);
+    });
+    const controller = new AbortController();
+    const removeEventListener = jest.spyOn(controller.signal, 'removeEventListener');
+
+    await expect(
+      runAgentCommand({
+        provider,
+        command: commandFactory.create('run.cancel', {}),
+        signal: controller.signal,
+        initialSequence: -1,
+        onEvent: () => {},
+      }),
+    ).rejects.toBe(failure);
+    expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+});

--- a/packages/x-sdk/src/chat-providers/__test__/runAgentCommand.test.ts
+++ b/packages/x-sdk/src/chat-providers/__test__/runAgentCommand.test.ts
@@ -128,7 +128,14 @@ describe('runAgentCommand', () => {
   it.each([
     ['invalid event', (event: AgentEvent) => ({ ...event, payload: {} })],
     ['wrong session', (event: AgentEvent) => ({ ...event, sessionId: 'other' })],
-    ['undeclared type', (event: AgentEvent) => ({ ...event, type: 'task.created' })],
+    [
+      'undeclared type',
+      (event: AgentEvent) => ({
+        ...event,
+        type: 'task.created',
+        payload: { taskId: 'task-1', title: 'Task' },
+      }),
+    ],
     ['old sequence', (event: AgentEvent) => ({ ...event, sequence: 2 })],
   ])('rejects %s from the provider', async (_name, mutate) => {
     const events = eventFactory();
@@ -205,6 +212,28 @@ describe('runAgentCommand', () => {
         signal: during.signal,
         initialSequence: -1,
         onEvent: () => during.abort('during'),
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    const after = new AbortController();
+    const afterProvider = createProvider();
+    afterProvider.executeCommand = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next() {
+            after.abort('after');
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    });
+    await expect(
+      runAgentCommand({
+        provider: afterProvider,
+        command: commandFactory.create('run.cancel', {}),
+        signal: after.signal,
+        initialSequence: -1,
+        onEvent: () => {},
       }),
     ).rejects.toMatchObject({ name: 'AbortError' });
   });

--- a/packages/x-sdk/src/chat-providers/index.ts
+++ b/packages/x-sdk/src/chat-providers/index.ts
@@ -1,18 +1,22 @@
 export type { ChatProviderConfig, TransformMessage } from './AbstractChatProvider';
 export { default as AbstractChatProvider } from './AbstractChatProvider';
 export type {
+  AgentCommandOptions,
   AgentProvider,
   AgentProviderCapabilities,
   AgentProviderContextOptions,
   AgentRunOptions,
   AgentTransport,
   AgentTransportKind,
+  RunAgentCommandOptions,
   RunAgentProviderOptions,
 } from './AgentProvider';
 export { isAgentProvider } from './AgentProvider';
 export { default as DeepSeekChatProvider } from './DeepSeekChatProvider';
 export { default as DefaultChatProvider } from './DefaultChatProvider';
 export { default as OpenAIChatProvider } from './OpenAIChatProvider';
+export type { AgentCommandRunnerErrorCode } from './runAgentCommand';
+export { AgentCommandRunnerError, runAgentCommand } from './runAgentCommand';
 export { runAgentProvider } from './runAgentProvider';
 export type { AgentProviderContractIssue } from './testing/validateAgentProviderEvents';
 export { validateAgentProviderEvents } from './testing/validateAgentProviderEvents';

--- a/packages/x-sdk/src/chat-providers/runAgentCommand.ts
+++ b/packages/x-sdk/src/chat-providers/runAgentCommand.ts
@@ -1,0 +1,110 @@
+import type { AgentEvent } from '../agent';
+import { AGENT_EVENT_PROTOCOL_VERSION, isAgentCommand, isAgentEvent } from '../agent';
+import type { RunAgentCommandOptions } from './AgentProvider';
+
+class AgentCommandConsumerError extends Error {
+  cause: unknown;
+
+  constructor(cause: unknown) {
+    super('Agent command event consumer failed.');
+    this.cause = cause;
+  }
+}
+
+export type AgentCommandRunnerErrorCode =
+  | 'unsupported_capability'
+  | 'invalid_command'
+  | 'protocol_error';
+
+export class AgentCommandRunnerError extends Error {
+  code: AgentCommandRunnerErrorCode;
+
+  constructor(code: AgentCommandRunnerErrorCode, message: string) {
+    super(message);
+    this.name = 'AgentCommandRunnerError';
+    this.code = code;
+  }
+}
+
+export async function runAgentCommand(options: RunAgentCommandOptions): Promise<void> {
+  const { provider, command, onEvent } = options;
+  if (!isAgentCommand(command)) {
+    throw new AgentCommandRunnerError('invalid_command', 'Agent command is invalid.');
+  }
+  if (provider.protocol.version !== AGENT_EVENT_PROTOCOL_VERSION) {
+    throw new AgentCommandRunnerError(
+      'protocol_error',
+      `Provider "${provider.id}" uses unsupported agent protocol "${provider.protocol.version}".`,
+    );
+  }
+  if (!provider.capabilities.commands?.includes(command.type) || !provider.executeCommand) {
+    throw new AgentCommandRunnerError(
+      'unsupported_capability',
+      `Provider "${provider.id}" does not support command "${command.type}".`,
+    );
+  }
+
+  const controller = new AbortController();
+  const externalSignal = options.signal;
+  const abort = () => controller.abort(externalSignal?.reason);
+  externalSignal?.addEventListener('abort', abort, { once: true });
+  if (externalSignal?.aborted) abort();
+
+  let lastSequence = options.initialSequence;
+  const emit = (event: AgentEvent) => {
+    if (!isAgentEvent(event)) {
+      throw new AgentCommandRunnerError(
+        'protocol_error',
+        `Provider "${provider.id}" emitted an invalid command event.`,
+      );
+    }
+    if (event.sessionId !== command.sessionId || event.runId !== command.runId) {
+      throw new AgentCommandRunnerError(
+        'protocol_error',
+        `Provider "${provider.id}" emitted a command event outside the active session or run.`,
+      );
+    }
+    if (!provider.capabilities.eventTypes.includes(event.type)) {
+      throw new AgentCommandRunnerError(
+        'protocol_error',
+        `Provider "${provider.id}" emitted undeclared event type "${event.type}".`,
+      );
+    }
+    if (event.sequence <= lastSequence) {
+      throw new AgentCommandRunnerError(
+        'protocol_error',
+        `Command event sequence ${event.sequence} must be greater than ${lastSequence}.`,
+      );
+    }
+    try {
+      onEvent(event);
+    } catch (error) {
+      throw new AgentCommandConsumerError(error);
+    }
+    lastSequence = event.sequence;
+  };
+
+  try {
+    if (controller.signal.aborted) {
+      throw new DOMException('Agent command was interrupted.', 'AbortError');
+    }
+    for await (const event of provider.executeCommand(command, {
+      signal: controller.signal,
+      initialSequence: options.initialSequence,
+      now: options.now,
+    })) {
+      if (controller.signal.aborted) {
+        throw new DOMException('Agent command was interrupted.', 'AbortError');
+      }
+      emit(event);
+    }
+    if (controller.signal.aborted) {
+      throw new DOMException('Agent command was interrupted.', 'AbortError');
+    }
+  } catch (error) {
+    if (error instanceof AgentCommandConsumerError) throw error.cause;
+    throw error;
+  } finally {
+    externalSignal?.removeEventListener('abort', abort);
+  }
+}

--- a/packages/x-sdk/src/chat-providers/runAgentProvider.ts
+++ b/packages/x-sdk/src/chat-providers/runAgentProvider.ts
@@ -69,6 +69,7 @@ export async function runAgentProvider<Input, Request, Chunk, Context>(
   } catch (error) {
     if (error instanceof AgentEventConsumerError) throw error.cause;
     if (error instanceof AgentProviderProtocolError) throw error;
+    if (controller.signal.aborted) return;
     provider.transformError(error, context).forEach(emit);
   } finally {
     externalSignal?.removeEventListener('abort', abort);

--- a/packages/x-sdk/src/index.ts
+++ b/packages/x-sdk/src/index.ts
@@ -5,7 +5,18 @@ export type {
   XModelParams,
   XModelResponse,
 } from './chat-providers/types/model';
-export type { AgentXChatConfig, DefaultMessageInfo, MessageInfo, XChatConfig } from './x-chat';
+export type {
+  AgentActionResult,
+  AgentActions,
+  AgentCommandError,
+  AgentCommandState,
+  AgentCommandStatus,
+  AgentXChatConfig,
+  DefaultMessageInfo,
+  MessageInfo,
+  ResolveApprovalInput,
+  XChatConfig,
+} from './x-chat';
 export { default as useXChat } from './x-chat';
 export type { ConversationData } from './x-conversations';
 export { default as useXConversations } from './x-conversations';

--- a/packages/x-sdk/src/x-chat/__test__/agentCommandStore.test.ts
+++ b/packages/x-sdk/src/x-chat/__test__/agentCommandStore.test.ts
@@ -1,0 +1,102 @@
+import { createAgentCommandFactory, getAgentCommandActionKey } from '../../agent';
+import { createAgentCommandStore } from '../agentCommandStore';
+
+describe('createAgentCommandStore', () => {
+  const factory = createAgentCommandFactory({
+    sessionId: 'session-1',
+    runId: 'run-1',
+    now: () => 10,
+  });
+
+  it('tracks command lifecycle and notifies subscribers', () => {
+    const store = createAgentCommandStore();
+    const listener = jest.fn();
+    const unsubscribe = store.subscribe(listener);
+    const command = factory.create('tool.retry', { toolCallId: 'tool-1' });
+
+    expect(store.start(command)).toMatchObject({
+      command,
+      key: command.commandId,
+      status: 'submitting',
+      createdAt: 10,
+      updatedAt: 10,
+    });
+    expect(store.getSnapshot().latestCommandByAction[getAgentCommandActionKey(command)]).toBe(
+      command.commandId,
+    );
+
+    store.succeed(command.commandId, 20);
+    expect(store.getSnapshot().commandStates[command.commandId]).toMatchObject({
+      status: 'succeeded',
+      updatedAt: 20,
+    });
+
+    const error = { code: 'provider_error' as const, message: 'failed', retryable: true };
+    store.fail(command.commandId, error, 30);
+    expect(store.getSnapshot().commandStates[command.commandId]).toMatchObject({
+      status: 'failed',
+      error,
+      updatedAt: 30,
+    });
+    expect(listener).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    store.succeed(command.commandId, 40);
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it('ignores unknown commands and uses the current time by default', () => {
+    const store = createAgentCommandStore();
+    const listener = jest.fn();
+    store.subscribe(listener);
+    const now = jest.spyOn(Date, 'now').mockReturnValue(50);
+    const command = factory.create('run.cancel', {});
+
+    store.succeed('missing');
+    store.fail('missing', { code: 'provider_error', message: 'missing', retryable: false });
+    expect(listener).not.toHaveBeenCalled();
+
+    store.start(command);
+    store.succeed(command.commandId);
+    expect(store.getSnapshot().commandStates[command.commandId].updatedAt).toBe(50);
+    now.mockRestore();
+  });
+
+  it('clears one run while optionally retaining submitting commands', () => {
+    const store = createAgentCommandStore();
+    const otherFactory = createAgentCommandFactory({
+      sessionId: 'session-1',
+      runId: 'run-2',
+      now: () => 10,
+    });
+    const submitting = factory.create('approval.resolve', {
+      approvalId: 'approval-1',
+      decision: 'approved',
+    });
+    const completed = factory.create('tool.retry', { toolCallId: 'tool-1' });
+    const otherRun = otherFactory.create('run.cancel', {});
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.start(submitting);
+    store.start(completed);
+    store.succeed(completed.commandId, 20);
+    store.start(otherRun);
+    store.clearRun('run-1', true);
+
+    expect(Object.keys(store.getSnapshot().commandStates)).toEqual([
+      submitting.commandId,
+      otherRun.commandId,
+    ]);
+    expect(store.getSnapshot().latestCommandByAction).toEqual({
+      [getAgentCommandActionKey(submitting)]: submitting.commandId,
+      [getAgentCommandActionKey(otherRun)]: otherRun.commandId,
+    });
+
+    const calls = listener.mock.calls.length;
+    store.clearRun('missing');
+    expect(listener).toHaveBeenCalledTimes(calls);
+    store.clearRun('run-1');
+    expect(Object.values(store.getSnapshot().commandStates)).toHaveLength(1);
+  });
+});

--- a/packages/x-sdk/src/x-chat/__test__/agentRuntime.test.tsx
+++ b/packages/x-sdk/src/x-chat/__test__/agentRuntime.test.tsx
@@ -1,0 +1,484 @@
+import { act, renderHook } from '../../../tests/utils';
+import type {
+  AgentCommand,
+  AgentCommandType,
+  AgentEvent,
+  AgentEventFactory,
+  AgentState,
+} from '../../agent';
+import {
+  AGENT_EVENT_PROTOCOL,
+  AGENT_EVENT_PROTOCOL_VERSION,
+  createAgentEventFactory,
+  createInitialAgentState,
+  getAgentEntityKey,
+} from '../../agent';
+import type { AgentCommandOptions, AgentProvider } from '../../chat-providers';
+import { projectAgentMessages, useAgentChatRuntime } from '../agentRuntime';
+import useXChat from '../index';
+
+interface FixtureContext {
+  events: AgentEventFactory;
+}
+
+interface ProviderOptions {
+  commands?: readonly AgentCommandType[];
+  start?: (input: string, context: FixtureContext) => readonly AgentEvent[];
+  executeCommand?: (
+    command: AgentCommand,
+    options: AgentCommandOptions,
+  ) => AsyncIterable<AgentEvent>;
+}
+
+const eventTypes = [
+  'run.started',
+  'run.cancelled',
+  'message.started',
+  'message.completed',
+  'approval.requested',
+  'approval.resolved',
+  'tool.requested',
+  'tool.running',
+  'tool.completed',
+  'tool.failed',
+  'task.created',
+  'task.cancelled',
+] as const;
+
+function createProvider(
+  options: ProviderOptions = {},
+): AgentProvider<string, string, never, FixtureContext> {
+  const provider: AgentProvider<string, string, never, FixtureContext> = {
+    id: 'interaction-provider',
+    protocol: { name: AGENT_EVENT_PROTOCOL, version: AGENT_EVENT_PROTOCOL_VERSION },
+    capabilities: {
+      eventTypes,
+      transports: ['test.pending'],
+      commands: options.commands ?? ['approval.resolve', 'tool.retry', 'run.cancel'],
+    },
+    transport: {
+      kind: 'test.pending',
+      open() {
+        return {
+          [Symbol.asyncIterator]() {
+            return { next: () => new Promise<IteratorResult<never>>(() => {}) };
+          },
+        };
+      },
+    },
+    createContext({ events }) {
+      return { events };
+    },
+    start(input, context) {
+      return options.start?.(input, context) ?? [context.events.create('run.started', { input })];
+    },
+    prepareRequest(input) {
+      return input;
+    },
+    transformChunk() {
+      return [];
+    },
+    flush() {
+      return [];
+    },
+    transformError() {
+      return [];
+    },
+  };
+  if (options.executeCommand) provider.executeCommand = options.executeCommand;
+  return provider;
+}
+
+const createCommandEvents = (command: AgentCommand, options: AgentCommandOptions) =>
+  createAgentEventFactory({
+    sessionId: command.sessionId,
+    runId: command.runId,
+    initialSequence: options.initialSequence,
+    now: () => 10,
+  });
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function startRun(result: React.RefObject<any>, input = 'start') {
+  act(() => result.current.onRequest(input));
+  await flush();
+  const runIds = Object.keys(result.current.agentState.runs);
+  return runIds[runIds.length - 1];
+}
+
+const getLatestCommand = (result: React.RefObject<any>) => {
+  const commands = Object.values(result.current.commandStates);
+  return commands[commands.length - 1];
+};
+
+describe('useAgentChatRuntime', () => {
+  it('resolves approvals, retries tools and cancels a running task', async () => {
+    const provider = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', {
+            approvalId: 'approval-1',
+            editable: true,
+            version: 1,
+          }),
+          events.create('tool.requested', { toolCallId: 'tool-1', name: 'search' }),
+          events.create('tool.failed', {
+            toolCallId: 'tool-1',
+            error: { message: 'timeout', retryable: true },
+          }),
+          events.create('task.created', { taskId: 'task-1', title: 'Long task' }),
+        ];
+      },
+      async *executeCommand(command, commandOptions) {
+        const events = createCommandEvents(command, commandOptions);
+        if (command.type === 'approval.resolve') {
+          yield events.create('approval.resolved', {
+            approvalId: command.payload.approvalId,
+            decision: command.payload.decision,
+            data: command.payload.data,
+          });
+        } else if (command.type === 'tool.retry') {
+          yield events.create('tool.requested', {
+            toolCallId: 'tool-2',
+            name: 'search',
+            attempt: 2,
+            retryOf: command.payload.toolCallId,
+          });
+          yield events.create('tool.running', { toolCallId: 'tool-2' });
+          yield events.create('tool.completed', { toolCallId: 'tool-2', result: 'ok' });
+        } else {
+          yield events.create('task.cancelled', {
+            taskId: 'task-1',
+            reason: command.payload.reason,
+          });
+          yield events.create('run.cancelled', { reason: command.payload.reason });
+        }
+      },
+    });
+    const conversationKey = 'agent-runtime-success';
+    const { result } = renderHook(() => useXChat({ provider, conversationKey }));
+    const runId = await startRun(result);
+
+    let approvalResult: any;
+    await act(async () => {
+      approvalResult = await result.current!.agentActions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'approved',
+        data: { approvedBy: 'user' },
+        expectedVersion: 1,
+      });
+    });
+    expect(approvalResult).toEqual({
+      commandId: expect.any(String),
+      idempotencyKey: expect.any(String),
+    });
+    expect(
+      result.current!.agentState.approvals[getAgentEntityKey(runId, 'approval-1')],
+    ).toMatchObject({ status: 'completed', decision: 'approved', data: { approvedBy: 'user' } });
+    expect(Object.values(result.current!.commandStates)[0]).toMatchObject({ status: 'succeeded' });
+
+    await act(async () => {
+      await result.current!.agentActions.retryTool({ runId, toolCallId: 'tool-1' });
+    });
+    expect(result.current!.agentState.toolCalls[getAgentEntityKey(runId, 'tool-2')]).toMatchObject({
+      status: 'completed',
+      attempt: 2,
+      retryOf: 'tool-1',
+      result: 'ok',
+    });
+    expect(Object.values(result.current!.commandStates)).toHaveLength(2);
+
+    await act(async () => {
+      await result.current!.agentActions.cancelRun({ runId, reason: 'user cancelled' });
+    });
+    expect(result.current!.agentState.runs[runId]).toMatchObject({
+      status: 'cancelled',
+      reason: 'user cancelled',
+    });
+    expect(result.current!.agentState.tasks[getAgentEntityKey(runId, 'task-1')]).toMatchObject({
+      status: 'cancelled',
+    });
+    expect(result.current!.commandStates).toEqual({});
+    expect(result.current!.isRequesting).toBe(false);
+  });
+
+  it('validates entity state before creating commands', async () => {
+    const provider = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', {
+            approvalId: 'approval-1',
+            editable: false,
+            expiresAt: 1,
+            version: 1,
+          }),
+          events.create('tool.requested', { toolCallId: 'pending-tool', name: 'pending' }),
+          events.create('tool.requested', { toolCallId: 'fixed-tool', name: 'fixed' }),
+          events.create('tool.failed', {
+            toolCallId: 'fixed-tool',
+            error: { message: 'fixed', retryable: false },
+          }),
+        ];
+      },
+      async *executeCommand() {},
+    });
+    const conversationKey = 'agent-runtime-validation';
+    const { result } = renderHook(() => useXChat({ provider, conversationKey }));
+    const runId = await startRun(result);
+    const actions = result.current!.agentActions;
+
+    expect(() =>
+      actions.resolveApproval({
+        runId,
+        approvalId: 'missing',
+        decision: 'approved',
+      }),
+    ).toThrow('is not waiting');
+    expect(() =>
+      actions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'modified',
+      }),
+    ).toThrow('is not editable');
+    expect(() =>
+      actions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'approved',
+        expectedVersion: 2,
+      }),
+    ).toThrow('version does not match');
+    expect(() =>
+      actions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'approved',
+        expectedVersion: 1,
+      }),
+    ).toThrow('has expired');
+    expect(() => actions.retryTool({ runId, toolCallId: 'missing' })).toThrow('is not failed');
+    expect(() => actions.retryTool({ runId, toolCallId: 'pending-tool' })).toThrow('is not failed');
+    expect(() => actions.retryTool({ runId, toolCallId: 'fixed-tool' })).toThrow(
+      'is not retryable',
+    );
+    expect(() => actions.cancelRun({ runId: 'missing' })).toThrow(
+      'does not exist in the active session',
+    );
+  });
+
+  it('rejects unsupported and duplicate actions', async () => {
+    const unsupported = createProvider({ commands: [], async *executeCommand() {} });
+    const unsupportedKey = 'agent-runtime-unsupported';
+    const unsupportedResult = renderHook(() =>
+      useXChat({ provider: unsupported, conversationKey: unsupportedKey }),
+    ).result;
+    const unsupportedRun = await startRun(unsupportedResult);
+    expect(() =>
+      unsupportedResult.current!.agentActions.cancelRun({ runId: unsupportedRun }),
+    ).toThrow('does not support command "run.cancel"');
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const pending = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', { approvalId: 'approval-1' }),
+          events.create('tool.requested', { toolCallId: 'tool-1', name: 'search' }),
+          events.create('tool.failed', {
+            toolCallId: 'tool-1',
+            error: { message: 'timeout', retryable: true },
+          }),
+        ];
+      },
+      async *executeCommand(command, commandOptions) {
+        await gate;
+        const events = createCommandEvents(command, commandOptions);
+        if (command.type === 'run.cancel') return;
+        yield events.create('approval.resolved', {
+          approvalId: 'approval-1',
+          decision: 'approved',
+        });
+      },
+    });
+    const pendingKey = 'agent-runtime-pending';
+    const pendingResult = renderHook(() =>
+      useXChat({ provider: pending, conversationKey: pendingKey }),
+    ).result;
+    const pendingRun = await startRun(pendingResult);
+    let first!: Promise<any>;
+    act(() => {
+      first = pendingResult.current!.agentActions.resolveApproval({
+        runId: pendingRun,
+        approvalId: 'approval-1',
+        decision: 'approved',
+      });
+    });
+    expect(() =>
+      pendingResult.current!.agentActions.resolveApproval({
+        runId: pendingRun,
+        approvalId: 'approval-1',
+        decision: 'approved',
+      }),
+    ).toThrow('has already been submitted');
+    release();
+    await act(async () => first);
+
+    await act(async () => {
+      await pendingResult.current!.agentActions.cancelRun({ runId: pendingRun });
+    });
+    expect(() => pendingResult.current!.agentActions.cancelRun({ runId: pendingRun })).toThrow(
+      'has already been submitted',
+    );
+    expect(() =>
+      pendingResult.current!.agentActions.retryTool({ runId: pendingRun, toolCallId: 'tool-1' }),
+    ).toThrow('cancellation has already been submitted');
+  });
+
+  it('records provider, runner and protocol failures on command state', async () => {
+    let mode: 'provider' | 'runner' | 'protocol' = 'provider';
+    const provider = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', { approvalId: 'approval-1' }),
+          events.create('tool.requested', { toolCallId: 'tool-1', name: 'search' }),
+          events.create('tool.failed', {
+            toolCallId: 'tool-1',
+            error: { message: 'timeout', retryable: true },
+          }),
+        ];
+      },
+      async *executeCommand(command, commandOptions) {
+        if (mode === 'provider') throw { message: 'offline', retryable: true };
+        const events = createCommandEvents(command, commandOptions);
+        if (mode === 'runner') {
+          yield events.create(
+            'approval.resolved',
+            { approvalId: 'approval-1', decision: 'approved' },
+            { sequence: commandOptions.initialSequence },
+          );
+          return;
+        }
+        yield events.create('approval.resolved', {
+          approvalId: 'missing-approval',
+          decision: 'approved',
+        });
+      },
+    });
+    const conversationKey = 'agent-runtime-errors';
+    const { result } = renderHook(() => useXChat({ provider, conversationKey }));
+    const runId = await startRun(result);
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current!.agentActions.resolveApproval({
+          runId,
+          approvalId: 'approval-1',
+          decision: 'approved',
+        });
+      } catch (error) {
+        caught = error;
+      }
+    });
+    expect(caught).toEqual({ message: 'offline', retryable: true });
+    expect(getLatestCommand(result)).toMatchObject({
+      status: 'failed',
+      error: { code: 'provider_error', retryable: true },
+    });
+
+    mode = 'runner';
+    await act(async () => {
+      try {
+        await result.current!.agentActions.retryTool({ runId, toolCallId: 'tool-1' });
+      } catch (error) {
+        caught = error;
+      }
+    });
+    expect(caught).toMatchObject({ code: 'protocol_error' });
+    expect(getLatestCommand(result)).toMatchObject({
+      error: { code: 'protocol_error', retryable: false },
+    });
+
+    mode = 'protocol';
+    await act(async () => {
+      try {
+        await result.current!.agentActions.retryTool({ runId, toolCallId: 'tool-1' });
+      } catch (error) {
+        caught = error;
+      }
+    });
+    expect(caught).toMatchObject({ name: 'AgentProtocolError' });
+    expect(getLatestCommand(result)).toMatchObject({
+      error: { code: 'protocol_error', retryable: false },
+    });
+  });
+
+  it('guards runtime methods when no AgentProvider is configured', () => {
+    const key = Symbol('no-provider');
+    const { result } = renderHook(() => useAgentChatRuntime(undefined, key));
+    expect(() => result.current!.onRequest('hello')).toThrow('provider is required');
+    expect(() =>
+      result.current!.agentActions.resolveApproval({
+        runId: 'run-1',
+        approvalId: 'approval-1',
+        decision: 'approved',
+      }),
+    ).toThrow('provider is required');
+    expect(() =>
+      result.current!.agentActions.retryTool({ runId: 'run-1', toolCallId: 'tool-1' }),
+    ).toThrow('provider is required');
+    expect(() => result.current!.agentActions.cancelRun({ runId: 'run-1' })).toThrow(
+      'provider is required',
+    );
+    expect(result.current!.abort()).toBeUndefined();
+  });
+
+  it('projects agent messages to legacy message statuses', () => {
+    const base = createInitialAgentState();
+    const statuses = [
+      ['user', 'streaming', 'local'],
+      ['assistant-completed', 'completed', 'success'],
+      ['assistant-failed', 'failed', 'error'],
+      ['assistant-cancelled', 'cancelled', 'abort'],
+      ['assistant-streaming', 'streaming', 'updating'],
+    ] as const;
+    const state: AgentState = {
+      ...base,
+      messages: Object.fromEntries(
+        statuses.map(([id, status]) => [
+          getAgentEntityKey('run-1', id),
+          {
+            id,
+            runId: 'run-1',
+            role: id === 'user' ? 'user' : 'assistant',
+            content: id,
+            status,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]),
+      ),
+      order: [
+        { kind: 'task', runId: 'run-1', id: 'task-1' },
+        ...statuses.map(([id]) => ({ kind: 'message' as const, runId: 'run-1', id })),
+        { kind: 'message', runId: 'run-1', id: 'missing' },
+      ],
+    };
+    expect(projectAgentMessages(state).map(({ status }) => status)).toEqual(
+      statuses.map(([, , status]) => status),
+    );
+  });
+});

--- a/packages/x-sdk/src/x-chat/__test__/agentRuntime.test.tsx
+++ b/packages/x-sdk/src/x-chat/__test__/agentRuntime.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from '../../../tests/utils';
+import React from 'react';
+import { act, render, renderHook } from '../../../tests/utils';
 import type {
   AgentCommand,
   AgentCommandType,
@@ -424,6 +425,212 @@ describe('useAgentChatRuntime', () => {
     expect(getLatestCommand(result)).toMatchObject({
       error: { code: 'protocol_error', retryable: false },
     });
+  });
+
+  it('continues queued commands after an earlier command fails', async () => {
+    const provider = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', { approvalId: 'approval-1' }),
+          events.create('tool.requested', { toolCallId: 'tool-1', name: 'search' }),
+          events.create('tool.failed', {
+            toolCallId: 'tool-1',
+            error: { message: 'timeout', retryable: true },
+          }),
+        ];
+      },
+      async *executeCommand(command, commandOptions) {
+        if (command.type === 'approval.resolve') throw new Error('approval failed');
+        const events = createCommandEvents(command, commandOptions);
+        yield events.create('tool.requested', {
+          toolCallId: 'tool-2',
+          name: 'search',
+          attempt: 2,
+          retryOf: 'tool-1',
+        });
+        yield events.create('tool.completed', { toolCallId: 'tool-2', result: 'ok' });
+      },
+    });
+    const conversationKey = 'agent-runtime-queue-after-error';
+    const { result } = renderHook(() => useXChat({ provider, conversationKey }));
+    const runId = await startRun(result);
+    let approval!: Promise<any>;
+    let retry!: Promise<any>;
+
+    act(() => {
+      approval = result.current!.agentActions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'approved',
+      });
+      retry = result.current!.agentActions.retryTool({ runId, toolCallId: 'tool-1' });
+    });
+    let settled!: PromiseSettledResult<any>[];
+    await act(async () => {
+      settled = await Promise.allSettled([approval, retry]);
+    });
+
+    expect(settled.map(({ status }) => status)).toEqual(['rejected', 'fulfilled']);
+    expect(result.current!.agentState.toolCalls[getAgentEntityKey(runId, 'tool-2')]).toMatchObject({
+      status: 'completed',
+    });
+  });
+
+  it('aborts other queued commands when a command terminates the run', async () => {
+    const provider = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', { approvalId: 'approval-1' }),
+          events.create('tool.requested', { toolCallId: 'tool-1', name: 'search' }),
+          events.create('tool.failed', {
+            toolCallId: 'tool-1',
+            error: { message: 'timeout', retryable: true },
+          }),
+        ];
+      },
+      async *executeCommand(command, commandOptions) {
+        const events = createCommandEvents(command, commandOptions);
+        yield events.create('run.cancelled', { reason: 'runtime stopped' });
+      },
+    });
+    const conversationKey = 'agent-runtime-terminal-queue';
+    const { result } = renderHook(() => useXChat({ provider, conversationKey }));
+    const runId = await startRun(result);
+    let approval!: Promise<any>;
+    let retry!: Promise<any>;
+
+    act(() => {
+      approval = result.current!.agentActions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'approved',
+      });
+      retry = result.current!.agentActions.retryTool({ runId, toolCallId: 'tool-1' });
+    });
+    let settled!: PromiseSettledResult<any>[];
+    await act(async () => {
+      settled = await Promise.allSettled([approval, retry]);
+    });
+
+    expect(settled[0].status).toBe('fulfilled');
+    expect(settled[1]).toMatchObject({
+      status: 'rejected',
+      reason: { code: 'invalid_command', message: expect.stringContaining('already cancelled') },
+    });
+  });
+
+  it('rejects command events overtaken by the active run stream', async () => {
+    let releaseTransport!: () => void;
+    const transportGate = new Promise<void>((resolve) => {
+      releaseTransport = resolve;
+    });
+    let releaseCommand!: () => void;
+    const commandGate = new Promise<void>((resolve) => {
+      releaseCommand = resolve;
+    });
+    const provider = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', { approvalId: 'approval-1' }),
+        ];
+      },
+      async *executeCommand(command, commandOptions) {
+        const events = createCommandEvents(command, commandOptions);
+        await commandGate;
+        yield events.create('approval.resolved', {
+          approvalId: 'approval-1',
+          decision: 'approved',
+        });
+      },
+    });
+    provider.transport.open = () => {
+      let emitted = false;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              if (emitted) return new Promise<IteratorResult<never>>(() => {});
+              emitted = true;
+              await transportGate;
+              return { done: false, value: undefined as never };
+            },
+          };
+        },
+      };
+    };
+    provider.transformChunk = (_chunk, context) => [
+      context.events.create('task.created', { taskId: 'task-1', title: 'Concurrent task' }),
+    ];
+    const conversationKey = 'agent-runtime-sequence-race';
+    const { result } = renderHook(() => useXChat({ provider, conversationKey }));
+    const runId = await startRun(result);
+    let action!: Promise<any>;
+    act(() => {
+      action = result.current!.agentActions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'approved',
+      });
+    });
+    releaseTransport();
+    await flush();
+    releaseCommand();
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await action;
+      } catch (error) {
+        caught = error;
+      }
+    });
+    expect(caught).toMatchObject({
+      code: 'protocol_error',
+      message: expect.stringContaining('must be greater than'),
+    });
+  });
+
+  it('interrupts active commands when the hook unmounts', async () => {
+    const provider = createProvider({
+      start(input, { events }) {
+        return [
+          events.create('run.started', { input }),
+          events.create('approval.requested', { approvalId: 'approval-1' }),
+        ];
+      },
+      async *executeCommand(_command, { signal }) {
+        yield await new Promise<AgentEvent>((_resolve, reject) => {
+          const abort = () => reject(new DOMException('Unmounted', 'AbortError'));
+          if (signal.aborted) abort();
+          else signal.addEventListener('abort', abort, { once: true });
+        });
+      },
+    });
+    const conversationKey = 'agent-runtime-unmount';
+    let current: any;
+    const Demo = () => {
+      current = useXChat({ provider, conversationKey });
+      return null;
+    };
+    const view = render(<Demo />);
+    act(() => current.onRequest('start'));
+    await flush();
+    const runId = Object.keys(current.agentState.runs)[0];
+    let action!: Promise<any>;
+    act(() => {
+      action = current.agentActions.resolveApproval({
+        runId,
+        approvalId: 'approval-1',
+        decision: 'approved',
+      });
+    });
+    const settled = action.catch((error) => error);
+    view.unmount();
+
+    await expect(settled).resolves.toMatchObject({ name: 'AbortError' });
   });
 
   it('guards runtime methods when no AgentProvider is configured', () => {

--- a/packages/x-sdk/src/x-chat/agentCommandStore.ts
+++ b/packages/x-sdk/src/x-chat/agentCommandStore.ts
@@ -1,0 +1,125 @@
+import type { AgentCommand } from '../agent';
+import { getAgentCommandActionKey, getAgentCommandKey } from '../agent';
+
+export type AgentCommandStatus = 'submitting' | 'succeeded' | 'failed';
+
+export interface AgentCommandError {
+  code:
+    | 'unsupported_capability'
+    | 'invalid_command'
+    | 'provider_error'
+    | 'protocol_error'
+    | 'interrupted';
+  message: string;
+  retryable: boolean;
+  cause?: unknown;
+}
+
+export interface AgentCommandState {
+  command: AgentCommand;
+  key: string;
+  status: AgentCommandStatus;
+  error?: AgentCommandError;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface AgentCommandStoreSnapshot {
+  commandStates: Readonly<Record<string, AgentCommandState>>;
+  latestCommandByAction: Readonly<Record<string, string>>;
+}
+
+export interface AgentCommandStore {
+  getSnapshot(): AgentCommandStoreSnapshot;
+  start(command: AgentCommand): AgentCommandState;
+  succeed(commandId: string, updatedAt?: number): void;
+  fail(commandId: string, error: AgentCommandError, updatedAt?: number): void;
+  clearRun(runId: string, keepSubmitting?: boolean): void;
+  subscribe(listener: () => void): () => void;
+}
+
+const initialSnapshot: AgentCommandStoreSnapshot = {
+  commandStates: {},
+  latestCommandByAction: {},
+};
+
+export function createAgentCommandStore(): AgentCommandStore {
+  let snapshot = initialSnapshot;
+  const listeners = new Set<() => void>();
+  const emit = () => {
+    listeners.forEach((listener) => {
+      listener();
+    });
+  };
+
+  const update = (commandId: string, updater: (state: AgentCommandState) => AgentCommandState) => {
+    const current = snapshot.commandStates[commandId];
+    if (!current) return;
+    snapshot = {
+      ...snapshot,
+      commandStates: {
+        ...snapshot.commandStates,
+        [commandId]: updater(current),
+      },
+    };
+    emit();
+  };
+
+  return {
+    getSnapshot() {
+      return snapshot;
+    },
+    start(command) {
+      const key = getAgentCommandKey(command);
+      const state: AgentCommandState = {
+        command,
+        key,
+        status: 'submitting',
+        createdAt: command.timestamp,
+        updatedAt: command.timestamp,
+      };
+      snapshot = {
+        commandStates: {
+          ...snapshot.commandStates,
+          [key]: state,
+        },
+        latestCommandByAction: {
+          ...snapshot.latestCommandByAction,
+          [getAgentCommandActionKey(command)]: key,
+        },
+      };
+      emit();
+      return state;
+    },
+    succeed(commandId, updatedAt = Date.now()) {
+      update(commandId, (state) => ({ ...state, status: 'succeeded', updatedAt }));
+    },
+    fail(commandId, error, updatedAt = Date.now()) {
+      update(commandId, (state) => ({ ...state, status: 'failed', error, updatedAt }));
+    },
+    clearRun(runId, keepSubmitting = false) {
+      const commandStates = Object.fromEntries(
+        Object.entries(snapshot.commandStates).filter(
+          ([, state]) =>
+            state.command.runId !== runId || (keepSubmitting && state.status === 'submitting'),
+        ),
+      );
+      if (Object.keys(commandStates).length === Object.keys(snapshot.commandStates).length) return;
+
+      const retainedCommandIds = new Set(Object.keys(commandStates));
+      snapshot = {
+        commandStates,
+        latestCommandByAction: Object.fromEntries(
+          Object.entries(snapshot.latestCommandByAction).filter(([, commandId]) =>
+            retainedCommandIds.has(commandId),
+          ),
+        ),
+      };
+      emit();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/packages/x-sdk/src/x-chat/agentRuntime.ts
+++ b/packages/x-sdk/src/x-chat/agentRuntime.ts
@@ -1,15 +1,56 @@
 import { useEvent } from '@rc-component/util';
 import { useEffect, useState, useSyncExternalStore } from 'react';
-import type { AgentMessageState, AgentState, AgentStore } from '../agent';
-import { createAgentStore, getAgentEntityKey } from '../agent';
+import type {
+  AgentCommand,
+  AgentCommandDecision,
+  AgentCommandFactory,
+  AgentEvent,
+  AgentMessageState,
+  AgentState,
+  AgentStore,
+} from '../agent';
+import {
+  AgentProtocolError,
+  createAgentCommandFactory,
+  createAgentStore,
+  getAgentActionKey,
+  getAgentEntityKey,
+} from '../agent';
 import type { AgentProvider } from '../chat-providers';
-import { runAgentProvider } from '../chat-providers';
+import { AgentCommandRunnerError, runAgentCommand, runAgentProvider } from '../chat-providers';
 import type { MessageInfo, MessageStatus } from '.';
+import type { AgentCommandError, AgentCommandStore } from './agentCommandStore';
+import { createAgentCommandStore } from './agentCommandStore';
 import type { ConversationKey } from './store';
+
+export interface AgentActionResult {
+  commandId: string;
+  idempotencyKey: string;
+}
+
+export interface ResolveApprovalInput {
+  runId: string;
+  approvalId: string;
+  decision: AgentCommandDecision;
+  data?: unknown;
+  expectedVersion?: string | number;
+}
+
+export interface AgentActions {
+  resolveApproval(input: ResolveApprovalInput): Promise<AgentActionResult>;
+  retryTool(input: { runId: string; toolCallId: string }): Promise<AgentActionResult>;
+  cancelRun(input: { runId: string; reason?: string }): Promise<AgentActionResult>;
+}
 
 interface AgentSession {
   id: string;
   store: AgentStore;
+  commandStore: AgentCommandStore;
+  commandFactories: Map<string, AgentCommandFactory>;
+  commandTails: Map<string, Promise<void>>;
+  commandControllers: Map<string, AbortController>;
+  runControllers: Map<string, AbortController>;
+  latestRunId?: string;
 }
 
 const agentSessions = new Map<ConversationKey, AgentSession>();
@@ -24,6 +65,11 @@ const getAgentSession = (conversationKey: ConversationKey) => {
       id:
         typeof conversationKey === 'symbol' ? `session_${nextSessionId}` : String(conversationKey),
       store: createAgentStore(),
+      commandStore: createAgentCommandStore(),
+      commandFactories: new Map(),
+      commandTails: new Map(),
+      commandControllers: new Map(),
+      runControllers: new Map(),
     };
     agentSessions.set(conversationKey, session);
   }
@@ -52,32 +98,192 @@ export const projectAgentMessages = (state: AgentState): MessageInfo<AgentMessag
     ];
   });
 
+const assertRunningRun = (state: AgentState, sessionId: string, runId: string) => {
+  const run = state.runs[runId];
+  if (!run || run.sessionId !== sessionId) {
+    throw new AgentCommandRunnerError(
+      'invalid_command',
+      `Run "${runId}" does not exist in the active session.`,
+    );
+  }
+  if (run.status !== 'running') {
+    throw new AgentCommandRunnerError(
+      'invalid_command',
+      `Run "${runId}" is already ${run.status}.`,
+    );
+  }
+  return run;
+};
+
+const assertCommandCapability = (
+  provider: AgentProvider<any, any, any, any>,
+  type: AgentCommand['type'],
+) => {
+  if (!provider.capabilities.commands?.includes(type) || !provider.executeCommand) {
+    throw new AgentCommandRunnerError(
+      'unsupported_capability',
+      `Provider "${provider.id}" does not support command "${type}".`,
+    );
+  }
+};
+
+const assertActionAvailable = (
+  session: AgentSession,
+  options: { runId: string; type: AgentCommand['type']; entityId?: string },
+) => {
+  const snapshot = session.commandStore.getSnapshot();
+  const actionKey = getAgentActionKey(options);
+  const latestCommandId = snapshot.latestCommandByAction[actionKey];
+  const latestCommand = latestCommandId ? snapshot.commandStates[latestCommandId] : undefined;
+  if (
+    latestCommand?.status === 'submitting' ||
+    (options.type === 'run.cancel' && latestCommand?.status === 'succeeded')
+  ) {
+    throw new Error(`Command action "${actionKey}" has already been submitted.`);
+  }
+
+  if (options.type !== 'run.cancel') {
+    const cancelKey = getAgentActionKey({ runId: options.runId, type: 'run.cancel' });
+    const cancelCommandId = snapshot.latestCommandByAction[cancelKey];
+    const cancelCommand = cancelCommandId ? snapshot.commandStates[cancelCommandId] : undefined;
+    if (cancelCommand && cancelCommand.status !== 'failed') {
+      throw new Error(`Run "${options.runId}" cancellation has already been submitted.`);
+    }
+  }
+};
+
+const isAbortError = (error: unknown) =>
+  error instanceof DOMException
+    ? error.name === 'AbortError'
+    : error instanceof Error && error.name === 'AbortError';
+
+const toCommandError = (error: unknown): AgentCommandError => {
+  if (error instanceof AgentCommandRunnerError) {
+    return {
+      code: error.code,
+      message: error.message,
+      retryable: false,
+      cause: error,
+    };
+  }
+  if (error instanceof AgentProtocolError) {
+    return {
+      code: 'protocol_error',
+      message: error.message,
+      retryable: false,
+      cause: error,
+    };
+  }
+  if (isAbortError(error)) {
+    return {
+      code: 'interrupted',
+      message: error instanceof Error ? error.message : 'Agent command was interrupted.',
+      retryable: true,
+      cause: error,
+    };
+  }
+  const retryable =
+    error &&
+    typeof error === 'object' &&
+    'retryable' in error &&
+    typeof error.retryable === 'boolean'
+      ? error.retryable
+      : false;
+  return {
+    code: 'provider_error',
+    message: error instanceof Error ? error.message : String(error),
+    retryable,
+    cause: error,
+  };
+};
+
+const getCommandFactory = (session: AgentSession, runId: string) => {
+  let factory = session.commandFactories.get(runId);
+  if (!factory) {
+    factory = createAgentCommandFactory({ sessionId: session.id, runId });
+    session.commandFactories.set(runId, factory);
+  }
+  return factory;
+};
+
 export function useAgentChatRuntime(
   provider: AgentProvider<any, any, any, any> | undefined,
   conversationKey: ConversationKey,
 ) {
   const [session, setSession] = useState(() => getAgentSession(conversationKey));
-  const [controller, setController] = useState<AbortController>();
 
   useEffect(() => {
     setSession(getAgentSession(conversationKey));
   }, [conversationKey]);
 
-  useEffect(() => () => controller?.abort(), [conversationKey, controller]);
+  useEffect(
+    () => () => {
+      session.runControllers.forEach((controller) => {
+        controller.abort();
+      });
+      session.commandControllers.forEach((controller) => {
+        controller.abort();
+      });
+    },
+    [session],
+  );
 
   const agentState = useSyncExternalStore(
     session.store.subscribe,
     session.store.getSnapshot,
     session.store.getSnapshot,
   );
+  const commandSnapshot = useSyncExternalStore(
+    session.commandStore.subscribe,
+    session.commandStore.getSnapshot,
+    session.commandStore.getSnapshot,
+  );
+
+  const dispatchEvent = (event: AgentEvent, sourceCommandId?: string) => {
+    const state = session.store.dispatch(event);
+    if (
+      event.type === 'run.completed' ||
+      event.type === 'run.failed' ||
+      event.type === 'run.cancelled'
+    ) {
+      session.runControllers.get(event.runId)?.abort();
+      const commandStates = session.commandStore.getSnapshot().commandStates;
+      session.commandControllers.forEach((controller, commandId) => {
+        if (
+          commandId !== sourceCommandId &&
+          commandStates[commandId]?.command.runId === event.runId
+        ) {
+          controller.abort();
+        }
+      });
+      session.commandStore.clearRun(event.runId, true);
+    }
+    return state;
+  };
+
+  const dispatchCommandEvent = (event: AgentEvent, commandId: string) => {
+    const before = session.store.getSnapshot();
+    const lastSequence = before.lastSequenceByRun[event.runId];
+    if (lastSequence !== undefined && event.sequence <= lastSequence) {
+      throw new AgentCommandRunnerError(
+        'protocol_error',
+        `Command event sequence ${event.sequence} must be greater than ${lastSequence}.`,
+      );
+    }
+    const next = dispatchEvent(event, commandId);
+    if (next.issues.length > before.issues.length) {
+      throw new AgentProtocolError(next.issues[next.issues.length - 1]);
+    }
+  };
 
   const onRequest = useEvent((input: unknown) => {
     if (!provider) throw new Error('provider is required');
 
-    const nextController = new AbortController();
-    setController(nextController);
+    const controller = new AbortController();
     nextRunId += 1;
     const runId = `run_${nextRunId}`;
+    session.latestRunId = runId;
+    session.runControllers.set(runId, controller);
 
     return runAgentProvider({
       provider,
@@ -85,17 +291,145 @@ export function useAgentChatRuntime(
       run: {
         sessionId: session.id,
         runId,
-        signal: nextController.signal,
+        signal: controller.signal,
       },
-      onEvent: session.store.dispatch,
+      onEvent: dispatchEvent,
+    }).finally(() => {
+      if (session.runControllers.get(runId) === controller) {
+        session.runControllers.delete(runId);
+      }
     });
   });
+
+  const executeCommand = useEvent(async (command: AgentCommand): Promise<AgentActionResult> => {
+    if (!provider) throw new Error('provider is required');
+    session.commandStore.start(command);
+    const controller = new AbortController();
+    session.commandControllers.set(command.commandId, controller);
+
+    const previous = session.commandTails.get(command.runId) ?? Promise.resolve();
+    const execution = previous
+      .catch(() => undefined)
+      .then(() => {
+        assertRunningRun(session.store.getSnapshot(), session.id, command.runId);
+        assertCommandCapability(provider, command.type);
+        const initialSequence = session.store.getSnapshot().lastSequenceByRun[command.runId] ?? -1;
+        return runAgentCommand({
+          provider,
+          command,
+          signal: controller.signal,
+          initialSequence,
+          onEvent: (event) => dispatchCommandEvent(event, command.commandId),
+        });
+      });
+    session.commandTails.set(command.runId, execution);
+
+    try {
+      await execution;
+      session.commandStore.succeed(command.commandId);
+      return {
+        commandId: command.commandId,
+        idempotencyKey: command.idempotencyKey,
+      };
+    } catch (error) {
+      session.commandStore.fail(command.commandId, toCommandError(error));
+      throw error;
+    } finally {
+      if (session.commandControllers.get(command.commandId) === controller) {
+        session.commandControllers.delete(command.commandId);
+      }
+      if (session.commandTails.get(command.runId) === execution) {
+        session.commandTails.delete(command.runId);
+      }
+      if (session.store.getSnapshot().runs[command.runId]?.status !== 'running') {
+        session.commandStore.clearRun(command.runId);
+      }
+    }
+  });
+
+  const resolveApproval = useEvent((input: ResolveApprovalInput) => {
+    if (!provider) throw new Error('provider is required');
+    const state = session.store.getSnapshot();
+    assertRunningRun(state, session.id, input.runId);
+    assertCommandCapability(provider, 'approval.resolve');
+    assertActionAvailable(session, {
+      runId: input.runId,
+      type: 'approval.resolve',
+      entityId: input.approvalId,
+    });
+    const approval = state.approvals[getAgentEntityKey(input.runId, input.approvalId)];
+    if (approval?.status !== 'waiting') {
+      throw new Error(`Approval "${input.approvalId}" is not waiting in run "${input.runId}".`);
+    }
+    if (input.decision === 'modified' && approval.editable === false) {
+      throw new Error(`Approval "${input.approvalId}" is not editable.`);
+    }
+    if (input.expectedVersion !== undefined && input.expectedVersion !== approval.version) {
+      throw new Error(`Approval "${input.approvalId}" version does not match.`);
+    }
+    if (approval.expiresAt !== undefined && approval.expiresAt <= Date.now()) {
+      throw new Error(`Approval "${input.approvalId}" has expired.`);
+    }
+    const command = getCommandFactory(session, input.runId).create('approval.resolve', {
+      approvalId: input.approvalId,
+      decision: input.decision,
+      data: input.data,
+      expectedVersion: input.expectedVersion,
+    });
+    return executeCommand(command);
+  });
+
+  const retryTool = useEvent((input: { runId: string; toolCallId: string }) => {
+    if (!provider) throw new Error('provider is required');
+    const state = session.store.getSnapshot();
+    assertRunningRun(state, session.id, input.runId);
+    assertCommandCapability(provider, 'tool.retry');
+    assertActionAvailable(session, {
+      runId: input.runId,
+      type: 'tool.retry',
+      entityId: input.toolCallId,
+    });
+    const toolCall = state.toolCalls[getAgentEntityKey(input.runId, input.toolCallId)];
+    if (toolCall?.status !== 'failed') {
+      throw new Error(`Tool call "${input.toolCallId}" is not failed in run "${input.runId}".`);
+    }
+    if (toolCall.error?.retryable !== true) {
+      throw new Error(`Tool call "${input.toolCallId}" is not retryable.`);
+    }
+    const command = getCommandFactory(session, input.runId).create('tool.retry', {
+      toolCallId: input.toolCallId,
+    });
+    return executeCommand(command);
+  });
+
+  const cancelRun = useEvent((input: { runId: string; reason?: string }) => {
+    if (!provider) throw new Error('provider is required');
+    assertRunningRun(session.store.getSnapshot(), session.id, input.runId);
+    assertCommandCapability(provider, 'run.cancel');
+    assertActionAvailable(session, { runId: input.runId, type: 'run.cancel' });
+    const command = getCommandFactory(session, input.runId).create('run.cancel', {
+      reason: input.reason,
+    });
+    return executeCommand(command);
+  });
+
+  const agentActions: AgentActions = {
+    resolveApproval,
+    retryTool,
+    cancelRun,
+  };
 
   return {
     agentState,
     messages: projectAgentMessages(agentState),
+    agentActions,
+    commandStates: commandSnapshot.commandStates,
+    latestCommandByAction: commandSnapshot.latestCommandByAction,
     onRequest,
-    abort: () => controller?.abort(),
+    abort: () => {
+      const runId = session.latestRunId;
+      if (runId) session.runControllers.get(runId)?.abort();
+    },
     isRequesting: Object.values(agentState.runs).some(({ status }) => status === 'running'),
   } as const;
 }

--- a/packages/x-sdk/src/x-chat/index.ts
+++ b/packages/x-sdk/src/x-chat/index.ts
@@ -7,6 +7,8 @@ import { AbstractChatProvider, isAgentProvider } from '../chat-providers';
 import { ConversationData } from '../x-conversations';
 import { AbstractXRequestClass } from '../x-request';
 import type { SSEOutput } from '../x-stream';
+import type { AgentCommandState } from './agentCommandStore';
+import type { AgentActions } from './agentRuntime';
 import { useAgentChatRuntime } from './agentRuntime';
 import { ConversationKey, useChatStore } from './store';
 
@@ -536,6 +538,9 @@ function useXChatInternal<
         ? IsRequestingMap?.get(conversationKey) || false
         : isRequesting,
     agentState: agentProvider ? agentRuntime.agentState : undefined,
+    agentActions: agentProvider ? agentRuntime.agentActions : undefined,
+    commandStates: agentProvider ? agentRuntime.commandStates : undefined,
+    latestCommandByAction: agentProvider ? agentRuntime.latestCommandByAction : undefined,
     onReload,
     queueRequest,
   } as const;
@@ -556,8 +561,14 @@ export default function useXChat<
   ParsedMessage extends SimpleType = AgentMessageState,
 >(
   config: AgentXChatConfig<Input, Request, Chunk, Context, ParsedMessage>,
-): Omit<XChatResult<AgentMessageState, ParsedMessage, Input, Chunk>, 'agentState'> & {
+): Omit<
+  XChatResult<AgentMessageState, ParsedMessage, Input, Chunk>,
+  'agentState' | 'agentActions' | 'commandStates' | 'latestCommandByAction'
+> & {
   agentState: AgentState;
+  agentActions: AgentActions;
+  commandStates: Readonly<Record<string, AgentCommandState>>;
+  latestCommandByAction: Readonly<Record<string, string>>;
 };
 
 export default function useXChat<
@@ -567,8 +578,14 @@ export default function useXChat<
   Output = SSEOutput,
 >(
   config: XChatConfig<ChatMessage, ParsedMessage, Input, Output>,
-): Omit<XChatResult<ChatMessage, ParsedMessage, Input, Output>, 'agentState'> & {
+): Omit<
+  XChatResult<ChatMessage, ParsedMessage, Input, Output>,
+  'agentState' | 'agentActions' | 'commandStates' | 'latestCommandByAction'
+> & {
   agentState: undefined;
+  agentActions: undefined;
+  commandStates: undefined;
+  latestCommandByAction: undefined;
 };
 
 export default function useXChat(
@@ -576,3 +593,6 @@ export default function useXChat(
 ): XChatResult<any, any, any, any> {
   return useXChatInternal(config);
 }
+
+export type { AgentCommandError, AgentCommandState, AgentCommandStatus } from './agentCommandStore';
+export type { AgentActionResult, AgentActions, ResolveApprovalInput } from './agentRuntime';

--- a/packages/x/docs/x-sdk/agent-provider.en-US.md
+++ b/packages/x/docs/x-sdk/agent-provider.en-US.md
@@ -28,6 +28,7 @@ The frontend entry remains `useXChat({ provider })`. There is no additional `use
 
 <!-- prettier-ignore -->
 <code src="./demos/x-chat/agent-provider.tsx">Generic AgentProvider</code>
+<code src="./demos/x-chat/agent-interaction.tsx">Agent Command Interaction</code>
 
 ## Quick Start
 
@@ -64,23 +65,56 @@ interface AgentProvider<Input, Request, Chunk, Context = unknown> {
   transformChunk(chunk: Chunk, context: Context): readonly AgentEvent[];
   flush(context: Context): readonly AgentEvent[];
   transformError(error: unknown, context: Context): readonly AgentEvent[];
+  executeCommand?(command: AgentCommand, options: AgentCommandOptions): AsyncIterable<AgentEvent>;
 }
 ```
 
-| Member           | Responsibility                                                             |
-| ---------------- | -------------------------------------------------------------------------- |
-| `id`             | Unique Provider metadata; it is never used for capability detection        |
-| `protocol`       | Explicit protocol declaration used by `useXChat` to identify AgentProvider |
-| `capabilities`   | Declares event and Transport types the Provider may use                    |
-| `transport`      | Binds request execution; the frontend does not configure it separately     |
-| `createContext`  | Creates per-Run parsing state shared across chunks                         |
-| `start`          | Emits the Run, user message, and initial entity events                     |
-| `prepareRequest` | Converts `onRequest` input into a Runtime request                          |
-| `transformChunk` | Converts one chunk into zero or more standard events                       |
-| `flush`          | Closes remaining entities and emits the terminal Run event                 |
-| `transformError` | Converts errors and interruptions into failure or cancellation events      |
+| Member | Responsibility |
+| --- | --- |
+| `id` | Unique Provider metadata; it is never used for capability detection |
+| `protocol` | Explicit protocol declaration used by `useXChat` to identify AgentProvider |
+| `capabilities` | Declares event and Transport types the Provider may use |
+| `transport` | Binds request execution; the frontend does not configure it separately |
+| `createContext` | Creates per-Run parsing state shared across chunks |
+| `start` | Emits the Run, user message, and initial entity events |
+| `prepareRequest` | Converts `onRequest` input into a Runtime request |
+| `transformChunk` | Converts one chunk into zero or more standard events |
+| `flush` | Closes remaining entities and emits the terminal Run event |
+| `transformError` | Converts errors and interruptions into failure or cancellation events |
+| `executeCommand` | Executes UI approval, tool retry, or Run cancellation commands and returns standard events |
 
 A Provider does not render React UI, maintain another message reducer, execute tools, or infer capabilities from a model name.
+
+## Command Interaction
+
+A Provider declares supported commands through `capabilities.commands` and sends each command to the Runtime through `executeCommand`:
+
+```tsx | pure
+const capabilities = {
+  eventTypes: [
+    'approval.resolved',
+    'tool.requested',
+    'tool.running',
+    'tool.completed',
+    'run.cancelled',
+  ],
+  transports: ['company.sse'],
+  commands: ['approval.resolve', 'tool.retry', 'run.cancel'],
+};
+
+async function* executeCommand(command, { signal, initialSequence }) {
+  const events = createAgentEventFactory({
+    sessionId: command.sessionId,
+    runId: command.runId,
+    initialSequence,
+  });
+
+  const result = await runtime.execute(command, { signal });
+  yield events.create('approval.resolved', result);
+}
+```
+
+Every command contains a `commandId` and `idempotencyKey`. Providers should forward the idempotency key to the server and ensure returned events belong to the command's `sessionId` and `runId`, with `sequence` greater than `initialSequence`. Command success means the Provider command event stream ended normally; entity completion is still determined by the returned AgentEvents.
 
 ## Transport
 

--- a/packages/x/docs/x-sdk/agent-provider.zh-CN.md
+++ b/packages/x/docs/x-sdk/agent-provider.zh-CN.md
@@ -28,6 +28,7 @@ Model / Agent Runtime / Fixture
 
 <!-- prettier-ignore -->
 <code src="./demos/x-chat/agent-provider.tsx">通用 AgentProvider</code>
+<code src="./demos/x-chat/agent-interaction.tsx">Agent 命令交互</code>
 
 ## 快速使用
 
@@ -64,23 +65,56 @@ interface AgentProvider<Input, Request, Chunk, Context = unknown> {
   transformChunk(chunk: Chunk, context: Context): readonly AgentEvent[];
   flush(context: Context): readonly AgentEvent[];
   transformError(error: unknown, context: Context): readonly AgentEvent[];
+  executeCommand?(command: AgentCommand, options: AgentCommandOptions): AsyncIterable<AgentEvent>;
 }
 ```
 
-| 成员             | 职责                                                        |
-| ---------------- | ----------------------------------------------------------- |
-| `id`             | Provider 唯一标识，只作为元信息，不参与能力判断             |
-| `protocol`       | 显式声明事件协议和版本，`useXChat` 通过它识别 AgentProvider |
-| `capabilities`   | 声明可能输出的事件类型和 Transport 类型                     |
-| `transport`      | 绑定请求执行方式，前端不单独配置                            |
-| `createContext`  | 创建单次 Run 的跨 Chunk 解析上下文                          |
-| `start`          | 产生 Run、用户消息或初始实体事件                            |
-| `prepareRequest` | 将 `onRequest` 输入转换为 Runtime 请求                      |
-| `transformChunk` | 将一个 Chunk 转换为零到多个标准事件                         |
-| `flush`          | 流结束时关闭剩余实体并产生 Run 终态                         |
-| `transformError` | 将异常或中断转换为失败/取消事件                             |
+| 成员             | 职责                                                          |
+| ---------------- | ------------------------------------------------------------- |
+| `id`             | Provider 唯一标识，只作为元信息，不参与能力判断               |
+| `protocol`       | 显式声明事件协议和版本，`useXChat` 通过它识别 AgentProvider   |
+| `capabilities`   | 声明可能输出的事件类型和 Transport 类型                       |
+| `transport`      | 绑定请求执行方式，前端不单独配置                              |
+| `createContext`  | 创建单次 Run 的跨 Chunk 解析上下文                            |
+| `start`          | 产生 Run、用户消息或初始实体事件                              |
+| `prepareRequest` | 将 `onRequest` 输入转换为 Runtime 请求                        |
+| `transformChunk` | 将一个 Chunk 转换为零到多个标准事件                           |
+| `flush`          | 流结束时关闭剩余实体并产生 Run 终态                           |
+| `transformError` | 将异常或中断转换为失败/取消事件                               |
+| `executeCommand` | 执行 UI 发起的审批、工具重试或 Run 取消命令，并返回标准事件流 |
 
 Provider 不负责 React 渲染、维护另一套消息状态、执行工具或根据模型名称猜测能力。
+
+## 命令交互
+
+Provider 通过 `capabilities.commands` 声明支持的命令，并通过 `executeCommand` 将命令交给 Runtime：
+
+```tsx | pure
+const capabilities = {
+  eventTypes: [
+    'approval.resolved',
+    'tool.requested',
+    'tool.running',
+    'tool.completed',
+    'run.cancelled',
+  ],
+  transports: ['company.sse'],
+  commands: ['approval.resolve', 'tool.retry', 'run.cancel'],
+};
+
+async function* executeCommand(command, { signal, initialSequence }) {
+  const events = createAgentEventFactory({
+    sessionId: command.sessionId,
+    runId: command.runId,
+    initialSequence,
+  });
+
+  const result = await runtime.execute(command, { signal });
+  yield events.create('approval.resolved', result);
+}
+```
+
+每个命令都包含 `commandId` 和 `idempotencyKey`。Provider 应将幂等键透传给服务端，并确保返回事件属于命令指定的 `sessionId` 和 `runId`，且 `sequence` 大于 `initialSequence`。命令成功表示 Provider 的命令事件流正常结束；实体是否完成仍由返回的 AgentEvent 决定。
 
 ## Transport
 

--- a/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.md
+++ b/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+通过本地 Fixture 验证 Agent 命令交互链路。启动不同场景后，可以处理审批、重试失败工具或取消 Run，并观察命令状态、实体状态和 AgentTimeline 的变化。
+
+## en-US
+
+Validate the Agent command interaction flow with a local fixture. Start a scenario to resolve an approval, retry a failed tool, or cancel a Run while observing command states, entity states, and AgentTimeline updates.

--- a/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.md
+++ b/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.md
@@ -1,7 +1,19 @@
 ## zh-CN
 
-通过本地 Fixture 验证 Agent 命令交互链路。启动不同场景后，可以处理审批、重试失败工具或取消 Run，并观察命令状态、实体状态和 AgentTimeline 的变化。
+这个 Demo 用三个本地场景展示同一条交互链路：Agent Event 先把待处理状态交给 SDK，用户操作再发送 Agent Command，Provider 返回的新事件最终更新实体状态。
+
+- 审批：`approval.requested` -> `approval.resolve` -> `approval.resolved`
+- 工具重试：`tool.failed` -> `tool.retry` -> `tool.completed`
+- 取消运行：`task.updated` -> `run.cancel` -> `run.cancelled`
+
+页面上方展示当前应执行的操作和三步进度，下方的 SDK 内部状态用于核对 Command States 与 AgentTimeline。
 
 ## en-US
 
-Validate the Agent command interaction flow with a local fixture. Start a scenario to resolve an approval, retry a failed tool, or cancel a Run while observing command states, entity states, and AgentTimeline updates.
+This demo uses three local scenarios to show the same interaction flow: an Agent Event first puts actionable state into the SDK, a user action sends an Agent Command, and the Provider's next event updates the entity state.
+
+- Approval: `approval.requested` -> `approval.resolve` -> `approval.resolved`
+- Tool retry: `tool.failed` -> `tool.retry` -> `tool.completed`
+- Run cancellation: `task.updated` -> `run.cancel` -> `run.cancelled`
+
+The main area presents the current action and its three-step progress. The SDK state section below exposes Command States and AgentTimeline for verification.

--- a/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.tsx
+++ b/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.tsx
@@ -14,7 +14,17 @@ import type {
   AgentTransport,
 } from '@ant-design/x-sdk';
 import { experimentalAgent, useXChat } from '@ant-design/x-sdk';
-import { Alert, Button, Descriptions, Divider, Flex, Segmented, Tag, Typography } from 'antd';
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Divider,
+  Flex,
+  Segmented,
+  Steps,
+  Tag,
+  Typography,
+} from 'antd';
 import React from 'react';
 
 type DemoScenario = 'approval' | 'retry' | 'cancel';
@@ -234,18 +244,47 @@ const statusColor = {
   waiting: 'warning',
 } as const;
 
+const scenarioProtocol = {
+  approval: {
+    command: 'approval.resolve',
+    resultEvent: 'approval.resolved',
+    startEvent: 'approval.requested',
+  },
+  cancel: {
+    command: 'run.cancel',
+    resultEvent: 'run.cancelled',
+    startEvent: 'task.updated',
+  },
+  retry: {
+    command: 'tool.retry',
+    resultEvent: 'tool.completed',
+    startEvent: 'tool.failed',
+  },
+} as const;
+
 const App = () => {
   const isCN = typeof location !== 'undefined' && location.pathname.endsWith('-cn');
   const [scenario, setScenario] = React.useState<DemoScenario>('approval');
+  const [conversationIndex, setConversationIndex] = React.useState(0);
+  const [isResetting, setIsResetting] = React.useState(false);
   const [provider] = React.useState(() => new InteractionProvider());
   const [pendingAction, setPendingAction] = React.useState<string>();
   const [lastResult, setLastResult] = React.useState<AgentActionResult>();
   const [actionError, setActionError] = React.useState<string>();
-  const { agentState, agentActions, commandStates, onRequest, isRequesting } = useXChat({
+  const { agentState, agentActions, commandStates, onRequest } = useXChat({
     provider,
+    conversationKey: `agent-command-demo-${conversationIndex}`,
   });
 
-  const run = Object.values(agentState.runs).at(-1);
+  const latestRun = Object.values(agentState.runs).at(-1);
+  const run = isResetting ? undefined : latestRun;
+
+  React.useEffect(() => {
+    if (isResetting && !latestRun) {
+      setIsResetting(false);
+    }
+  }, [isResetting, latestRun]);
+
   const approval = run
     ? experimentalAgent.selectApproval(agentState, {
         runId: run.id,
@@ -262,6 +301,39 @@ const App = () => {
     (command) => !run || command.command.runId === run.id,
   );
   const timeline = run ? experimentalAgent.selectAgentTimeline(agentState, { runId: run.id }) : [];
+  const protocol = scenarioProtocol[scenario];
+  const commandState = commands.at(-1);
+  const interactionCompleted = Boolean(lastResult);
+  const currentStep = !run ? 0 : interactionCompleted ? 2 : 1;
+
+  const scenarioTitle = {
+    approval: isCN ? '生产发布需要人工审批' : 'Production deployment needs approval',
+    cancel: isCN ? '长任务仍在执行' : 'A long-running task is in progress',
+    retry: isCN ? '知识检索工具执行失败' : 'The knowledge search tool failed',
+  }[scenario];
+  const scenarioDescription = {
+    approval: isCN
+      ? 'Agent 发起高风险操作前暂停，等待用户批准或拒绝。'
+      : 'The Agent pauses before a high-risk action and waits for a decision.',
+    cancel: isCN
+      ? 'Agent 正在生成发布报告，用户可以主动终止整个 Run。'
+      : 'The Agent is generating a release report and the user can stop the Run.',
+    retry: isCN
+      ? '第一次调用因超时失败，用户可以要求 Agent 重新执行工具。'
+      : 'The first call timed out and the user can ask the Agent to run the tool again.',
+  }[scenario];
+  const resultMessage = {
+    approval:
+      approval?.decision === 'approved'
+        ? isCN
+          ? '发布审批已批准'
+          : 'Deployment approved'
+        : isCN
+          ? '发布审批已拒绝'
+          : 'Deployment rejected',
+    cancel: isCN ? 'Run 和关联任务均已取消' : 'The Run and its task were cancelled',
+    retry: isCN ? '第二次工具调用执行成功' : 'The second tool call succeeded',
+  }[scenario];
 
   const runAction = async (key: string, action: () => Promise<AgentActionResult>) => {
     setPendingAction(key);
@@ -281,191 +353,274 @@ const App = () => {
     onRequest({ scenario, locale: isCN ? 'zh-CN' : 'en-US' });
   };
 
+  const reset = () => {
+    setIsResetting(true);
+    setConversationIndex((current) => current + 1);
+    setLastResult(undefined);
+    setActionError(undefined);
+    setPendingAction(undefined);
+  };
+
   return (
-    <Flex vertical gap={16}>
-      <Flex gap={8} wrap>
-        <Segmented
-          value={scenario}
-          disabled={isRequesting}
-          options={[
-            { label: isCN ? '审批' : 'Approval', value: 'approval' },
-            { label: isCN ? '工具重试' : 'Tool retry', value: 'retry' },
-            { label: isCN ? '取消运行' : 'Run cancel', value: 'cancel' },
-          ]}
-          onChange={(value) => setScenario(value as DemoScenario)}
-        />
-        <Button
-          type="primary"
-          icon={<PlayCircleOutlined />}
-          disabled={isRequesting}
-          onClick={start}
-        >
-          {isCN ? '启动 Run' : 'Start Run'}
-        </Button>
-      </Flex>
+    <Flex vertical gap={20}>
+      <Segmented
+        block
+        value={scenario}
+        disabled={Boolean(run) || isResetting}
+        options={[
+          { label: isCN ? '审批' : 'Approval', value: 'approval' },
+          { label: isCN ? '工具重试' : 'Tool retry', value: 'retry' },
+          { label: isCN ? '取消运行' : 'Run cancel', value: 'cancel' },
+        ]}
+        onChange={(value) => setScenario(value as DemoScenario)}
+      />
 
-      <Descriptions size="small" column={{ xs: 1, sm: 3 }}>
-        <Descriptions.Item label="Run ID">{run?.id ?? '-'}</Descriptions.Item>
-        <Descriptions.Item label={isCN ? '运行状态' : 'Run status'}>
-          {run ? <Tag color={statusColor[run.status]}>{run.status}</Tag> : '-'}
-        </Descriptions.Item>
-        <Descriptions.Item label={isCN ? '最近命令' : 'Last command'}>
-          {lastResult?.commandId ?? '-'}
-        </Descriptions.Item>
-      </Descriptions>
+      <Steps
+        size="small"
+        current={currentStep}
+        status={actionError ? 'error' : 'process'}
+        items={[
+          { title: isCN ? 'Agent 发起交互' : 'Agent requests action' },
+          { title: isCN ? '用户发送命令' : 'User sends command' },
+          { title: isCN ? '状态完成更新' : 'State is updated' },
+        ]}
+      />
 
-      {approval && (
-        <Flex vertical gap={8}>
-          <Typography.Text strong>{approval.description}</Typography.Text>
-          <Flex gap={8} align="center" wrap>
-            <Tag color={statusColor[approval.status]}>{approval.status}</Tag>
-            <Tag color="red">{approval.risk}</Tag>
-            {approval.status === 'waiting' && (
-              <>
-                <Button
-                  icon={<CheckOutlined />}
-                  loading={pendingAction === 'approve'}
-                  onClick={() =>
-                    void runAction('approve', () =>
-                      agentActions.resolveApproval({
-                        runId: approval.runId,
-                        approvalId: approval.id,
-                        decision: 'approved',
-                        expectedVersion: approval.version,
-                      }),
-                    )
-                  }
-                >
-                  {isCN ? '批准' : 'Approve'}
-                </Button>
-                <Button
-                  danger
-                  icon={<CloseOutlined />}
-                  loading={pendingAction === 'reject'}
-                  onClick={() =>
-                    void runAction('reject', () =>
-                      agentActions.resolveApproval({
-                        runId: approval.runId,
-                        approvalId: approval.id,
-                        decision: 'rejected',
-                        expectedVersion: approval.version,
-                      }),
-                    )
-                  }
-                >
-                  {isCN ? '拒绝' : 'Reject'}
-                </Button>
-              </>
-            )}
-          </Flex>
-        </Flex>
-      )}
-
-      {tools.length > 0 && (
-        <Flex vertical gap={8}>
-          {tools.map((tool) => (
-            <Flex key={tool.id} justify="space-between" align="center" gap={12} wrap>
-              <Flex vertical gap={2} style={{ minWidth: 0 }}>
-                <Flex gap={8} align="center" wrap>
-                  <Typography.Text>{tool.name}</Typography.Text>
-                  <Tag color={statusColor[tool.status]}>{tool.status}</Tag>
-                </Flex>
-                <Typography.Text type="secondary">
-                  {`attempt: ${tool.attempt ?? 1}${tool.retryOf ? `, retryOf: ${tool.retryOf}` : ''}`}
-                </Typography.Text>
-              </Flex>
-              {tool.status === 'failed' && tool.error?.retryable && (
-                <Button
-                  icon={<RedoOutlined />}
-                  loading={pendingAction === `retry-${tool.id}`}
-                  onClick={() =>
-                    void runAction(`retry-${tool.id}`, () =>
-                      agentActions.retryTool({ runId: tool.runId, toolCallId: tool.id }),
-                    )
-                  }
-                >
-                  {isCN ? '重试' : 'Retry'}
-                </Button>
-              )}
+      {!run && (
+        <Alert
+          showIcon
+          type="info"
+          title={scenarioTitle}
+          description={
+            <Flex vertical gap={12} align="flex-start">
+              <Typography.Text>{scenarioDescription}</Typography.Text>
+              <Button
+                type="primary"
+                icon={<PlayCircleOutlined />}
+                loading={isResetting}
+                onClick={start}
+              >
+                {isCN ? '启动场景' : 'Start scenario'}
+              </Button>
             </Flex>
-          ))}
-        </Flex>
+          }
+        />
       )}
 
-      {task && (
-        <Flex gap={8} align="center" wrap>
-          <Typography.Text>{task.title}</Typography.Text>
-          <Tag color={statusColor[task.status]}>{task.status}</Tag>
+      {run && !interactionCompleted && (
+        <Flex vertical gap={12}>
+          <Flex gap={8} align="center" wrap>
+            <Tag color="blue">Agent Event</Tag>
+            <Typography.Text code>{protocol.startEvent}</Typography.Text>
+            <Typography.Text type="secondary">
+              {isCN ? '已更新到 SDK 状态' : 'received by SDK state'}
+            </Typography.Text>
+          </Flex>
+
+          {approval && !interactionCompleted && (
+            <Flex vertical gap={8}>
+              <Typography.Text strong>{approval.description}</Typography.Text>
+              <Flex gap={8} align="center" wrap>
+                <Tag color={statusColor[approval.status]}>{approval.status}</Tag>
+                <Tag color="red">{approval.risk}</Tag>
+                {approval.status === 'waiting' && (
+                  <>
+                    <Button
+                      icon={<CheckOutlined />}
+                      loading={pendingAction === 'approve'}
+                      onClick={() =>
+                        void runAction('approve', () =>
+                          agentActions.resolveApproval({
+                            runId: approval.runId,
+                            approvalId: approval.id,
+                            decision: 'approved',
+                            expectedVersion: approval.version,
+                          }),
+                        )
+                      }
+                    >
+                      {isCN ? '批准' : 'Approve'}
+                    </Button>
+                    <Button
+                      danger
+                      icon={<CloseOutlined />}
+                      loading={pendingAction === 'reject'}
+                      onClick={() =>
+                        void runAction('reject', () =>
+                          agentActions.resolveApproval({
+                            runId: approval.runId,
+                            approvalId: approval.id,
+                            decision: 'rejected',
+                            expectedVersion: approval.version,
+                          }),
+                        )
+                      }
+                    >
+                      {isCN ? '拒绝' : 'Reject'}
+                    </Button>
+                  </>
+                )}
+              </Flex>
+            </Flex>
+          )}
+
+          {scenario === 'retry' && tools.length > 0 && !interactionCompleted && (
+            <Flex vertical gap={8}>
+              {tools.map((tool) => (
+                <Flex key={tool.id} justify="space-between" align="center" gap={12} wrap>
+                  <Flex vertical gap={2} style={{ minWidth: 0 }}>
+                    <Flex gap={8} align="center" wrap>
+                      <Typography.Text>{tool.name}</Typography.Text>
+                      <Tag color={statusColor[tool.status]}>{tool.status}</Tag>
+                    </Flex>
+                    <Typography.Text type="secondary">
+                      {`attempt: ${tool.attempt ?? 1}${tool.retryOf ? `, retryOf: ${tool.retryOf}` : ''}`}
+                    </Typography.Text>
+                  </Flex>
+                  {tool.status === 'failed' && tool.error?.retryable && (
+                    <Button
+                      icon={<RedoOutlined />}
+                      loading={pendingAction === `retry-${tool.id}`}
+                      onClick={() =>
+                        void runAction(`retry-${tool.id}`, () =>
+                          agentActions.retryTool({ runId: tool.runId, toolCallId: tool.id }),
+                        )
+                      }
+                    >
+                      {isCN ? '重试' : 'Retry'}
+                    </Button>
+                  )}
+                </Flex>
+              ))}
+            </Flex>
+          )}
+
+          {scenario === 'cancel' && task && !interactionCompleted && (
+            <Flex gap={8} align="center" wrap>
+              <Typography.Text>{task.title}</Typography.Text>
+              <Tag color={statusColor[task.status]}>{task.status}</Tag>
+              <Typography.Text type="secondary">
+                {Math.round((task.progress ?? 0) * 100)}%
+              </Typography.Text>
+            </Flex>
+          )}
+
+          {scenario === 'cancel' && run.status === 'running' && !interactionCompleted && (
+            <Button
+              danger
+              icon={<StopOutlined />}
+              loading={pendingAction === 'cancel'}
+              onClick={() =>
+                void runAction('cancel', () =>
+                  agentActions.cancelRun({ runId: run.id, reason: 'Cancelled from the demo' }),
+                )
+              }
+            >
+              {isCN ? '取消 Run' : 'Cancel Run'}
+            </Button>
+          )}
+
           <Typography.Text type="secondary">
-            {Math.round((task.progress ?? 0) * 100)}%
+            {isCN ? '下一步将发送' : 'Next command'}{' '}
+            <Typography.Text code>{protocol.command}</Typography.Text>
           </Typography.Text>
         </Flex>
       )}
 
-      {run?.status === 'running' && (
-        <Button
-          danger
-          icon={<StopOutlined />}
-          loading={pendingAction === 'cancel'}
-          onClick={() =>
-            void runAction('cancel', () =>
-              agentActions.cancelRun({ runId: run.id, reason: 'Cancelled from the demo' }),
-            )
+      {interactionCompleted && (
+        <Alert
+          showIcon
+          type="success"
+          title={resultMessage}
+          description={
+            <Flex vertical gap={4}>
+              <Typography.Text>
+                <Tag color="green">Agent Command</Tag>
+                <Typography.Text code>{protocol.command}</Typography.Text>{' '}
+                {isCN ? '执行成功' : 'succeeded'}
+              </Typography.Text>
+              <Typography.Text>
+                <Tag color="blue">Agent Event</Tag>
+                <Typography.Text code>{protocol.resultEvent}</Typography.Text>{' '}
+                {isCN ? '已更新实体状态' : 'updated the entity state'}
+              </Typography.Text>
+              <Button icon={<RedoOutlined />} onClick={reset}>
+                {isCN ? '体验其他场景' : 'Try another scenario'}
+              </Button>
+            </Flex>
           }
-        >
-          {isCN ? '取消 Run' : 'Cancel Run'}
-        </Button>
+        />
       )}
 
-      {actionError && <Alert type="error" showIcon message={actionError} />}
+      {actionError && <Alert type="error" showIcon title={actionError} />}
 
-      <Divider style={{ margin: 0 }} />
-      <Flex gap={24} wrap>
-        <div style={{ flex: '1 1 260px', minWidth: 0 }}>
-          <Typography.Title level={5}>{isCN ? '命令状态' : 'Command states'}</Typography.Title>
-          {commands.length ? (
-            <Flex vertical gap={8}>
-              {commands.map((command) => (
-                <Flex
-                  key={command.key}
-                  justify="space-between"
-                  align="center"
-                  gap={8}
-                  style={{ width: '100%' }}
-                >
-                  <Typography.Text code>{command.command.type}</Typography.Text>
-                  <Tag color={statusColor[command.status]}>{command.status}</Tag>
+      {run && (
+        <>
+          <Divider style={{ margin: 0 }} />
+          <Typography.Title level={5} style={{ margin: 0 }}>
+            {isCN ? 'SDK 内部状态' : 'SDK state'}
+          </Typography.Title>
+          <Descriptions size="small" column={{ xs: 1, sm: 3 }}>
+            <Descriptions.Item label="Run ID">{run.id}</Descriptions.Item>
+            <Descriptions.Item label={isCN ? '运行状态' : 'Run status'}>
+              <Tag color={statusColor[run.status]}>{run.status}</Tag>
+            </Descriptions.Item>
+            <Descriptions.Item label={isCN ? '命令 ID' : 'Command ID'}>
+              {lastResult?.commandId ?? commandState?.command.commandId ?? '-'}
+            </Descriptions.Item>
+          </Descriptions>
+          <Flex gap={24} wrap>
+            <div style={{ flex: '1 1 260px', minWidth: 0 }}>
+              <Typography.Title level={5}>{isCN ? '命令状态' : 'Command states'}</Typography.Title>
+              {commands.length ? (
+                <Flex vertical gap={8}>
+                  {commands.map((command) => (
+                    <Flex
+                      key={command.key}
+                      justify="space-between"
+                      align="center"
+                      gap={8}
+                      style={{ width: '100%' }}
+                    >
+                      <Typography.Text code>{command.command.type}</Typography.Text>
+                      <Tag color={statusColor[command.status]}>{command.status}</Tag>
+                    </Flex>
+                  ))}
                 </Flex>
-              ))}
-            </Flex>
-          ) : (
-            <Typography.Text type="secondary">{isCN ? '暂无命令' : 'No commands'}</Typography.Text>
-          )}
-        </div>
-        <div style={{ flex: '1 1 260px', minWidth: 0 }}>
-          <Typography.Title level={5}>AgentTimeline</Typography.Title>
-          {timeline.length ? (
-            <Flex vertical gap={8}>
-              {timeline.map((entry) => (
-                <Flex
-                  key={`${entry.kind}:${entry.entity.runId}:${entry.entity.id}`}
-                  justify="space-between"
-                  align="center"
-                  gap={8}
-                  style={{ width: '100%' }}
-                >
-                  <Typography.Text code>{entry.kind}</Typography.Text>
-                  <Tag color={statusColor[entry.entity.status]}>{entry.entity.status}</Tag>
+              ) : (
+                <Typography.Text type="secondary">
+                  {isCN ? '暂无命令' : 'No commands'}
+                </Typography.Text>
+              )}
+            </div>
+            <div style={{ flex: '1 1 260px', minWidth: 0 }}>
+              <Typography.Title level={5}>AgentTimeline</Typography.Title>
+              {timeline.length ? (
+                <Flex vertical gap={8}>
+                  {timeline.map((entry) => (
+                    <Flex
+                      key={`${entry.kind}:${entry.entity.runId}:${entry.entity.id}`}
+                      justify="space-between"
+                      align="center"
+                      gap={8}
+                      style={{ width: '100%' }}
+                    >
+                      <Typography.Text code>
+                        {entry.kind}:{entry.entity.id}
+                      </Typography.Text>
+                      <Tag color={statusColor[entry.entity.status]}>{entry.entity.status}</Tag>
+                    </Flex>
+                  ))}
                 </Flex>
-              ))}
-            </Flex>
-          ) : (
-            <Typography.Text type="secondary">
-              {isCN ? '暂无实体事件' : 'No entity events'}
-            </Typography.Text>
-          )}
-        </div>
-      </Flex>
+              ) : (
+                <Typography.Text type="secondary">
+                  {isCN ? '暂无实体事件' : 'No entity events'}
+                </Typography.Text>
+              )}
+            </div>
+          </Flex>
+        </>
+      )}
     </Flex>
   );
 };

--- a/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.tsx
+++ b/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.tsx
@@ -1,0 +1,473 @@
+import {
+  CheckOutlined,
+  CloseOutlined,
+  PlayCircleOutlined,
+  RedoOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
+import type {
+  AgentActionResult,
+  AgentCommandOptions,
+  AgentProvider,
+  AgentProviderCapabilities,
+  AgentProviderContextOptions,
+  AgentTransport,
+} from '@ant-design/x-sdk';
+import { experimentalAgent, useXChat } from '@ant-design/x-sdk';
+import { Alert, Button, Descriptions, Divider, Flex, Segmented, Tag, Typography } from 'antd';
+import React from 'react';
+
+type DemoScenario = 'approval' | 'retry' | 'cancel';
+
+interface DemoInput {
+  scenario: DemoScenario;
+  locale: 'en-US' | 'zh-CN';
+}
+
+interface DemoContext {
+  events: AgentProviderContextOptions['events'];
+  runId: string;
+}
+
+const wait = (signal: AbortSignal, timeout = 500) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+      return;
+    }
+    const timer = window.setTimeout(resolve, timeout);
+    signal.addEventListener(
+      'abort',
+      () => {
+        window.clearTimeout(timer);
+        reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+      },
+      { once: true },
+    );
+  });
+
+const waitForAbort = (signal: AbortSignal) =>
+  new Promise<never>((_, reject) => {
+    const abort = () =>
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+    signal.addEventListener('abort', abort, { once: true });
+  });
+
+class PendingTransport implements AgentTransport<DemoInput, never> {
+  readonly kind = 'demo.pending' as const;
+
+  open(_request: DemoInput, signal: AbortSignal): AsyncIterable<never> {
+    return {
+      [Symbol.asyncIterator]() {
+        return { next: () => waitForAbort(signal) };
+      },
+    };
+  }
+}
+
+class InteractionProvider implements AgentProvider<DemoInput, DemoInput, never, DemoContext> {
+  readonly id = 'demo-agent-interaction';
+  readonly protocol = { name: 'agent-event', version: '0.1' } as const;
+  readonly capabilities: AgentProviderCapabilities = {
+    eventTypes: [
+      'run.started',
+      'run.cancelled',
+      'approval.requested',
+      'approval.resolved',
+      'tool.requested',
+      'tool.running',
+      'tool.completed',
+      'tool.failed',
+      'task.created',
+      'task.updated',
+      'task.cancelled',
+    ],
+    transports: ['demo.pending'],
+    commands: ['approval.resolve', 'tool.retry', 'run.cancel'],
+  };
+  readonly transport = new PendingTransport();
+
+  private readonly scenarios = new Map<string, DemoScenario>();
+  private readonly resolvedApprovals = new Set<string>();
+  private readonly retryCounts = new Map<string, number>();
+
+  createContext(options: AgentProviderContextOptions): DemoContext {
+    return { events: options.events, runId: options.runId };
+  }
+
+  start(input: DemoInput, context: DemoContext) {
+    this.scenarios.set(context.runId, input.scenario);
+    const isCN = input.locale === 'zh-CN';
+    const started = context.events.create('run.started', { input });
+
+    if (input.scenario === 'approval') {
+      return [
+        started,
+        context.events.create('approval.requested', {
+          approvalId: 'deploy-approval',
+          description: isCN ? '将 2.9.0 版本部署到生产环境' : 'Deploy release 2.9.0 to production',
+          risk: 'high',
+          editable: true,
+          version: 1,
+          data: { environment: 'production', version: '2.9.0' },
+        }),
+      ];
+    }
+
+    if (input.scenario === 'retry') {
+      return [
+        started,
+        context.events.create('tool.requested', {
+          toolCallId: 'search-tool-1',
+          name: 'knowledge.search',
+          arguments: JSON.stringify({ query: 'Agent interaction protocol' }),
+          attempt: 1,
+        }),
+        context.events.create('tool.running', { toolCallId: 'search-tool-1' }),
+        context.events.create('tool.failed', {
+          toolCallId: 'search-tool-1',
+          error: {
+            code: 'TIMEOUT',
+            message: isCN ? '检索超时' : 'Search timed out',
+            retryable: true,
+          },
+        }),
+      ];
+    }
+
+    return [
+      started,
+      context.events.create('task.created', {
+        taskId: 'long-task',
+        title: isCN ? '生成发布报告' : 'Generate release report',
+      }),
+      context.events.create('task.updated', { taskId: 'long-task', progress: 0.35 }),
+    ];
+  }
+
+  prepareRequest(input: DemoInput) {
+    return input;
+  }
+
+  transformChunk(_chunk: never) {
+    return [];
+  }
+
+  flush() {
+    return [];
+  }
+
+  transformError() {
+    return [];
+  }
+
+  async *executeCommand(command: experimentalAgent.AgentCommand, options: AgentCommandOptions) {
+    const events = experimentalAgent.createAgentEventFactory({
+      sessionId: command.sessionId,
+      runId: command.runId,
+      initialSequence: options.initialSequence,
+      now: options.now,
+    });
+
+    await wait(options.signal);
+
+    if (command.type === 'approval.resolve') {
+      this.resolvedApprovals.add(command.runId);
+      yield events.create('approval.resolved', {
+        approvalId: command.payload.approvalId,
+        decision: command.payload.decision,
+        data: command.payload.data,
+      });
+      return;
+    }
+
+    if (command.type === 'tool.retry') {
+      const attempt = (this.retryCounts.get(command.runId) ?? 1) + 1;
+      this.retryCounts.set(command.runId, attempt);
+      const toolCallId = `search-tool-${attempt}`;
+      yield events.create('tool.requested', {
+        toolCallId,
+        name: 'knowledge.search',
+        arguments: JSON.stringify({ query: 'Agent interaction protocol' }),
+        attempt,
+        retryOf: command.payload.toolCallId,
+      });
+      yield events.create('tool.running', { toolCallId });
+      await wait(options.signal);
+      yield events.create('tool.completed', {
+        toolCallId,
+        result: { matches: 8, source: 'local-fixture' },
+      });
+      return;
+    }
+
+    const scenario = this.scenarios.get(command.runId);
+    if (scenario === 'approval' && !this.resolvedApprovals.has(command.runId)) {
+      yield events.create('approval.resolved', {
+        approvalId: 'deploy-approval',
+        decision: 'expired',
+      });
+    }
+    if (scenario === 'cancel') {
+      yield events.create('task.cancelled', {
+        taskId: 'long-task',
+        reason: command.payload.reason,
+      });
+    }
+    yield events.create('run.cancelled', { reason: command.payload.reason });
+  }
+}
+
+const statusColor = {
+  cancelled: 'default',
+  completed: 'success',
+  failed: 'error',
+  pending: 'processing',
+  running: 'processing',
+  streaming: 'processing',
+  submitting: 'processing',
+  succeeded: 'success',
+  waiting: 'warning',
+} as const;
+
+const App = () => {
+  const isCN = typeof location !== 'undefined' && location.pathname.endsWith('-cn');
+  const [scenario, setScenario] = React.useState<DemoScenario>('approval');
+  const [provider] = React.useState(() => new InteractionProvider());
+  const [pendingAction, setPendingAction] = React.useState<string>();
+  const [lastResult, setLastResult] = React.useState<AgentActionResult>();
+  const [actionError, setActionError] = React.useState<string>();
+  const { agentState, agentActions, commandStates, onRequest, isRequesting } = useXChat({
+    provider,
+  });
+
+  const run = Object.values(agentState.runs).at(-1);
+  const approval = run
+    ? experimentalAgent.selectApproval(agentState, {
+        runId: run.id,
+        approvalId: 'deploy-approval',
+      })
+    : undefined;
+  const tools = run
+    ? Object.values(agentState.toolCalls).filter((tool) => tool.runId === run.id)
+    : [];
+  const task = run
+    ? Object.values(agentState.tasks).find((item) => item.runId === run.id)
+    : undefined;
+  const commands = Object.values(commandStates).filter(
+    (command) => !run || command.command.runId === run.id,
+  );
+  const timeline = run ? experimentalAgent.selectAgentTimeline(agentState, { runId: run.id }) : [];
+
+  const runAction = async (key: string, action: () => Promise<AgentActionResult>) => {
+    setPendingAction(key);
+    setActionError(undefined);
+    try {
+      setLastResult(await action());
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPendingAction(undefined);
+    }
+  };
+
+  const start = () => {
+    setLastResult(undefined);
+    setActionError(undefined);
+    onRequest({ scenario, locale: isCN ? 'zh-CN' : 'en-US' });
+  };
+
+  return (
+    <Flex vertical gap={16}>
+      <Flex gap={8} wrap>
+        <Segmented
+          value={scenario}
+          disabled={isRequesting}
+          options={[
+            { label: isCN ? '审批' : 'Approval', value: 'approval' },
+            { label: isCN ? '工具重试' : 'Tool retry', value: 'retry' },
+            { label: isCN ? '取消运行' : 'Run cancel', value: 'cancel' },
+          ]}
+          onChange={(value) => setScenario(value as DemoScenario)}
+        />
+        <Button
+          type="primary"
+          icon={<PlayCircleOutlined />}
+          disabled={isRequesting}
+          onClick={start}
+        >
+          {isCN ? '启动 Run' : 'Start Run'}
+        </Button>
+      </Flex>
+
+      <Descriptions size="small" column={{ xs: 1, sm: 3 }}>
+        <Descriptions.Item label="Run ID">{run?.id ?? '-'}</Descriptions.Item>
+        <Descriptions.Item label={isCN ? '运行状态' : 'Run status'}>
+          {run ? <Tag color={statusColor[run.status]}>{run.status}</Tag> : '-'}
+        </Descriptions.Item>
+        <Descriptions.Item label={isCN ? '最近命令' : 'Last command'}>
+          {lastResult?.commandId ?? '-'}
+        </Descriptions.Item>
+      </Descriptions>
+
+      {approval && (
+        <Flex vertical gap={8}>
+          <Typography.Text strong>{approval.description}</Typography.Text>
+          <Flex gap={8} align="center" wrap>
+            <Tag color={statusColor[approval.status]}>{approval.status}</Tag>
+            <Tag color="red">{approval.risk}</Tag>
+            {approval.status === 'waiting' && (
+              <>
+                <Button
+                  icon={<CheckOutlined />}
+                  loading={pendingAction === 'approve'}
+                  onClick={() =>
+                    void runAction('approve', () =>
+                      agentActions.resolveApproval({
+                        runId: approval.runId,
+                        approvalId: approval.id,
+                        decision: 'approved',
+                        expectedVersion: approval.version,
+                      }),
+                    )
+                  }
+                >
+                  {isCN ? '批准' : 'Approve'}
+                </Button>
+                <Button
+                  danger
+                  icon={<CloseOutlined />}
+                  loading={pendingAction === 'reject'}
+                  onClick={() =>
+                    void runAction('reject', () =>
+                      agentActions.resolveApproval({
+                        runId: approval.runId,
+                        approvalId: approval.id,
+                        decision: 'rejected',
+                        expectedVersion: approval.version,
+                      }),
+                    )
+                  }
+                >
+                  {isCN ? '拒绝' : 'Reject'}
+                </Button>
+              </>
+            )}
+          </Flex>
+        </Flex>
+      )}
+
+      {tools.length > 0 && (
+        <Flex vertical gap={8}>
+          {tools.map((tool) => (
+            <Flex key={tool.id} justify="space-between" align="center" gap={12} wrap>
+              <Flex vertical gap={2} style={{ minWidth: 0 }}>
+                <Flex gap={8} align="center" wrap>
+                  <Typography.Text>{tool.name}</Typography.Text>
+                  <Tag color={statusColor[tool.status]}>{tool.status}</Tag>
+                </Flex>
+                <Typography.Text type="secondary">
+                  {`attempt: ${tool.attempt ?? 1}${tool.retryOf ? `, retryOf: ${tool.retryOf}` : ''}`}
+                </Typography.Text>
+              </Flex>
+              {tool.status === 'failed' && tool.error?.retryable && (
+                <Button
+                  icon={<RedoOutlined />}
+                  loading={pendingAction === `retry-${tool.id}`}
+                  onClick={() =>
+                    void runAction(`retry-${tool.id}`, () =>
+                      agentActions.retryTool({ runId: tool.runId, toolCallId: tool.id }),
+                    )
+                  }
+                >
+                  {isCN ? '重试' : 'Retry'}
+                </Button>
+              )}
+            </Flex>
+          ))}
+        </Flex>
+      )}
+
+      {task && (
+        <Flex gap={8} align="center" wrap>
+          <Typography.Text>{task.title}</Typography.Text>
+          <Tag color={statusColor[task.status]}>{task.status}</Tag>
+          <Typography.Text type="secondary">
+            {Math.round((task.progress ?? 0) * 100)}%
+          </Typography.Text>
+        </Flex>
+      )}
+
+      {run?.status === 'running' && (
+        <Button
+          danger
+          icon={<StopOutlined />}
+          loading={pendingAction === 'cancel'}
+          onClick={() =>
+            void runAction('cancel', () =>
+              agentActions.cancelRun({ runId: run.id, reason: 'Cancelled from the demo' }),
+            )
+          }
+        >
+          {isCN ? '取消 Run' : 'Cancel Run'}
+        </Button>
+      )}
+
+      {actionError && <Alert type="error" showIcon message={actionError} />}
+
+      <Divider style={{ margin: 0 }} />
+      <Flex gap={24} wrap>
+        <div style={{ flex: '1 1 260px', minWidth: 0 }}>
+          <Typography.Title level={5}>{isCN ? '命令状态' : 'Command states'}</Typography.Title>
+          {commands.length ? (
+            <Flex vertical gap={8}>
+              {commands.map((command) => (
+                <Flex
+                  key={command.key}
+                  justify="space-between"
+                  align="center"
+                  gap={8}
+                  style={{ width: '100%' }}
+                >
+                  <Typography.Text code>{command.command.type}</Typography.Text>
+                  <Tag color={statusColor[command.status]}>{command.status}</Tag>
+                </Flex>
+              ))}
+            </Flex>
+          ) : (
+            <Typography.Text type="secondary">{isCN ? '暂无命令' : 'No commands'}</Typography.Text>
+          )}
+        </div>
+        <div style={{ flex: '1 1 260px', minWidth: 0 }}>
+          <Typography.Title level={5}>AgentTimeline</Typography.Title>
+          {timeline.length ? (
+            <Flex vertical gap={8}>
+              {timeline.map((entry) => (
+                <Flex
+                  key={`${entry.kind}:${entry.entity.runId}:${entry.entity.id}`}
+                  justify="space-between"
+                  align="center"
+                  gap={8}
+                  style={{ width: '100%' }}
+                >
+                  <Typography.Text code>{entry.kind}</Typography.Text>
+                  <Tag color={statusColor[entry.entity.status]}>{entry.entity.status}</Tag>
+                </Flex>
+              ))}
+            </Flex>
+          ) : (
+            <Typography.Text type="secondary">
+              {isCN ? '暂无实体事件' : 'No entity events'}
+            </Typography.Text>
+          )}
+        </div>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default App;

--- a/packages/x/docs/x-sdk/use-x-chat.en-US.md
+++ b/packages/x/docs/x-sdk/use-x-chat.en-US.md
@@ -21,6 +21,7 @@ Manage conversation data through Agent and produce data for page rendering.
 <code src="./demos/x-chat/openai.tsx">OpenAI Model Integration</code>
 <code src="./demos/x-chat/deepSeek.tsx">Thinking Model Integration</code>
 <code src="./demos/x-chat/agent-provider.tsx">Generic AgentProvider Integration</code>
+<code src="./demos/x-chat/agent-interaction.tsx">Agent Command Interaction</code>
 <code src="./demos/x-chat/defaultMessages.tsx">Historical Messages Setup</code>
 <code src="./demos/x-chat/async-defaultMessages.tsx">Request Remote Historical Messages</code>
 <code src="./demos/x-chat/developer.tsx">System Prompt Setup</code>
@@ -45,7 +46,16 @@ type useXChat<
 AgentProvider uses the same Hook. The overload infers input, Chunk, and structured state types:
 
 ```tsx | pure
-const { messages, agentState, onRequest, abort, isRequesting } = useXChat({ provider });
+const {
+  messages,
+  agentState,
+  agentActions,
+  commandStates,
+  latestCommandByAction,
+  onRequest,
+  abort,
+  isRequesting,
+} = useXChat({ provider });
 ```
 
 See [Agent Provider](/x-sdks/agent-provider) for the complete contract and implementation guide.
@@ -86,6 +96,9 @@ See [Agent Provider](/x-sdks/agent-provider) for the complete contract and imple
 | removeMessage | Deleting a single message will not trigger a request | (id: string \| number) => boolean | - | - |
 | queueRequest | Will add the request to a queue, waiting for the conversationKey to be initialized before sending | (conversationKey: string \| symbol, requestParams: Partial\<Input\>, opts?: { extraInfo: AnyObject }) => void | - | - |
 | agentState | Complete structured state in AgentProvider mode; `undefined` in regular ChatProvider mode | AgentState \| undefined | undefined | - |
+| agentActions | Approval, tool retry, and Run cancellation operations in AgentProvider mode; `undefined` in regular ChatProvider mode | AgentActions \| undefined | undefined | - |
+| commandStates | Command submission state for the active Runs, keyed by `commandId` | Record\<string, AgentCommandState\> \| undefined | undefined | - |
+| latestCommandByAction | Maps an action key to its latest `commandId` for duplicate prevention and control state lookup | Record\<string, string\> \| undefined | undefined | - |
 
 ### AgentProvider Mode
 
@@ -94,6 +107,28 @@ AgentProvider mode accepts only `provider`, `conversationKey`, `defaultMessages`
 `messages` remains compatible with existing message components and contains `AgentMessageState`. Non-message data such as reasoning, tools, approvals, tasks, and artifacts is available from `agentState`.
 
 `setMessages`, `setMessage`, and `removeMessage` only affect the compatibility message layer and do not directly mutate `agentState`. In AgentProvider mode, `onReload` starts a new Run.
+
+#### Agent Actions
+
+After an AgentProvider declares command capabilities and implements `executeCommand`, the UI invokes operations through `agentActions`:
+
+```tsx | pure
+await agentActions.resolveApproval({
+  runId,
+  approvalId,
+  decision: 'approved',
+  expectedVersion: approval.version,
+});
+
+await agentActions.retryTool({ runId, toolCallId });
+await agentActions.cancelRun({ runId, reason: 'User cancelled' });
+```
+
+- `resolveApproval` only accepts a non-expired Approval in the `waiting` state.
+- `retryTool` only accepts a failed ToolCall with `error.retryable === true`.
+- `cancelRun` is a business command sent to the Runtime and waits for `run.cancelled`; `abort()` only interrupts the local Transport.
+- Commands for one Run execute serially. The SDK rejects duplicate in-flight actions and further actions after cancellation is submitted.
+- `commandStates` exposes `submitting`, `succeeded`, and `failed`, and is cleared after the Run reaches a terminal state.
 
 #### MessageInfo
 

--- a/packages/x/docs/x-sdk/use-x-chat.zh-CN.md
+++ b/packages/x/docs/x-sdk/use-x-chat.zh-CN.md
@@ -21,6 +21,7 @@ tag: 2.0.0
 <code src="./demos/x-chat/openai.tsx">OpenAI 模型接入</code>
 <code src="./demos/x-chat/deepSeek.tsx">DeepSeek 思考模型接入</code>
 <code src="./demos/x-chat/agent-provider.tsx">通用 AgentProvider 接入</code>
+<code src="./demos/x-chat/agent-interaction.tsx">Agent 命令交互</code>
 <code src="./demos/x-chat/defaultMessages.tsx">历史消息设置</code>
 <code src="./demos/x-chat/async-defaultMessages.tsx">请求远程历史消息</code>
 <code src="./demos/x-chat/developer.tsx">系统提示词设置</code>
@@ -45,7 +46,16 @@ type useXChat<
 AgentProvider 使用同一个 Hook，通过重载推导输入、Chunk 和结构化状态类型：
 
 ```tsx | pure
-const { messages, agentState, onRequest, abort, isRequesting } = useXChat({ provider });
+const {
+  messages,
+  agentState,
+  agentActions,
+  commandStates,
+  latestCommandByAction,
+  onRequest,
+  abort,
+  isRequesting,
+} = useXChat({ provider });
 ```
 
 完整契约和实现方式请参阅 [Agent Provider](/x-sdks/agent-provider-cn)。
@@ -86,6 +96,9 @@ const { messages, agentState, onRequest, abort, isRequesting } = useXChat({ prov
 | removeMessage | 删除单条 message，不会触发请求 | (id: string \| number) => boolean | - | - |
 | queueRequest | 会将请求加入队列，等待 conversationKey 初始化完成后再发送 | (conversationKey: string \| symbol, requestParams: Partial\<Input\>, opts?: { extraInfo: AnyObject }) => void | - | - |
 | agentState | AgentProvider 模式下的完整结构化状态；普通 ChatProvider 模式为 `undefined` | AgentState \| undefined | undefined | - |
+| agentActions | AgentProvider 模式下的审批、工具重试和 Run 取消操作；普通 ChatProvider 模式为 `undefined` | AgentActions \| undefined | undefined | - |
+| commandStates | 按 `commandId` 保存当前 Run 的命令提交状态 | Record\<string, AgentCommandState\> \| undefined | undefined | - |
+| latestCommandByAction | 从动作键到最近一次 `commandId` 的映射，用于防重复提交和定位按钮状态 | Record\<string, string\> \| undefined | undefined | - |
 
 ### AgentProvider 模式
 
@@ -94,6 +107,28 @@ AgentProvider 模式只接受 `provider`、`conversationKey`、`defaultMessages`
 `messages` 仍可供现有消息组件消费，实际消息为 `AgentMessageState`。推理、工具、审批、任务和 Artifact 等非消息数据保存在 `agentState` 中。
 
 `setMessages`、`setMessage` 和 `removeMessage` 只影响兼容消息层，不会直接修改 `agentState`。AgentProvider 模式下调用 `onReload` 会创建新 Run。
+
+#### Agent Actions
+
+AgentProvider 声明对应命令能力并实现 `executeCommand` 后，UI 通过 `agentActions` 发起操作：
+
+```tsx | pure
+await agentActions.resolveApproval({
+  runId,
+  approvalId,
+  decision: 'approved',
+  expectedVersion: approval.version,
+});
+
+await agentActions.retryTool({ runId, toolCallId });
+await agentActions.cancelRun({ runId, reason: 'User cancelled' });
+```
+
+- `resolveApproval` 只接受处于 `waiting` 状态且未过期的 Approval。
+- `retryTool` 只接受 `error.retryable === true` 的失败 ToolCall。
+- `cancelRun` 是发给 Runtime 的业务命令，等待 Provider 返回 `run.cancelled`；`abort()` 只中断本地 Transport。
+- 同一 Run 的命令串行执行。相同动作提交中以及取消已提交后，SDK 会阻止重复操作。
+- `commandStates` 包含 `submitting`、`succeeded` 和 `failed`，Run 进入终态后会自动清理。
 
 #### MessageInfo
 


### PR DESCRIPTION
## Summary

- add the versioned AgentCommand 0.1 protocol with validation, command factories, action keys, and idempotency keys
- support approval.resolve, tool.retry, and run.cancel through AgentProvider and useXChat agentActions
- serialize commands per Run, prevent duplicate actions, track command submission state, and clean up terminal Run transports
- expose UI-independent Run, ToolCall, Approval, and AgentTimeline selectors
- extend ToolCall retry metadata and Approval edit, expiry, and version metadata

## Validation

- npm run tsc --workspace packages/x-sdk
- npm run lint:script --workspace packages/x-sdk
- npm test --workspace packages/x-sdk -- --runInBand (15 suites, 154 tests)
- npm run compile --workspace packages/x-sdk
- git diff --check

## RFC

- https://github.com/ant-design/x/discussions/2007