### PR TITLE
fix(x-markdown): 识别带 0-3 个前导空格的围栏代码块（缩进 fence）

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/hooks.test.tsx
+++ b/packages/x-markdown/src/XMarkdown/__tests__/hooks.test.tsx
@@ -272,6 +272,37 @@ const fencedCodeTestCases = [
     output: '```typescript\ninterface Test {\n  name: string;\n}\n```\n\nThis is ',
     config: { streaming: { hasNextChunk: true } },
   },
+  {
+    title: 'fenced code block with 2-space indented opening and closing fence',
+    input: '  ```js\nconst a = [1,2];\n  ```',
+    output: '  ```js\nconst a = [1,2];\n  ```',
+  },
+  {
+    title: 'fenced code block with 3-space indented opening fence',
+    input: '   ```js\nconst a = [1,2];\n  ```',
+    output: '   ```js\nconst a = [1,2];\n  ```',
+  },
+  {
+    title: 'fenced code block with indented tilde fences',
+    input: '  ~~~json\n{"key": "value"}\n  ~~~',
+    output: '  ~~~json\n{"key": "value"}\n  ~~~',
+  },
+  {
+    title: 'fenced code block inside a list item',
+    input: '- item\n  ```js\nconst x = [1];\n  ```\n',
+    output: '- item\n  ```js\nconst x = [1];\n  ```\n',
+  },
+  {
+    title: 'indented fenced code block with trailing spaces after closing fence',
+    input: '  ```js\ncode\n  ```   ',
+    output: '  ```js\ncode\n  ```   ',
+    config: { streaming: { hasNextChunk: true } },
+  },
+  {
+    title: '4-space indent is indented code, not a fence',
+    input: '    ```js\ncode\n```',
+    output: '    ```js\ncode\n```',
+  },
 ];
 
 // 错误处理测试

--- a/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts
@@ -26,6 +26,8 @@ interface FenceState {
   lineFenceChar: string;
   lineFenceLen: number;
   lineFenceRunEnded: boolean;
+  /** Leading spaces consumed on the current line (CommonMark allows 0-3 before a fence) */
+  lineFenceIndent: number;
   /** Whether every char after the leading run is whitespace (closing fences allow only whitespace) */
   lineTailBlank: boolean;
 }
@@ -168,6 +170,7 @@ const getInitialFenceState = (): FenceState => ({
   lineFenceChar: '',
   lineFenceLen: 0,
   lineFenceRunEnded: false,
+  lineFenceIndent: 0,
   lineTailBlank: true,
 });
 
@@ -211,15 +214,26 @@ const feedFenceState = (fence: FenceState, char: string): void => {
     fence.lineFenceChar = '';
     fence.lineFenceLen = 0;
     fence.lineFenceRunEnded = false;
+    fence.lineFenceIndent = 0;
     fence.lineTailBlank = true;
     return;
   }
 
   if (!fence.lineFenceRunEnded) {
-    if (fence.lineFenceLen === 0 && (char === '`' || char === '~')) {
-      fence.lineFenceChar = char;
-      fence.lineFenceLen = 1;
-    } else if (fence.lineFenceLen > 0 && char === fence.lineFenceChar) {
+    if (fence.lineFenceLen === 0) {
+      // CommonMark allows 0-3 leading spaces before an opening or closing
+      // fence (e.g. a fence nested inside a list item). Consume them without
+      // ending the run; a 4th space or any non-fence character ends it.
+      if (char === ' ' && fence.lineFenceIndent < 3) {
+        fence.lineFenceIndent += 1;
+      } else if (char === '`' || char === '~') {
+        fence.lineFenceChar = char;
+        fence.lineFenceLen = 1;
+      } else {
+        fence.lineFenceRunEnded = true;
+        fence.lineTailBlank = fence.lineTailBlank && /\s/.test(char);
+      }
+    } else if (char === fence.lineFenceChar) {
       fence.lineFenceLen += 1;
     } else {
       fence.lineFenceRunEnded = true;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

fix #2017

### 💡 需求背景和解决方案

**问题**：`feedFenceState`（`packages/x-markdown/src/XMarkdown/hooks/useStreaming.ts`）只在行首为列 0 时识别围栏代码块（fenced code block）。CommonMark 允许 fence 前有 0-3 个空格（例如列表项内嵌套的代码块），但前导空格会先命中 else 分支置 `lineFenceRunEnded = true`，反引号不再累积——缩进的 opening fence 不可见，之后顶格的 closing fence 被误认为新的 opening，`inFenced` 永久 latch。流式中间态下缩进代码块内容不受 `isInCodeBlock` 保护，`[`/`<`/`$` 开头的内容被挂起（闪烁 / 占位符抖动），且最终输出可能丢失 closing fence 的字符。

**方案**：在 `FenceState` 中新增 `lineFenceIndent`（当前行已消费的前导空格数），`feedFenceState` 在 fence run 开始前容忍 0-3 个空格；第 4 个空格或任何非 fence 字符仍会结束 run（4 空格缩进代码块、普通缩进文本不受影响）。`lineFenceIndent` 随其他行内状态在 `\n` 时重置。

**验证**：

- 状态机级：原始版 vs 修复版逐字符对照（11 个用例），2/3 空格、波浪线、closing 尾随空格、fence 内反引号内容行等场景原始版全部 latch `inFenced=true`，修复版全部正确开合；无缩进对照与 4 空格缩进代码（非 fence）行为不变。
- 端到端：真实 `useStreaming`（流式模式，`hasNextChunk: true`）下，`  ```js\nconst a = [1,2];\n  ``` ` 原始版输出丢失 closing fence（以 `  `` ` 结尾），修复版输出与输入逐字一致。
- 新增 6 个 `fencedCodeTestCases`（2/3 空格缩进开合、缩进波浪线、列表项内 fence、closing 后带尾随空格、4 空格反向用例），本地 jest 全量通过（102/102，含存量 4 个 fence 回归用例）。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix `feedFenceState` not recognizing fenced code blocks with 0-3 leading spaces (e.g. inside list items) during streaming, which caused incomplete-token churn and a stuck fence state. |
| 🇨🇳 中文 | 修复流式渲染时无法识别带 0-3 个前导空格（如列表项内）的围栏代码块，导致的未完成 token 抖动与 fence 状态卡死问题。 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进流式 Markdown 中代码围栏的识别，支持最多 3 个空格缩进。
  - 正确处理列表项内的反引号或波浪线代码围栏，以及闭合围栏后的尾随空格。
  - 4 个空格缩进的内容将继续按缩进代码块处理，避免错误识别。
  - 确保流式输出保持原始输入内容不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->