### PR TITLE
fix(theme): restore Popover shadow with XProvider

### DIFF
--- a/packages/x/components/theme/interface/alias.ts
+++ b/packages/x/components/theme/interface/alias.ts
@@ -592,6 +592,8 @@ export interface AliasToken extends MapToken {
   /** @internal */
   boxShadowPopoverArrow: string;
   /** @internal */
+  dropShadowPopover: string;
+  /** @internal */
   boxShadowCard: string;
   /** @internal */
   boxShadowDrawerRight: string;

--- a/packages/x/components/theme/util/alias.ts
+++ b/packages/x/components/theme/util/alias.ts
@@ -166,6 +166,8 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
     screenXXLMin: screenXXL,
 
     boxShadowPopoverArrow: '2px 2px 5px rgba(0, 0, 0, 0.05)',
+    dropShadowPopover:
+      'drop-shadow(0 6px 16px rgba(0, 0, 0, 0.08)) drop-shadow(0 3px 6px rgba(0, 0, 0, 0.12)) drop-shadow(0 9px 28px rgba(0, 0, 0, 0.05))',
     boxShadowCard: `
       0 1px 2px -2px ${new FastColor('rgba(0, 0, 0, 0.16)').toRgbString()},
       0 3px 6px 0 ${new FastColor('rgba(0, 0, 0, 0.12)').toRgbString()},

--- a/packages/x/components/x-provider/__tests__/cssVar.test.tsx
+++ b/packages/x/components/x-provider/__tests__/cssVar.test.tsx
@@ -1,4 +1,5 @@
 import { createCache, StyleProvider } from '@ant-design/cssinjs';
+import { Popover } from 'antd';
 import React from 'react';
 import { render } from '../../../tests/utils';
 import { Bubble } from '../../index';
@@ -45,5 +46,32 @@ describe('XProvider.cssVar', () => {
     expect(bubbleStyle.innerHTML).toContain('var(--ant-');
 
     expect(container.querySelector('.ant-bubble')?.className).toContain('css-var-');
+  });
+
+  it('preserves the Popover drop shadow token', () => {
+    render(
+      <StyleProvider cache={createCache()}>
+        <XProvider>
+          <Bubble content="test" />
+          <Popover content="popover" open>
+            <button type="button">trigger</button>
+          </Popover>
+        </XProvider>
+      </StyleProvider>,
+    );
+
+    const popover = document.querySelector('.ant-popover');
+    const cssVarClass = Array.from(popover?.classList ?? []).find((className) =>
+      className.startsWith('css-var-'),
+    );
+    const cssVarStyle = Array.from(document.head.querySelectorAll('style')).find(
+      (style) =>
+        cssVarClass &&
+        style.innerHTML.includes(`.${cssVarClass}`) &&
+        style.innerHTML.includes('--ant-drop-shadow-popover:'),
+    );
+
+    expect(cssVarClass).toBeTruthy();
+    expect(cssVarStyle?.innerHTML).toMatch(/--ant-drop-shadow-popover:\s*drop-shadow\(/);
   });
 });


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #2021

### 💡 Background and Solution

#### Why

antd 6 renders Popover elevation with the `dropShadowPopover` alias token. XProvider's token formatter did not expose that newer alias. When X components generated a scoped CSS-variable class, `--ant-drop-shadow-popover` was missing, so Popover resolved `filter` to `none` and lost its elevation.

#### What

- add `dropShadowPopover` to the X alias-token contract
- generate the same three-layer drop shadow expected by antd Popover
- add a regression test covering an antd Popover rendered in the shared XProvider CSS-variable context

#### How

```ts
dropShadowPopover:
  'drop-shadow(0 6px 16px rgba(0, 0, 0, 0.08)) drop-shadow(0 3px 6px rgba(0, 0, 0, 0.12)) drop-shadow(0 9px 28px rgba(0, 0, 0, 0.05))',
```

The fix restores the missing CSS variable instead of adding a component-specific override, so Popover keeps using antd's own `filter: var(--ant-drop-shadow-popover)` rule.

### 🔎 Browser verification

**Before — official 2.9.0 playground:** the Popover is visible but its computed filter is `none`.


**After — patched source:** the Popover receives the three-layer drop shadow.


### ✅ Validation

```text
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshots:   0 total
```

- `tsc --noEmit -p packages/x/tsconfig.json`
- Biome check on all three changed files
- `git diff --check`
- real-browser comparison: `filter: none` before; three computed `drop-shadow(...)` layers after

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Restore Popover shadows when antd components share XProvider's CSS-variable theme context. |
| 🇨🇳 Chinese | 修复 antd 组件共用 XProvider CSS 变量主题时 Popover 阴影丢失的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式改进**
  * 优化弹出层阴影效果，使其视觉层次更加清晰。
  * 为弹出层提供对应的 CSS 阴影变量，确保主题样式正确生效。

* **测试**
  * 新增验证，确保弹出层阴影变量能够在主题提供组件中正确生成。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🎬 Before / After browser recording

The same reproduction was run in the same browser viewport. Each GIF preview links to the original MP4.

### Before — Popover shadow missing (filter: none)

[![Before: Popover renders without its shadow](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-2021/before.gif)](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-2021/before.mp4)

[Open the original before MP4](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-2021/before.mp4)

### After — three-layer drop-shadow(...) restored

[![After: Popover receives the three-layer shadow](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-2021/after.gif)](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-2021/after.mp4)

[Open the original after MP4](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-2021/after.mp4)
