### PR TITLE
fix(x-markdown): update marked to v18 to fix strikethrough parsing

### DIFF
--- a/packages/x-markdown/package.json
+++ b/packages/x-markdown/package.json
@@ -57,7 +57,7 @@
     "dompurify": "^3.2.6",
     "html-react-parser": "^5.2.13",
     "katex": "^0.16.22",
-    "marked": "^15.0.12"
+    "marked": "^18.0.7"
   },
   "devDependencies": {
     "@playwright/experimental-ct-react": "^1.56.1",


### PR DESCRIPTION
### Background

The tilde-syntax strikethrough (`~123 foo bar (~123)~`) was rendering as plain text in XMarkdown because the `marked` dependency had a known parsing bug fixed in later versions.

### Fix

Update `marked` from `^15.0.12` to `^18.0.7`. The issue reporter confirmed this works via package overrides.

### Related

Closes #2000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新 Markdown 渲染组件所使用的解析依赖，提升兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->