### PR TITLE
fix(mermaid): use stable id to prevent re-mount flicker on streaming render #1947

### DIFF
--- a/packages/x/components/mermaid/Mermaid.tsx
+++ b/packages/x/components/mermaid/Mermaid.tsx
@@ -64,7 +64,12 @@ const Mermaid: React.FC<MermaidProps> = React.memo((props) => {
   const [isDragging, setIsDragging] = useState(false);
   const [lastMousePos, setLastMousePos] = useState({ x: 0, y: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
-  const id = `mermaid-${uuid++}-${children?.length || 0}`;
+  // 使用稳定的 id 避免流式渲染时因 id 变化导致 DOM 反复 mount/unmount 引起抖动
+  const idRef = useRef<string | null>(null);
+  if (idRef.current === null) {
+    idRef.current = `mermaid-${uuid++}`;
+  }
+  const id = idRef.current;
 
   // ============================ locale ============================
   const [contextLocale] = useLocale('Mermaid', locale_EN.Mermaid);


### PR DESCRIPTION
close #1947

## 问题
Mermaid.tsx 第 67 行 `const id = \`mermaid-${uuid++}-${children?.length||0}\``,
每次渲染都生成新 id（uuid++ 且流式时 children.length 变化），导致 mermaid
生成的 DOM 反复创建/销毁，引起页面抖动。

## 修复
使用 `useRef` 缓存 id，组件生命周期内只生成一次：

```ts
const idRef = useRef<string | null>(null);
if (idRef.current === null) {
  idRef.current = `mermaid-${uuid++}`;
}
const id = idRef.current;
```

流式渲染时 children 变化不会改变 id，DOM 不再反复 mount/unmount，
解决关联抖动问题 (#1742)。

## 改动文件
- `packages/x/components/mermaid/Mermaid.tsx`

## 验证
- 流式场景下 Mermaid 渲染不再抖动
- 与上游 ant-design/x main 可以自动 merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 Mermaid 图表组件在重新渲染时生成不稳定渲染标识的问题。
  * 提升图表渲染的稳定性，避免潜在的显示异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->