### PR TITLE
feat: support typewriter animation for contentRender custom components

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/Renderer.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Renderer.test.ts
@@ -1516,6 +1516,58 @@ describe('Renderer', () => {
 
       createElementSpy.mockRestore();
     });
+
+    it('should apply animation to text nodes inside custom components when enableAnimationForCustomComponents is true', () => {
+      const createElementSpy = jest.spyOn(React, 'createElement');
+
+      const CustomComponent: React.FC<any> = (props) => React.createElement('div', props);
+      const renderer = new Renderer({
+        components: { 'content-render': CustomComponent },
+        streaming: {
+          enableAnimation: true,
+          enableAnimationForCustomComponents: true,
+          animationConfig: {
+            fadeDuration: 150,
+            easing: 'ease-out',
+          },
+        },
+      });
+
+      const html = '<content-render>Hello World</content-render>';
+      renderer.processHtml(html);
+
+      // Verify that AnimationText was used for text inside custom component
+      const animationTextCalls = createElementSpy.mock.calls.filter(
+        (call) => call[0]?.displayName === 'AnimationText' || call[0]?.name === 'AnimationText',
+      );
+      expect(animationTextCalls.length).toBeGreaterThan(0);
+
+      createElementSpy.mockRestore();
+    });
+
+    it('should NOT apply animation to text nodes inside custom components when enableAnimationForCustomComponents is false', () => {
+      const createElementSpy = jest.spyOn(React, 'createElement');
+
+      const CustomComponent: React.FC<any> = (props) => React.createElement('div', props);
+      const renderer = new Renderer({
+        components: { 'content-render': CustomComponent },
+        streaming: {
+          enableAnimation: true,
+          enableAnimationForCustomComponents: false,
+        },
+      });
+
+      const html = '<content-render>Hello World</content-render>';
+      renderer.processHtml(html);
+
+      // Verify that AnimationText was NOT used for text inside custom component
+      const animationTextCalls = createElementSpy.mock.calls.filter(
+        (call) => call[0]?.displayName === 'AnimationText' || call[0]?.name === 'AnimationText',
+      );
+      expect(animationTextCalls.length).toBe(0);
+
+      createElementSpy.mockRestore();
+    });
   });
 
   describe('SSR / no DOM safety', () => {

--- a/packages/x-markdown/src/XMarkdown/core/Renderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Renderer.ts
@@ -172,7 +172,8 @@ class Renderer {
     unclosedTags: Set<string> | undefined,
     cidRef: { current: number; tagIndexes: Record<string, number> },
   ) {
-    const { enableAnimation, animationConfig } = this.options.streaming || {};
+    const { enableAnimation, animationConfig, enableAnimationForCustomComponents } =
+      this.options.streaming || {};
     return (domNode: DOMNode) => {
       const key = `x-markdown-component-${cidRef.current++}`;
 
@@ -180,9 +181,13 @@ class Renderer {
       const isValidTextNode =
         domNode.type === 'text' && domNode.data && Renderer.NON_WHITESPACE_REGEX.test(domNode.data);
       // Skip animation for text nodes inside custom components to preserve their internal structure
+      // unless enableAnimationForCustomComponents is true
       const parentTagName = (domNode.parent as Element)?.name;
       const isParentCustomComponent = parentTagName && this.options.components?.[parentTagName];
-      const shouldReplaceText = enableAnimation && isValidTextNode && !isParentCustomComponent;
+      const shouldReplaceText =
+        enableAnimation &&
+        isValidTextNode &&
+        (!isParentCustomComponent || enableAnimationForCustomComponents);
       if (shouldReplaceText) {
         return React.createElement(AnimationText, { text: domNode.data, key, animationConfig });
       }

--- a/packages/x-markdown/src/XMarkdown/interface.ts
+++ b/packages/x-markdown/src/XMarkdown/interface.ts
@@ -80,6 +80,12 @@ interface StreamingOption {
       string
     >
   >;
+  /**
+   * @description 是否为自定义组件内的文本节点启用打字机动画效果，配合 contentRender 使用时可实现自定义渲染的逐字输出
+   * @description Whether to enable typewriter animation for text nodes inside custom components, enabling character-by-character output when used with contentRender
+   * @default false
+   */
+  enableAnimationForCustomComponents?: boolean;
 }
 
 type StreamStatus = 'loading' | 'done';


### PR DESCRIPTION
## What does this PR do?

Adds support for typewriter animation in custom components (contentRender).

## Changes

- Added enableAnimationForCustomComponents option to StreamingOption interface
- Updated Renderer to apply animation to text nodes inside custom components when enabled
- Added unit tests for the new feature

## Usage

`	sx
<XMarkdown
  content={markdownContent}
  streaming={{
    enableAnimation: true,
    enableAnimationForCustomComponents: true,
  }}
  components={{
    'content-render': MyCustomComponent,
  }}
/>
`

## Related Issues

Closes #1950
Related to #1685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增配置项，可控制自定义组件内部文本是否启用逐字动画。
  * 默认关闭该动画，保持现有行为不变。
  * 启用后，自定义组件中的有效文本节点将显示动画效果。

* **测试**
  * 新增测试，验证动画开启和关闭时的显示行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->