### PR TITLE
fix(CodeHighlighter): load Prism grammars through a bundler-analyzable loader

### DIFF
--- a/packages/x/components/code-highlighter/CodeHighlighter.tsx
+++ b/packages/x/components/code-highlighter/CodeHighlighter.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import React, { lazy, Suspense } from 'react';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import Actions from '../actions';
@@ -16,37 +16,8 @@ const customOneLight = {
   },
 };
 
-// Module-level cache for loaded language highlighters
-const highlighterCache = new Map<string, React.LazyExoticComponent<React.ComponentType<any>>>();
 // Full Prism highlighter (cached, loaded on demand)
 let FullPrismHighlighter: React.LazyExoticComponent<React.ComponentType<any>> | null = null;
-
-const getAsyncHighlighter = (lang: string) => {
-  if (!highlighterCache.has(lang)) {
-    const LazyHighlighter = lazy(async () => {
-      try {
-        const langModule = await import(
-          `react-syntax-highlighter/dist/esm/languages/prism/${lang}`
-        );
-        SyntaxHighlighter.registerLanguage(lang, langModule.default);
-      } catch (error) {
-        console.warn(`[CodeHighlighter] Failed to load language: ${lang}`, error);
-      }
-      return {
-        default: ({
-          children,
-          ...rest
-        }: { children: string } & CodeHighlighterProps['highlightProps']) => (
-          <SyntaxHighlighter language={lang} {...rest}>
-            {children}
-          </SyntaxHighlighter>
-        ),
-      };
-    });
-    highlighterCache.set(lang, LazyHighlighter);
-  }
-  return highlighterCache.get(lang)!;
-};
 
 const getFullPrismHighlighter = () => {
   if (!FullPrismHighlighter) {
@@ -81,13 +52,10 @@ const CodeHighlighter = React.forwardRef<HTMLDivElement, CodeHighlighterProps>((
   const contextConfig = useXComponentConfig('codeHighlighter');
 
   // Get the appropriate highlighter component
-  // - prismLightMode = true (default): Use PrismLight with async language loading
+  // - prismLightMode = true (default): Use PrismAsyncLight, which loads AND registers the
+  //   grammar for `lang` on demand through a statically analyzable loader map
   // - prismLightMode = false: Use full Prism (all languages included)
-  const Highlighter = prismLightMode
-    ? lang
-      ? getAsyncHighlighter(lang)
-      : SyntaxHighlighter
-    : getFullPrismHighlighter();
+  const Highlighter = prismLightMode ? SyntaxHighlighter : getFullPrismHighlighter();
 
   // ============================ Early Returns ============================
   if (!children) {

--- a/packages/x/components/code-highlighter/__tests__/index.test.tsx
+++ b/packages/x/components/code-highlighter/__tests__/index.test.tsx
@@ -20,21 +20,6 @@ jest.mock('../../mermaid', () => ({
   default: () => <div data-testid="mock-mermaid">Mermaid Diagram</div>,
 }));
 
-// Mock react-syntax-highlighter
-jest.mock('react-syntax-highlighter/dist/esm/languages/prism/typescript', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-
-// Mock a language that doesn't exist to test the catch block
-jest.mock(
-  'react-syntax-highlighter/dist/esm/languages/prism/nonexistent-lang',
-  () => {
-    throw new Error('Module not found');
-  },
-  { virtual: true },
-);
-
 // Spy on console.warn
 const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -480,26 +465,19 @@ describe('CodeHighlighter', () => {
   });
 
   describe('language loading error handling', () => {
-    it('should handle language import failure gracefully', async () => {
-      // Use a non-existent language that will fail to import
-      // This tests the catch block in getAsyncHighlighter (line 30)
+    it('should handle an unsupported language gracefully', async () => {
+      // PrismAsyncLight normalizes unsupported languages to `text` instead of throwing
       const { container } = render(
         <CodeHighlighter lang="nonexistent-lang">{`console.log("test");`}</CodeHighlighter>,
       );
 
-      // Should still render the code even if language import fails
+      // Should still render the code even if the language is not supported
       await waitFor(() => {
         expect(container.querySelector('pre')).toBeInTheDocument();
       });
-
-      // Should have logged a warning about the failed language import
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        '[CodeHighlighter] Failed to load language: nonexistent-lang',
-        expect.any(Error),
-      );
     });
 
-    it('should render code fallback when language import fails', async () => {
+    it('should render code fallback when the language is unsupported', async () => {
       // Use a non-existent language
       const { container } = render(
         <CodeHighlighter lang="nonexistent-lang">{`const x = 42;`}</CodeHighlighter>,

--- a/packages/x/components/folder/FilePreview.tsx
+++ b/packages/x/components/folder/FilePreview.tsx
@@ -1,7 +1,7 @@
 import { Empty, Flex, Spin } from 'antd';
 import { clsx } from 'clsx';
 import React from 'react';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import ActionsCopy from '../actions/ActionsCopy';


### PR DESCRIPTION
## 🤔 This is a ...

- [x] 🐞 Bug fix

## 🔗 Related issue link

None — found while debugging why every code block in a Vite-bundled app renders unhighlighted.

## 💡 Background and solution

### The bug

`CodeHighlighter` uses `PrismLight`, which is backed by `refractor/core`. That instance ships **only** `plain`, `plaintext`, `text` and `txt`:

```js
import { refractor } from 'refractor/core'
refractor.listLanguages()
// => ["plain", "plaintext", "text", "txt"]
refractor.highlight('const a = 1', 'typescript')
// => Error: Unknown language: `typescript` is not registered
```

Grammars therefore have to be registered explicitly. The on-demand loader tries to do that, but it cannot work in any bundled app:

```js
const langModule = await import(`react-syntax-highlighter/dist/esm/languages/prism/${lang}`);
SyntaxHighlighter.registerLanguage(lang, langModule.default);
```

A **template literal over a bare specifier** is not statically analyzable. Vite/Rollup leave it in the output verbatim and emit no language chunk. Here is the expression as it appears in a production build of an app on `@ant-design/x@2.8.0`:

```js
await __vitePreload(() => import(`react-syntax-highlighter/dist/esm/languages/prism/${lang}`), true ? [] : void 0, import.meta.url);
```

Note the empty preload dependency list. At runtime the browser cannot resolve a bare specifier, so the import throws, the `registerLanguage` call on the next line never runs, and only `console.warn('[CodeHighlighter] Failed to load language: …')` is left behind.

`refractor.highlight()` then throws `Unknown language`; `react-syntax-highlighter` swallows that in `getCodeTree` and falls back to a single text node. **Every code block renders as unstyled plain text, silently.**

This is not fixed by upgrading. `2.8.0` had no `registerLanguage` call at all; `2.9.0` added one, but it sits right after the import that always fails, so it never executes.

`folder/FilePreview.tsx` has the same defect in a more direct form — it renders raw `PrismLight` and never registers anything, so file previews are never highlighted either.

### The fix

Use `PrismAsyncLight` instead of hand-rolling the loader. It already does exactly what is needed, and does it correctly:

- its `languageLoaders` map is a static object of literal `import('refractor/<lang>')` calls, so bundlers can code-split every grammar into a real chunk;
- it **loads and registers** the grammar, then re-renders;
- unsupported languages normalize to `text` rather than throwing.

`folder/FilePreview.tsx` is switched over too.

Two tests asserted the old `console.warn` behaviour for an unsupported language. `PrismAsyncLight` normalizes instead of warning, so those assertions are updated to check the graceful fallback (which is what they were really about). The now-dead `jest.mock` entries for the per-language modules are removed.

### Verification

```
jest components/code-highlighter   40 passed
jest components/folder            134 passed
```

## 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `CodeHighlighter` and `Folder` file preview rendering code without syntax highlighting: Prism grammars were loaded through a dynamic import that bundlers cannot analyze, so no grammar was ever registered. |
| 🇨🇳 Chinese | 修复 `CodeHighlighter` 与 `Folder` 文件预览代码无语法高亮的问题：Prism 语法通过打包器无法分析的动态 import 加载，导致语法从未被注册。 |

## ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化代码语法高亮的加载方式，按需加载语言支持，提升相关组件的加载效率。
  - 文件预览中的代码高亮现已支持异步加载。
  - 不受支持的语言会自动按纯文本方式正常显示，并保留代码回退渲染能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->