### PR TITLE
fix(Mermaid): stop leaking the error diagram into document.body

### DIFF
--- a/packages/x/components/mermaid/Mermaid.tsx
+++ b/packages/x/components/mermaid/Mermaid.tsx
@@ -98,6 +98,14 @@ const Mermaid: React.FC<MermaidProps> = React.memo((props) => {
       securityLevel: 'strict',
       theme: 'default',
       fontFamily: 'monospace',
+      // `mermaid.render(id, text)` below is called without a container element, so mermaid
+      // mounts its temporary `div#d{id}` on `document.body`. With error rendering enabled
+      // (mermaid's default) a failed render draws the "Syntax error in text" bomb diagram
+      // into that element and *then* throws, so mermaid's own `removeTempElements()` never
+      // runs — leaving the error SVG behind in `document.body`, outside this component and
+      // outside any layout, once per failure. Suppressing it makes both failure branches
+      // clean up after themselves instead.
+      suppressErrorRendering: true,
       ...(config || {}),
     });
   }, [config]);


### PR DESCRIPTION
## 🤔 This is a ...

- [x] 🐞 Bug fix

## 🔗 Related issue link

None — reproduced while streaming Mermaid diagrams into a chat UI.

## 💡 Background and solution

### The bug

A failed Mermaid render leaves a **visible "Syntax error in text" bomb diagram attached to `document.body`**, outside the component and outside any layout, and it accumulates one node per failure. It cannot be scrolled away, dismissed, or cleaned up by the consumer.

Two things combine to cause it.

**1. `render` is called without a container.**

```js
const { svg } = await mermaid.render(id, children);
```

With no `svgContainingElement`, mermaid mounts its temporary `div#d{id}` on `document.body`:

```js
} else {
  removeExistingElements(document, id, enclosingDivID, iFrameID);
  root = select('body');           // <-- here
  appendDivSvgG(root, id, enclosingDivID);
}
```

**2. `suppressErrorRendering` is left at mermaid's default (`false`).**

In that mode both failure branches of mermaid's `render()` draw the error diagram into that body-level element and *then* throw:

```js
try { diag = await Diagram.fromText(text, { title }) }
catch (error) {
  if (config.suppressErrorRendering) { removeTempElements(); throw error }
  diag = await Diagram.fromText('error');      // draws the bomb
  parseEncounteredException = error;
}
...
try { await diag.renderer.draw(text, id, version, diag) }
catch (e) {
  if (config.suppressErrorRendering) { removeTempElements() }
  else { errorRenderer.draw(text, id, version) }   // draws the bomb
  throw e
}
```

`removeTempElements()` is only reached on the fully successful path:

```js
if (parseEncounteredException) { throw parseEncounteredException }
removeTempElements();     // unreachable from either throw above
return { diagramType, svg: svgCode, bindFunctions: diag.db.bindFunctions }
```

So every failed render leaks. The existing `mermaid.parse(…, { suppressErrors: true })` guard only covers syntax errors — it does not cover failures inside `renderer.draw`, which are easy to hit when a diagram arrives incrementally (streaming), where an intermediate partial diagram can parse fine but fail to draw.

Consumers cannot work around this: the node is injected straight into the DOM, so an `ErrorBoundary` never sees it, and polling `document.body` still lets the bomb flash on screen first.

### Reproduction

Driving mermaid directly with an invalid diagram, in jsdom, with the exact `initialize` options this component uses:

| `suppressErrorRendering` | `render` threw | `document.body` children left behind | contains "Syntax error" |
| --- | --- | --- | --- |
| `false` (current default) | ✓ | **1** | **✓** |
| `true` | ✓ | **0** | ✗ |

### The fix

Default `suppressErrorRendering` to `true` so both failure branches clean up after themselves. It is still overridable through the `config` prop, since it is spread after the defaults.

### Follow-ups, deliberately left out to keep this focused

- Pass `containerRef.current` as `mermaid.render`'s third argument so the temporary element never touches `document.body` at all.
- `renderDiagram` re-creates its `throttle(…, 100)` wrapper on every render, so the throttle never actually applies — every streamed chunk triggers a full render.

### Verification

```
jest components/mermaid   70 passed
```

## 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Mermaid` leaving the "Syntax error in text" diagram attached to `document.body` when a render fails. |
| 🇨🇳 Chinese | 修复 `Mermaid` 渲染失败时把「Syntax error in text」错误图残留在 `document.body` 上的问题。 |

## ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * Mermaid 图表渲染失败时不再向页面插入错误提示 SVG，避免页面出现异常内容。
  * 渲染错误仍会被捕获并通过警告进行提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->