### PR TITLE
fix(think): hide retained content when collapsed

### DIFF
--- a/packages/x/components/think/__tests__/index.test.tsx
+++ b/packages/x/components/think/__tests__/index.test.tsx
@@ -119,6 +119,8 @@ describe('Think Component', () => {
     await waitFakeTimer();
     // content should still be in DOM with leavedClassName
     expect(container.querySelector('.ant-think-content')).toBeTruthy();
-    expect(container.querySelector('.ant-think-content-hidden')).toBeTruthy();
+    const hiddenContent = container.querySelector('.ant-think-content-hidden');
+    expect(hiddenContent).toBeTruthy();
+    expect(window.getComputedStyle(hiddenContent!).display).toBe('none');
   });
 });

--- a/packages/x/components/think/style/index.ts
+++ b/packages/x/components/think/style/index.ts
@@ -68,6 +68,9 @@ const genThinkStyle: GenerateStyle<ThinkToken> = (token) => {
         paddingInlineStart: paddingSM,
         borderInlineStart: `${calc(lineWidth).mul(2).equal()} solid ${colorBorder}`,
       },
+      [`${componentCls}-content-hidden`]: {
+        display: 'none',
+      },
       [`&${componentCls}-rtl`]: {
         direction: 'rtl',
       },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

Fixes #2025

### 💡 需求背景和解决方案

`destroyOnHidden={false}` 时，Think 折叠后会保留内容节点并添加 `ant-think-content-hidden`，但缺少对应的隐藏样式，导致内容仍然可见。

为离场后的内容包装节点补充 `display: none`，并增加回归测试，验证节点仍保留在 DOM 中但不可见。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Think content remaining visible after collapse when `destroyOnHidden` is `false`. |
| 🇨🇳 中文 | 修复 Think 在 `destroyOnHidden` 为 `false` 时折叠后内容仍然可见的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复 Think 组件折叠时内容仍可能显示的问题，隐藏状态下内容区域现在会正确设置为不显示。

* **测试**
  * 增强折叠状态测试，确认隐藏内容的显示样式为 `none`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->