### PR TITLE
feat: add Task component for agent progress

### DIFF
--- a/packages/x/components/index.ts
+++ b/packages/x/components/index.ts
@@ -27,6 +27,15 @@ export type { SourcesProps } from './sources';
 export { default as Sources } from './sources';
 export type { SuggestionProps } from './suggestion';
 export { default as Suggestion } from './suggestion';
+export type {
+  TaskError,
+  TaskItem,
+  TaskProps,
+  TaskRef,
+  TaskSemanticType,
+  TaskStatus,
+} from './task';
+export { default as Task } from './task';
 export type { ThinkProps } from './think';
 export { default as Think } from './think';
 export type {

--- a/packages/x/components/locale/en_US.ts
+++ b/packages/x/components/locale/en_US.ts
@@ -35,6 +35,20 @@ const localeValues: Required<xLocale> = {
     noService: 'File content service not configured',
     loadFailed: 'Failed to load file',
   },
+  Task: {
+    status: {
+      pending: 'Pending',
+      running: 'In progress',
+      completed: 'Completed',
+      failed: 'Failed',
+      cancelled: 'Cancelled',
+    },
+    expand: 'Expand task details',
+    collapse: 'Collapse task details',
+    result: 'Result',
+    error: 'Error',
+    reason: 'Reason',
+  },
 };
 
 export default localeValues;

--- a/packages/x/components/locale/index.tsx
+++ b/packages/x/components/locale/index.tsx
@@ -43,6 +43,14 @@ export interface xLocale {
     noService: string;
     loadFailed: string;
   };
+  Task?: {
+    status: Record<'pending' | 'running' | 'completed' | 'failed' | 'cancelled', string>;
+    expand: string;
+    collapse: string;
+    result: string;
+    error: string;
+    reason: string;
+  };
 }
 
 export type Locale = xLocale & antdLocale;

--- a/packages/x/components/locale/zh_CN.ts
+++ b/packages/x/components/locale/zh_CN.ts
@@ -35,6 +35,20 @@ const localeValues: Required<xLocale> = {
     noService: '未配置文件内容服务',
     loadFailed: '加载文件失败',
   },
+  Task: {
+    status: {
+      pending: '等待执行',
+      running: '进行中',
+      completed: '已完成',
+      failed: '执行失败',
+      cancelled: '已取消',
+    },
+    expand: '展开任务详情',
+    collapse: '收起任务详情',
+    result: '结果',
+    error: '错误',
+    reason: '原因',
+  },
 };
 
 export default localeValues;

--- a/packages/x/components/task/Task.tsx
+++ b/packages/x/components/task/Task.tsx
@@ -1,0 +1,276 @@
+import {
+  CheckCircleFilled,
+  ClockCircleOutlined,
+  CloseCircleFilled,
+  DownOutlined,
+  LoadingOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
+import type { CSSMotionProps } from '@rc-component/motion';
+import CSSMotion from '@rc-component/motion';
+import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { Progress } from 'antd';
+import { clsx } from 'clsx';
+import React from 'react';
+import useProxyImperativeHandle from '../_util/hooks/use-proxy-imperative-handle';
+import useXComponentConfig from '../_util/hooks/use-x-component-config';
+import initCollapseMotion from '../_util/motion';
+import { useLocale } from '../locale';
+import enUS from '../locale/en_US';
+import { useXProviderContext } from '../x-provider';
+import type { TaskError, TaskProps, TaskRef, TaskSemanticType, TaskStatus } from './interface';
+import useStyle from './style';
+
+const DEFAULT_EXPANDED: Record<TaskStatus, boolean> = {
+  pending: false,
+  running: true,
+  completed: false,
+  failed: true,
+  cancelled: false,
+};
+
+const STATUS_ICONS: Record<TaskStatus, React.ReactNode> = {
+  pending: <ClockCircleOutlined />,
+  running: <LoadingOutlined spin />,
+  completed: <CheckCircleFilled />,
+  failed: <CloseCircleFilled />,
+  cancelled: <StopOutlined />,
+};
+
+const valueType = (value: unknown): string => {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return `Array(${value.length})`;
+  return Object.prototype.toString.call(value).slice(8, -1);
+};
+
+const safeStringify = (value: unknown): string => {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || value == null) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? `[${valueType(value)}]`;
+  } catch {
+    return `[${valueType(value)}, unable to serialize]`;
+  }
+};
+
+const normalizeProgress = (progress: number) => Math.min(100, Math.max(0, progress * 100));
+
+const Task = React.forwardRef<TaskRef, TaskProps>((props, ref) => {
+  const {
+    item,
+    expanded: controlledExpanded,
+    defaultExpanded,
+    onExpandedChange,
+    statusRender,
+    progressRender,
+    resultRender,
+    errorRender,
+    actions,
+    classNames = {},
+    styles = {},
+    prefixCls: customizePrefixCls,
+    rootClassName,
+    className,
+    style,
+    children,
+    ...restProps
+  } = props;
+
+  const { direction, getPrefixCls } = useXProviderContext();
+  const prefixCls = getPrefixCls('task', customizePrefixCls);
+  const contextConfig = useXComponentConfig('task');
+  const [hashId, cssVarCls] = useStyle(prefixCls);
+  const [locale] = useLocale('Task', enUS.Task);
+  const [innerExpanded, setInnerExpanded] = React.useState(
+    defaultExpanded ?? DEFAULT_EXPANDED[item.status],
+  );
+  const mergedExpanded = controlledExpanded ?? innerExpanded;
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const detailsId = `${prefixCls}-details-${React.useId().replace(/:/g, '')}`;
+
+  useProxyImperativeHandle(ref, () => ({ nativeElement: rootRef.current! }));
+
+  React.useEffect(() => {
+    if (controlledExpanded === undefined && defaultExpanded === undefined) {
+      setInnerExpanded(DEFAULT_EXPANDED[item.status]);
+    }
+  }, [controlledExpanded, defaultExpanded, item.status]);
+
+  const setExpanded = (next: boolean) => {
+    if (controlledExpanded === undefined) setInnerExpanded(next);
+    onExpandedChange?.(next);
+  };
+
+  const hasResult = item.result !== undefined;
+  const hasError = item.error !== undefined;
+  const hasReason = item.reason !== undefined;
+  const hasContent = children !== undefined && children !== null;
+  const hasDetails = hasContent || hasResult || hasError || hasReason;
+  const customActions = typeof actions === 'function' ? actions(item) : actions;
+  const visibleProgress = item.status === 'completed' ? 1 : item.progress;
+  const percent = visibleProgress === undefined ? undefined : normalizeProgress(visibleProgress);
+  const statusLabel = locale.status[item.status];
+  const domProps = pickAttrs(restProps, { attr: true, aria: true, data: true });
+
+  const semanticClass = (name: TaskSemanticType) =>
+    clsx(`${prefixCls}-${name}`, contextConfig.classNames[name], classNames[name]);
+  const semanticStyle = (name: TaskSemanticType) => ({
+    ...contextConfig.styles[name],
+    ...styles[name],
+  });
+
+  const collapseMotion: CSSMotionProps = {
+    ...initCollapseMotion(),
+    motionAppear: false,
+    leavedClassName: `${prefixCls}-details-hidden`,
+  };
+
+  const renderError = (error: TaskError) => {
+    if (errorRender) return errorRender(error, item);
+    return (
+      <>
+        <div className={`${prefixCls}-error-message`}>{error.message}</div>
+        {error.code && <div className={`${prefixCls}-error-code`}>{error.code}</div>}
+        {error.details !== undefined && (
+          <pre className={`${prefixCls}-code`}>{safeStringify(error.details)}</pre>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <div
+      {...domProps}
+      ref={rootRef}
+      role="group"
+      aria-label={
+        restProps['aria-label'] ?? (typeof item.title === 'string' ? item.title : undefined)
+      }
+      className={clsx(
+        prefixCls,
+        `${prefixCls}-${item.status}`,
+        contextConfig.className,
+        contextConfig.classNames.root,
+        rootClassName,
+        className,
+        classNames.root,
+        hashId,
+        cssVarCls,
+        { [`${prefixCls}-rtl`]: direction === 'rtl' },
+      )}
+      style={{ ...contextConfig.style, ...contextConfig.styles.root, ...styles.root, ...style }}
+    >
+      <div className={semanticClass('header')} style={semanticStyle('header')}>
+        <span
+          className={semanticClass('status')}
+          style={semanticStyle('status')}
+          data-status={item.status}
+          aria-live="polite"
+        >
+          {statusRender ? statusRender(item.status, item) : STATUS_ICONS[item.status]}
+          <span className={`${prefixCls}-status-text`}>{statusLabel}</span>
+        </span>
+
+        <div className={semanticClass('summary')} style={semanticStyle('summary')}>
+          <div className={semanticClass('title')} style={semanticStyle('title')}>
+            {item.title}
+          </div>
+          <div className={semanticClass('description')} style={semanticStyle('description')}>
+            {item.description && <span>{item.description}</span>}
+            {item.description && <span aria-hidden="true"> · </span>}
+            <span>{statusLabel}</span>
+          </div>
+        </div>
+
+        <div className={semanticClass('actions')} style={semanticStyle('actions')}>
+          {customActions}
+          {hasDetails && (
+            <button
+              type="button"
+              className={clsx(`${prefixCls}-expand`, {
+                [`${prefixCls}-expand-open`]: mergedExpanded,
+              })}
+              aria-label={mergedExpanded ? locale.collapse : locale.expand}
+              aria-expanded={mergedExpanded}
+              aria-controls={detailsId}
+              onClick={() => setExpanded(!mergedExpanded)}
+            >
+              <DownOutlined />
+            </button>
+          )}
+        </div>
+
+        {percent !== undefined && (
+          <div className={semanticClass('progress')} style={semanticStyle('progress')}>
+            {progressRender ? (
+              progressRender(visibleProgress!, item)
+            ) : (
+              <>
+                <Progress
+                  percent={percent}
+                  showInfo={false}
+                  size="small"
+                  status={item.status === 'failed' ? 'exception' : undefined}
+                />
+                <span className={`${prefixCls}-progress-text`}>{Math.round(percent)}%</span>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {hasDetails && (
+        <CSSMotion {...collapseMotion} visible={mergedExpanded}>
+          {({ className: motionClassName, style: motionStyle }, motionRef) => (
+            <div
+              ref={motionRef}
+              className={motionClassName || ''}
+              style={motionStyle}
+              aria-hidden={!mergedExpanded}
+            >
+              <div
+                id={detailsId}
+                className={semanticClass('details')}
+                style={semanticStyle('details')}
+              >
+                {hasContent && (
+                  <section className={semanticClass('content')} style={semanticStyle('content')}>
+                    {children}
+                  </section>
+                )}
+                {hasResult && (
+                  <section className={semanticClass('result')} style={semanticStyle('result')}>
+                    <div className={`${prefixCls}-section-title`}>{locale.result}</div>
+                    {resultRender ? (
+                      resultRender(item.result, item)
+                    ) : (
+                      <pre className={`${prefixCls}-code`}>{safeStringify(item.result)}</pre>
+                    )}
+                  </section>
+                )}
+                {hasError && (
+                  <section className={semanticClass('error')} style={semanticStyle('error')}>
+                    <div className={`${prefixCls}-section-title`}>{locale.error}</div>
+                    {renderError(item.error!)}
+                  </section>
+                )}
+                {hasReason && (
+                  <section className={semanticClass('reason')} style={semanticStyle('reason')}>
+                    <div className={`${prefixCls}-section-title`}>{locale.reason}</div>
+                    {item.reason}
+                  </section>
+                )}
+              </div>
+            </div>
+          )}
+        </CSSMotion>
+      )}
+    </div>
+  );
+});
+
+if (process.env.NODE_ENV !== 'production') Task.displayName = 'Task';
+
+export default Task;

--- a/packages/x/components/task/__tests__/a11y.test.tsx
+++ b/packages/x/components/task/__tests__/a11y.test.tsx
@@ -1,0 +1,33 @@
+import { axe } from 'jest-axe';
+import React from 'react';
+import { fireEvent, render, screen } from '../../../tests/utils';
+import Task from '../index';
+
+describe('Task accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Task
+        item={{
+          id: 'a11y',
+          title: 'Generate report',
+          status: 'failed',
+          progress: 0.7,
+          error: { message: 'Generation failed' },
+        }}
+      />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('exposes task status and expandable details', () => {
+    render(
+      <Task item={{ id: 'a11y', title: 'Generate report', status: 'running' }}>Reading files</Task>,
+    );
+    expect(screen.getByRole('group', { name: 'Generate report' })).toBeTruthy();
+    expect(screen.getAllByText('In progress')[0]).toHaveAttribute('aria-live', 'polite');
+    const button = screen.getByRole('button', { name: 'Collapse task details' });
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/packages/x/components/task/__tests__/demo.test.tsx
+++ b/packages/x/components/task/__tests__/demo.test.tsx
@@ -1,0 +1,7 @@
+import demoTest from '../../../tests/shared/demoTest';
+
+demoTest('task', {
+  testRootProps: {
+    item: { id: 'root-props', title: 'Root props task', status: 'pending' },
+  },
+});

--- a/packages/x/components/task/__tests__/index.test.tsx
+++ b/packages/x/components/task/__tests__/index.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import mountTest from '../../../tests/shared/mountTest';
+import rtlTest from '../../../tests/shared/rtlTest';
+import themeTest from '../../../tests/shared/themeTest';
+import { fireEvent, render, screen } from '../../../tests/utils';
+import XProvider from '../../x-provider';
+import Task from '../index';
+import type { TaskItem } from '../interface';
+
+const baseItem: TaskItem = {
+  id: 'task-1',
+  title: 'Analyze repository',
+  description: 'Scanning source files',
+  status: 'running',
+  progress: 0.42,
+};
+
+describe('Task', () => {
+  mountTest(() => <Task item={baseItem} />);
+  rtlTest(() => <Task item={baseItem} />);
+  themeTest(() => <Task item={baseItem} />);
+
+  it.each([
+    ['pending', 'Pending'],
+    ['running', 'In progress'],
+    ['completed', 'Completed'],
+    ['failed', 'Failed'],
+    ['cancelled', 'Cancelled'],
+  ] as const)('renders %s status', (status, label) => {
+    const { container } = render(<Task item={{ ...baseItem, status }} />);
+    expect(container.querySelector(`.ant-task-${status}`)).toBeTruthy();
+    expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+  });
+
+  it('renders normalized and completed progress', () => {
+    const { rerender } = render(<Task item={baseItem} />);
+    expect(screen.getByText('42%')).toBeTruthy();
+    rerender(<Task item={{ ...baseItem, status: 'completed', progress: 0.42 }} />);
+    expect(screen.getByText('100%')).toBeTruthy();
+  });
+
+  it('supports uncontrolled and controlled expansion', () => {
+    const onExpandedChange = jest.fn();
+    const { rerender } = render(
+      <Task
+        item={{ ...baseItem, status: 'completed', result: { files: 12 } }}
+        onExpandedChange={onExpandedChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Expand task details' }));
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+    expect(screen.getByText(/"files": 12/)).toBeTruthy();
+
+    rerender(
+      <Task
+        item={{ ...baseItem, status: 'completed', result: { files: 12 } }}
+        expanded={false}
+        onExpandedChange={onExpandedChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Expand task details' }));
+    expect(onExpandedChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('adopts status expansion defaults after a transition', () => {
+    const { rerender } = render(
+      <Task item={{ ...baseItem, status: 'pending', error: { message: 'Later failure' } }} />,
+    );
+    expect(screen.getByRole('button', { name: 'Expand task details' })).toBeTruthy();
+    rerender(
+      <Task item={{ ...baseItem, status: 'failed', error: { message: 'Later failure' } }} />,
+    );
+    expect(screen.getByRole('button', { name: 'Collapse task details' })).toBeTruthy();
+  });
+
+  it('renders result, error, cancellation reason, and safe fallbacks', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    render(
+      <Task
+        item={{
+          ...baseItem,
+          status: 'failed',
+          result: circular,
+          error: { code: 'FAILED', message: 'Task failed', details: circular },
+          reason: 'Stopped by user',
+        }}
+      />,
+    );
+    expect(screen.getAllByText('[Object, unable to serialize]')).toHaveLength(2);
+    expect(screen.getByText('FAILED')).toBeTruthy();
+    expect(screen.getByText('Stopped by user')).toBeTruthy();
+  });
+
+  it('supports custom renderers, actions, semantic styles, and ref', () => {
+    const ref = React.createRef<{ nativeElement: HTMLDivElement }>();
+    const { container } = render(
+      <Task
+        ref={ref}
+        item={{ ...baseItem, status: 'failed', result: {}, error: { message: 'failed' } }}
+        statusRender={() => <span>custom status</span>}
+        progressRender={() => <span>custom progress</span>}
+        resultRender={() => <span>custom result</span>}
+        errorRender={() => <span>custom error</span>}
+        actions={() => <button type="button">Inspect</button>}
+        classNames={{ title: 'custom-title' }}
+        styles={{ details: { padding: 24 } }}
+        prefixCls="custom-task"
+        rootClassName="custom-root"
+      />,
+    );
+    expect(screen.getByText('custom status')).toBeTruthy();
+    expect(screen.getByText('custom progress')).toBeTruthy();
+    expect(screen.getByText('custom result')).toBeTruthy();
+    expect(screen.getByText('custom error')).toBeTruthy();
+    expect(screen.getByText('Inspect')).toBeTruthy();
+    expect(container.querySelector('.custom-title')).toBeTruthy();
+    expect(container.querySelector('.custom-task-details')).toHaveStyle({ padding: '24px' });
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.custom-task'));
+  });
+
+  it('merges XProvider component configuration', () => {
+    const { container } = render(
+      <XProvider
+        task={{
+          className: 'provider-root',
+          classNames: { title: 'provider-title' },
+          style: { maxWidth: 640 },
+          styles: { progress: { maxWidth: 320 } },
+        }}
+      >
+        <Task item={baseItem} />
+      </XProvider>,
+    );
+    expect(container.querySelector('.provider-root')).toHaveStyle({ maxWidth: '640px' });
+    expect(container.querySelector('.provider-title')).toBeTruthy();
+    expect(container.querySelector('.ant-task-progress')).toHaveStyle({ maxWidth: '320px' });
+  });
+});

--- a/packages/x/components/task/demo/_semantic.tsx
+++ b/packages/x/components/task/demo/_semantic.tsx
@@ -1,0 +1,62 @@
+import { Task } from '@ant-design/x';
+import React from 'react';
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const locales = {
+  cn: {
+    root: '根元素',
+    header: '头部',
+    status: '状态',
+    summary: '摘要',
+    title: '标题',
+    description: '描述',
+    progress: '进度',
+    actions: '操作区',
+    details: '详情',
+    content: '自定义内容',
+    result: '结果',
+    error: '错误',
+    reason: '取消原因',
+  },
+  en: {
+    root: 'Root',
+    header: 'Header',
+    status: 'Status',
+    summary: 'Summary',
+    title: 'Title',
+    description: 'Description',
+    progress: 'Progress',
+    actions: 'Actions',
+    details: 'Details',
+    content: 'Custom content',
+    result: 'Result',
+    error: 'Error',
+    reason: 'Cancellation reason',
+  },
+};
+
+const App = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      semantics={Object.entries(locale).map(([name, desc]) => ({ name, desc }))}
+      componentName="Task"
+    >
+      <Task
+        item={{
+          id: 'semantic',
+          title: 'Analyze repository',
+          description: 'Collecting component metadata',
+          status: 'running',
+          progress: 0.65,
+          result: { components: 18 },
+        }}
+      >
+        Task detail content
+      </Task>
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/packages/x/components/task/demo/basic.md
+++ b/packages/x/components/task/demo/basic.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+使用状态和进度描述一个持续更新的 Agent 任务。
+
+## en-US
+
+Use status and progress to describe an Agent task that updates over time.

--- a/packages/x/components/task/demo/basic.tsx
+++ b/packages/x/components/task/demo/basic.tsx
@@ -1,0 +1,53 @@
+import { PlayCircleOutlined, RedoOutlined } from '@ant-design/icons';
+import type { TaskItem } from '@ant-design/x';
+import { Task } from '@ant-design/x';
+import { Button, Flex, Typography } from 'antd';
+import React from 'react';
+
+const initialTask: TaskItem = {
+  id: 'release-report',
+  title: 'Generate release report',
+  description: 'Collect changes, test results, and deployment notes',
+  status: 'pending',
+  progress: 0,
+};
+
+const App = () => {
+  const [item, setItem] = React.useState(initialTask);
+
+  const advance = () => {
+    setItem((current) => {
+      const progress = Math.min(1, (current.progress ?? 0) + 0.25);
+      return {
+        ...current,
+        progress,
+        status: progress === 1 ? 'completed' : 'running',
+        result: progress === 1 ? { sections: 6, checks: 'passed' } : undefined,
+      };
+    });
+  };
+
+  return (
+    <Flex vertical gap={12}>
+      <Task item={item}>
+        <Typography.Text type="secondary">
+          Reading changelog entries and CI results from the current release branch.
+        </Typography.Text>
+      </Task>
+      <Flex gap={8}>
+        <Button
+          icon={<PlayCircleOutlined />}
+          disabled={item.status === 'completed'}
+          onClick={advance}
+        >
+          Advance
+        </Button>
+        <Button icon={<RedoOutlined />} onClick={() => setItem(initialTask)}>
+          Reset
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default App;

--- a/packages/x/components/task/demo/controlled.md
+++ b/packages/x/components/task/demo/controlled.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+通过 `expanded` 和 `onExpandedChange` 控制详情展开状态。
+
+## en-US
+
+Control task detail expansion with `expanded` and `onExpandedChange`.

--- a/packages/x/components/task/demo/controlled.tsx
+++ b/packages/x/components/task/demo/controlled.tsx
@@ -1,0 +1,31 @@
+import { Task } from '@ant-design/x';
+import { Switch } from 'antd';
+import React from 'react';
+
+const App = () => {
+  const [expanded, setExpanded] = React.useState(false);
+
+  return (
+    <Task
+      item={{
+        id: 'controlled-task',
+        title: 'Build component package',
+        description: 'Output ES modules and type declarations',
+        status: 'completed',
+        result: { files: 42, duration: '3.4s' },
+      }}
+      expanded={expanded}
+      onExpandedChange={setExpanded}
+      actions={
+        <Switch
+          size="small"
+          checked={expanded}
+          aria-label="Toggle task details"
+          onChange={setExpanded}
+        />
+      }
+    />
+  );
+};
+
+export default App;

--- a/packages/x/components/task/demo/custom-render.md
+++ b/packages/x/components/task/demo/custom-render.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+自定义任务状态、进度、结果和操作区域。
+
+## en-US
+
+Customize task status, progress, result, and actions.

--- a/packages/x/components/task/demo/custom-render.tsx
+++ b/packages/x/components/task/demo/custom-render.tsx
@@ -1,0 +1,28 @@
+import { CloudSyncOutlined } from '@ant-design/icons';
+import { Task } from '@ant-design/x';
+import { Progress, Tag, Typography } from 'antd';
+import React from 'react';
+
+const App = () => (
+  <Task
+    item={{
+      id: 'custom-task',
+      title: 'Synchronize knowledge base',
+      status: 'running',
+      progress: 0.73,
+      result: { indexed: 238 },
+    }}
+    statusRender={() => <CloudSyncOutlined />}
+    progressRender={(progress) => (
+      <Progress percent={progress * 100} size="small" strokeColor="#1677ff" />
+    )}
+    resultRender={(result) => (
+      <Typography.Text>
+        Indexed <Tag color="blue">{(result as { indexed: number }).indexed}</Tag> documents
+      </Typography.Text>
+    )}
+    actions={<Tag bordered={false}>Workspace</Tag>}
+  />
+);
+
+export default App;

--- a/packages/x/components/task/demo/status.md
+++ b/packages/x/components/task/demo/status.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+任务支持等待、进行中、完成、失败和取消五种状态。
+
+## en-US
+
+Tasks support pending, running, completed, failed, and cancelled states.

--- a/packages/x/components/task/demo/status.tsx
+++ b/packages/x/components/task/demo/status.tsx
@@ -1,0 +1,44 @@
+import type { TaskItem } from '@ant-design/x';
+import { Task } from '@ant-design/x';
+import { Flex } from 'antd';
+import React from 'react';
+
+const items: TaskItem[] = [
+  { id: 'pending', title: 'Index project files', status: 'pending', progress: 0 },
+  {
+    id: 'running',
+    title: 'Analyze dependency graph',
+    description: 'Scanning 128 modules',
+    status: 'running',
+    progress: 0.62,
+  },
+  {
+    id: 'completed',
+    title: 'Run validation checks',
+    status: 'completed',
+    result: { passed: 18, failed: 0 },
+  },
+  {
+    id: 'failed',
+    title: 'Publish preview',
+    status: 'failed',
+    progress: 0.8,
+    error: { code: 'PREVIEW_TIMEOUT', message: 'Preview deployment timed out.' },
+  },
+  {
+    id: 'cancelled',
+    title: 'Generate screenshots',
+    status: 'cancelled',
+    reason: 'The run was cancelled by the user.',
+  },
+];
+
+const App = () => (
+  <Flex vertical gap={12}>
+    {items.map((item) => (
+      <Task key={item.id} item={item} />
+    ))}
+  </Flex>
+);
+
+export default App;

--- a/packages/x/components/task/index.en-US.md
+++ b/packages/x/components/task/index.en-US.md
@@ -1,0 +1,76 @@
+---
+category: Components
+group:
+  title: Confirm
+  order: 1
+title: Task
+description: Display the status, progress, result, and failure details of a long-running Agent task.
+tag: 2.9.0
+---
+
+## When To Use
+
+- Display a long-running task created and updated by an Agent.
+- Present task progress, results, errors, or cancellation reasons in a conversation or execution timeline.
+- `Task` renders one task entity. Use `ThoughtChain` for task planning and compose multiple tasks at the timeline layer.
+
+## Examples
+
+<!-- prettier-ignore -->
+<code src="./demo/basic.tsx">Basic</code>
+<code src="./demo/status.tsx">Statuses</code>
+<code src="./demo/controlled.tsx">Controlled expansion</code>
+<code src="./demo/custom-render.tsx">Custom rendering</code>
+
+## API
+
+Common props ref: [Common props](/docs/react/common-props)
+
+### TaskProps
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| item | Task view model | [TaskItem](#taskitem) | - |
+| expanded | Whether details are expanded in controlled mode | boolean | - |
+| defaultExpanded | Initial expansion; derived from status when omitted | boolean | - |
+| onExpandedChange | Called when expansion changes | (expanded: boolean) => void | - |
+| statusRender | Custom status icon | (status: TaskStatus, item: TaskItem) => ReactNode | - |
+| progressRender | Custom progress region | (progress: number, item: TaskItem) => ReactNode | - |
+| resultRender | Custom result renderer | (result: unknown, item: TaskItem) => ReactNode | - |
+| errorRender | Custom error renderer | (error: TaskError, item: TaskItem) => ReactNode | - |
+| actions | Custom actions | ReactNode \| (item: TaskItem) => ReactNode | - |
+| classNames | Semantic class names | Record&lt;SemanticDOM, string&gt; | - |
+| styles | Semantic styles | Record&lt;SemanticDOM, CSSProperties&gt; | - |
+| prefixCls | Style class prefix | string | - |
+| rootClassName | Root class name | string | - |
+
+### TaskItem
+
+```typescript
+type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+interface TaskItem {
+  id: React.Key;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  status: TaskStatus;
+  progress?: number;
+  result?: unknown;
+  error?: TaskError;
+  reason?: React.ReactNode;
+}
+```
+
+`progress` is a ratio from `0` to `1`, matching `AgentTaskState.progress`. Completed tasks always display 100%.
+
+`running` and `failed` expand by default; other states collapse. When status changes, an uncontrolled component adopts the new status default. The expand control only appears when custom content, a result, an error, or a cancellation reason exists.
+
+Object results use safe serialization, with type summaries for circular values. The application or Agent Command owns task execution, cancellation, and retry; inject those controls through `actions`.
+
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
+## Design Token
+
+<ComponentTokenTable component="Task"></ComponentTokenTable>

--- a/packages/x/components/task/index.tsx
+++ b/packages/x/components/task/index.tsx
@@ -1,0 +1,9 @@
+export type {
+  TaskError,
+  TaskItem,
+  TaskProps,
+  TaskRef,
+  TaskSemanticType,
+  TaskStatus,
+} from './interface';
+export { default } from './Task';

--- a/packages/x/components/task/index.zh-CN.md
+++ b/packages/x/components/task/index.zh-CN.md
@@ -1,0 +1,77 @@
+---
+category: Components
+group:
+  title: 确认
+  order: 1
+title: Task
+subtitle: 任务
+description: 展示 Agent 长任务的状态、进度、结果与失败信息。
+tag: 2.9.0
+---
+
+## 何时使用
+
+- 展示由 Agent 创建并持续更新的长任务。
+- 在对话或执行时间线中呈现任务进度、完成结果、错误或取消原因。
+- `Task` 只负责单个任务实体的展示；任务编排使用 `ThoughtChain`，多任务时间线由应用层组合。
+
+## 代码演示
+
+<!-- prettier-ignore -->
+<code src="./demo/basic.tsx">基础用法</code>
+<code src="./demo/status.tsx">任务状态</code>
+<code src="./demo/controlled.tsx">受控展开</code>
+<code src="./demo/custom-render.tsx">自定义渲染</code>
+
+## API
+
+通用属性参考：[通用属性](/docs/react/common-props)
+
+### TaskProps
+
+| 属性 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| item | 任务展示模型 | [TaskItem](#taskitem) | - |
+| expanded | 是否展开详情，受控模式 | boolean | - |
+| defaultExpanded | 默认是否展开；未设置时根据状态决定 | boolean | - |
+| onExpandedChange | 展开状态变化回调 | (expanded: boolean) => void | - |
+| statusRender | 自定义状态图标 | (status: TaskStatus, item: TaskItem) => ReactNode | - |
+| progressRender | 自定义进度区域 | (progress: number, item: TaskItem) => ReactNode | - |
+| resultRender | 自定义结果 | (result: unknown, item: TaskItem) => ReactNode | - |
+| errorRender | 自定义错误 | (error: TaskError, item: TaskItem) => ReactNode | - |
+| actions | 自定义操作区 | ReactNode \| (item: TaskItem) => ReactNode | - |
+| classNames | 语义化结构类名 | Record&lt;SemanticDOM, string&gt; | - |
+| styles | 语义化结构样式 | Record&lt;SemanticDOM, CSSProperties&gt; | - |
+| prefixCls | 样式类名前缀 | string | - |
+| rootClassName | 根节点样式类 | string | - |
+
+### TaskItem
+
+```typescript
+type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+interface TaskItem {
+  id: React.Key;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  status: TaskStatus;
+  progress?: number;
+  result?: unknown;
+  error?: TaskError;
+  reason?: React.ReactNode;
+}
+```
+
+`progress` 使用 `0` 到 `1` 的比例，与 `AgentTaskState.progress` 保持一致。完成态始终展示为 100%。
+
+`running` 和 `failed` 默认展开，其他状态默认收起；状态变化时，非受控组件会切换到新状态的默认展开方式。只有存在自定义内容、结果、错误或取消原因时才显示展开按钮。
+
+对象结果使用安全序列化，循环引用会显示类型摘要。真实任务执行、取消与重试由应用层或 Agent Command 负责，可通过 `actions` 注入相应操作。
+
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
+## 主题变量（Design Token）
+
+<ComponentTokenTable component="Task"></ComponentTokenTable>

--- a/packages/x/components/task/interface.ts
+++ b/packages/x/components/task/interface.ts
@@ -1,0 +1,57 @@
+import type React from 'react';
+
+export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface TaskError {
+  code?: string;
+  message: string;
+  retryable?: boolean;
+  details?: unknown;
+}
+
+export interface TaskItem {
+  id: React.Key;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  status: TaskStatus;
+  /** Progress ratio between 0 and 1. */
+  progress?: number;
+  result?: unknown;
+  error?: TaskError;
+  reason?: React.ReactNode;
+}
+
+export type TaskSemanticType =
+  | 'root'
+  | 'header'
+  | 'status'
+  | 'summary'
+  | 'title'
+  | 'description'
+  | 'progress'
+  | 'actions'
+  | 'details'
+  | 'content'
+  | 'result'
+  | 'error'
+  | 'reason';
+
+export interface TaskProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
+  item: TaskItem;
+  expanded?: boolean;
+  defaultExpanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  statusRender?: (status: TaskStatus, item: TaskItem) => React.ReactNode;
+  progressRender?: (progress: number, item: TaskItem) => React.ReactNode;
+  resultRender?: (result: TaskItem['result'], item: TaskItem) => React.ReactNode;
+  errorRender?: (error: TaskError, item: TaskItem) => React.ReactNode;
+  actions?: React.ReactNode | ((item: TaskItem) => React.ReactNode);
+  classNames?: Partial<Record<TaskSemanticType, string>>;
+  styles?: Partial<Record<TaskSemanticType, React.CSSProperties>>;
+  prefixCls?: string;
+  rootClassName?: string;
+}
+
+export interface TaskRef {
+  nativeElement: HTMLDivElement;
+}

--- a/packages/x/components/task/style/index.ts
+++ b/packages/x/components/task/style/index.ts
@@ -1,0 +1,213 @@
+import { unit } from '@ant-design/cssinjs';
+import { mergeToken } from '@ant-design/cssinjs-utils';
+import { genCollapseMotion } from '../../style';
+import { genStyleHooks } from '../../theme/genStyleUtils';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/interface';
+
+export interface ComponentToken {
+  headerBg: string;
+  detailBg: string;
+  statusSize: number;
+  progressWidth: number;
+  successColor: string;
+  runningColor: string;
+  errorColor: string;
+}
+
+export interface TaskToken extends FullToken<'Task'> {}
+
+const genTaskStyle: GenerateStyle<TaskToken> = (token) => {
+  const { componentCls, calc } = token;
+
+  return {
+    [componentCls]: {
+      boxSizing: 'border-box',
+      width: '100%',
+      overflow: 'hidden',
+      color: token.colorText,
+      fontSize: token.fontSize,
+      lineHeight: token.lineHeight,
+      background: token.colorBgContainer,
+      border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
+      borderRadius: token.borderRadiusLG,
+
+      [`${componentCls}-header`]: {
+        display: 'grid',
+        gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+        alignItems: 'center',
+        gap: `${unit(token.marginXS)} ${unit(token.paddingSM)}`,
+        minHeight: token.controlHeightLG,
+        padding: `${unit(token.paddingSM)} ${unit(token.padding)}`,
+        background: token.headerBg,
+      },
+
+      [`${componentCls}-status`]: {
+        position: 'relative',
+        alignSelf: 'start',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: token.statusSize,
+        height: token.controlHeightSM,
+        color: token.colorTextSecondary,
+        fontSize: token.statusSize,
+      },
+
+      [`${componentCls}-status-text`]: {
+        position: 'absolute',
+        width: 1,
+        height: 1,
+        padding: 0,
+        margin: -1,
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        border: 0,
+      },
+
+      [`${componentCls}-summary`]: { minWidth: 0 },
+      [`${componentCls}-title`]: {
+        minWidth: 0,
+        overflowWrap: 'anywhere',
+        fontWeight: token.fontWeightStrong,
+      },
+      [`${componentCls}-description`]: {
+        minWidth: 0,
+        marginTop: token.marginXXS,
+        overflow: 'hidden',
+        color: token.colorTextDescription,
+        fontSize: token.fontSizeSM,
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      },
+
+      [`${componentCls}-actions`]: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: token.marginXXS,
+      },
+      [`${componentCls}-expand`]: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: token.controlHeightSM,
+        height: token.controlHeightSM,
+        padding: 0,
+        color: token.colorTextSecondary,
+        font: 'inherit',
+        cursor: 'pointer',
+        background: 'transparent',
+        border: 0,
+        borderRadius: token.borderRadiusSM,
+        transition: `background ${token.motionDurationMid}`,
+        '&:hover': { background: token.colorFillTertiary },
+        '&:focus-visible': { outline: `${unit(token.lineWidthBold)} solid ${token.colorPrimary}` },
+        '.anticon': {
+          transition: `transform ${token.motionDurationMid} ${token.motionEaseInOut}`,
+        },
+      },
+      [`${componentCls}-expand-open .anticon`]: { transform: 'rotate(180deg)' },
+
+      [`${componentCls}-progress`]: {
+        gridColumn: '2 / -1',
+        display: 'grid',
+        gridTemplateColumns: `minmax(0, ${unit(token.progressWidth)}) auto`,
+        alignItems: 'center',
+        gap: token.marginXS,
+        [`${token.antCls}-progress`]: { lineHeight: 1 },
+      },
+      [`${componentCls}-progress-text`]: {
+        minWidth: '3ch',
+        color: token.colorTextDescription,
+        fontSize: token.fontSizeSM,
+        fontVariantNumeric: 'tabular-nums',
+        textAlign: 'end',
+      },
+
+      [`${componentCls}-details`]: {
+        display: 'grid',
+        gap: token.padding,
+        padding: token.padding,
+        background: token.detailBg,
+        borderTop: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
+      },
+      [`${componentCls}-details-hidden`]: { display: 'none' },
+      [`${componentCls}-section-title`]: {
+        marginBottom: token.marginXS,
+        color: token.colorTextSecondary,
+        fontSize: token.fontSizeSM,
+        fontWeight: token.fontWeightStrong,
+      },
+      [`${componentCls}-code`]: {
+        boxSizing: 'border-box',
+        maxHeight: 240,
+        margin: 0,
+        padding: `${unit(token.paddingSM)} ${unit(token.padding)}`,
+        overflow: 'auto',
+        fontFamily: token.fontFamilyCode,
+        fontSize: token.fontSizeSM,
+        lineHeight: 1.65,
+        whiteSpace: 'pre-wrap',
+        overflowWrap: 'anywhere',
+        background: token.colorFillQuaternary,
+        borderRadius: token.borderRadius,
+      },
+      [`${componentCls}-error`]: {
+        paddingInlineStart: token.paddingSM,
+        color: token.errorColor,
+        borderInlineStart: `${unit(calc(token.lineWidth).mul(2).equal())} solid ${token.errorColor}`,
+      },
+      [`${componentCls}-error-message`]: { fontWeight: token.fontWeightStrong },
+      [`${componentCls}-error-code`]: {
+        display: 'inline-block',
+        marginTop: token.marginXS,
+        paddingInline: token.paddingXS,
+        color: token.errorColor,
+        fontFamily: token.fontFamilyCode,
+        fontSize: token.fontSizeSM,
+        background: token.colorErrorBg,
+        borderRadius: token.borderRadiusSM,
+      },
+      [`${componentCls}-reason`]: { color: token.colorTextDescription },
+
+      [`&${componentCls}-running ${componentCls}-status`]: { color: token.runningColor },
+      [`&${componentCls}-completed ${componentCls}-status`]: { color: token.successColor },
+      [`&${componentCls}-failed`]: {
+        borderColor: token.colorErrorBorder,
+        [`${componentCls}-status`]: { color: token.errorColor },
+      },
+      [`&${componentCls}-cancelled ${componentCls}-status`]: {
+        color: token.colorTextQuaternary,
+      },
+      [`&${componentCls}-rtl`]: { direction: 'rtl' },
+
+      [`@media (max-width: ${unit(token.screenXS)})`]: {
+        [`${componentCls}-header`]: { paddingInline: token.paddingSM },
+        [`${componentCls}-progress`]: {
+          gridColumn: '1 / -1',
+          gridTemplateColumns: 'minmax(0, 1fr) auto',
+        },
+        [`${componentCls}-details`]: { padding: token.paddingSM },
+      },
+    },
+  };
+};
+
+export const prepareComponentToken: GetDefaultToken<'Task'> = (token) => ({
+  headerBg: token.colorFillQuaternary,
+  detailBg: token.colorBgContainer,
+  statusSize: token.fontSizeLG,
+  progressWidth: 240,
+  successColor: token.colorSuccess,
+  runningColor: token.colorPrimary,
+  errorColor: token.colorError,
+});
+
+export default genStyleHooks<'Task'>(
+  'Task',
+  (token) => {
+    const taskToken = mergeToken<TaskToken>(token, {});
+    return [genTaskStyle(taskToken), genCollapseMotion(taskToken)];
+  },
+  prepareComponentToken,
+);

--- a/packages/x/components/theme/interface/components.ts
+++ b/packages/x/components/theme/interface/components.ts
@@ -10,6 +10,7 @@ import type { ComponentToken as PromptsComponentToken } from '../../prompts/styl
 import type { ComponentToken as SenderComponentToken } from '../../sender/style';
 import type { ComponentToken as SourcesComponentToken } from '../../sources/style';
 import type { ComponentToken as SuggestionComponentToken } from '../../suggestion/style';
+import type { ComponentToken as TaskComponentToken } from '../../task/style';
 import type { ComponentToken as ThinkComponentToken } from '../../think/style';
 import type { ComponentToken as ThoughtChainComponentToken } from '../../thought-chain/style';
 import type { ComponentToken as WelcomeComponentToken } from '../../welcome/style';
@@ -21,6 +22,7 @@ export interface ComponentTokenMap {
   Prompts?: PromptsComponentToken;
   Sender?: SenderComponentToken;
   Suggestion?: SuggestionComponentToken;
+  Task?: TaskComponentToken;
   Think?: ThinkComponentToken;
   ThoughtChain?: ThoughtChainComponentToken;
   Welcome?: WelcomeComponentToken;

--- a/packages/x/components/x-provider/context.ts
+++ b/packages/x/components/x-provider/context.ts
@@ -14,6 +14,7 @@ import type { PromptsProps } from '../prompts';
 import type { SenderProps } from '../sender';
 import type { SourcesProps } from '../sources';
 import type { SuggestionProps } from '../suggestion';
+import type { TaskProps } from '../task';
 import type { MappingAlgorithm, OverrideToken } from '../theme/interface';
 import type { ThinkProps } from '../think';
 import type { ThoughtChainProps } from '../thought-chain';
@@ -40,6 +41,7 @@ export interface XComponentsConfig {
   prompts?: ComponentConfig<PromptsProps>;
   sender?: ComponentConfig<SenderProps>;
   suggestion?: ComponentConfig<SuggestionProps>;
+  task?: ComponentConfig<TaskProps>;
   thoughtChain?: ComponentConfig<ThoughtChainProps>;
   attachments?: ComponentConfig<AttachmentsProps>;
   welcome?: ComponentConfig<WelcomeProps>;

--- a/packages/x/components/x-provider/index.tsx
+++ b/packages/x/components/x-provider/index.tsx
@@ -16,6 +16,7 @@ const XProvider: React.FC<XProviderProps> = (props) => {
     prompts,
     sender,
     suggestion,
+    task,
     thoughtChain,
     welcome,
     fileCard,
@@ -38,6 +39,7 @@ const XProvider: React.FC<XProviderProps> = (props) => {
       prompts,
       sender,
       suggestion,
+      task,
       thoughtChain,
       fileCard,
       think,
@@ -53,6 +55,7 @@ const XProvider: React.FC<XProviderProps> = (props) => {
     prompts,
     sender,
     suggestion,
+    task,
     thoughtChain,
     welcome,
     mermaid,
@@ -96,9 +99,8 @@ const XProvider: React.FC<XProviderProps> = (props) => {
   );
 };
 
-export { useXProviderContext, defaultPrefixCls };
-
 export type { XProviderProps };
+export { defaultPrefixCls, useXProviderContext };
 
 if (process.env.NODE_ENV !== 'production') {
   XProvider.displayName = 'XProvider';

--- a/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.tsx
+++ b/packages/x/docs/x-sdk/demos/x-chat/agent-interaction.tsx
@@ -5,6 +5,8 @@ import {
   RedoOutlined,
   StopOutlined,
 } from '@ant-design/icons';
+import type { TaskStatus } from '@ant-design/x';
+import { Task } from '@ant-design/x';
 import type {
   AgentActionResult,
   AgentCommandOptions,
@@ -393,13 +395,18 @@ const App = () => {
       )}
 
       {task && (
-        <Flex gap={8} align="center" wrap>
-          <Typography.Text>{task.title}</Typography.Text>
-          <Tag color={statusColor[task.status]}>{task.status}</Tag>
-          <Typography.Text type="secondary">
-            {Math.round((task.progress ?? 0) * 100)}%
-          </Typography.Text>
-        </Flex>
+        <Task
+          item={{
+            id: task.id,
+            title: task.title,
+            description: task.description,
+            status: task.status as TaskStatus,
+            progress: task.progress,
+            result: task.result,
+            error: task.error,
+            reason: task.reason,
+          }}
+        />
       )}
 
       {run?.status === 'running' && (

--- a/packages/x/tests/__snapshots__/index.test.ts.snap
+++ b/packages/x/tests/__snapshots__/index.test.ts.snap
@@ -15,6 +15,7 @@ exports[`antd dist files exports modules correctly 1`] = `
   "SenderSwitch",
   "Sources",
   "Suggestion",
+  "Task",
   "Think",
   "ThoughtChain",
   "Welcome",


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation improvement
- [x] Demo improvement
- [ ] Component style improvement
- [x] TypeScript definition improvement
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Feature enhancement
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Accessibility improvement
- [ ] Other

### Related Issues

N/A

### Background and Solution

Add a Task component for representing a single long-running Agent task.

- Support pending, running, completed, failed, and cancelled states.
- Render progress, results, errors, and cancellation reasons.
- Support controlled expansion, custom status/progress/result/error rendering, semantic styles, locale, RTL, theme tokens, and XProvider configuration.
- Replace the temporary task row in the Agent Interaction demo with Task.
- Keep Task scoped to one task entity; ThoughtChain owns planning and AgentTimeline can compose multiple tasks.
- Follow the Agent protocol's 0-1 progress ratio and map directly from AgentTaskState.progress.

### Testing

- npm run tsc --workspace packages/x
- Biome checks for the changed files

Jest is currently blocked before test discovery by an incomplete local @ant-design/cssinjs installation (./useStreaming is missing).

### Change Log

| Language | Changelog |
| --- | --- |
| English | Add Task for displaying Agent task status, progress, results, and errors. |
| Chinese | 新增 Task 组件，用于展示 Agent 任务状态、进度、结果和错误信息。 |
