### PR TITLE
fix(sender): preserve multiline paste in slot mode

### DIFF
--- a/packages/x/components/sender/__tests__/slot.test.tsx
+++ b/packages/x/components/sender/__tests__/slot.test.tsx
@@ -623,22 +623,36 @@ describe('Sender Slot Component', () => {
       });
       expect(onPasteFile).toHaveBeenCalledWith([mockFile]);
     });
-    it('should handle paste text events', () => {
+    it('should preserve multiline text when pasting in slot mode', () => {
       const onPaste = jest.fn();
-      document.execCommand = undefined as any;
+      document.execCommand = jest.fn(() => true);
       const slotConfig = [textSlotConfig];
       const { container } = render(<Sender slotConfig={slotConfig} onPaste={onPaste} />);
 
       const inputArea = container.querySelector('[role="textbox"]') as HTMLElement;
+      const mockRange = createMockRange({
+        startContainer: inputArea,
+        endContainer: inputArea,
+        startOffset: inputArea.childNodes.length,
+        endOffset: inputArea.childNodes.length,
+        collapsed: true,
+      });
+      setupDOMMocks({}, mockRange);
 
       fireEvent.paste(inputArea, {
         clipboardData: {
-          getData: () => 'pasted text',
+          getData: () => '\nfirst line\r\nsecond line\nthird line\n',
           files: [],
         },
       });
 
       expect(onPaste).toHaveBeenCalled();
+      expect(document.execCommand).not.toHaveBeenCalled();
+      expect(mockRange.insertNode).toHaveBeenCalledTimes(1);
+
+      const insertedNode = mockRange.insertNode.mock.calls[0][0];
+      expect(insertedNode).toBeInstanceOf(Text);
+      expect(insertedNode.textContent).toBe('first line\nsecond line\nthird line');
     });
     it('should handle select all keyboard shortcut', () => {
       const onKeyDown = jest.fn();

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -646,15 +646,8 @@ const SlotTextArea = React.forwardRef<SlotTextAreaRef>((_, ref) => {
       return;
     }
     if (text) {
-      let success = false;
       const cleanedText = getCleanedText(text);
-      try {
-        success = document.execCommand('insertText', false, cleanedText);
-      } catch (err) {
-        warning(false, 'Sender', `insertText command failed: ${err}`);
-      }
-
-      if (!success) {
+      if (cleanedText) {
         insert([{ type: 'text', value: cleanedText }]);
       }
     }

--- a/packages/x/components/sender/hooks/use-cursor.ts
+++ b/packages/x/components/sender/hooks/use-cursor.ts
@@ -484,7 +484,7 @@ const useCursor = (options?: UseCursorOptions): UseCursorReturn => {
   const getCleanedText = useCallback((ori: string) => {
     return ori
       .replace(/\u200B/g, '') // 移除零宽空格
-      .replace(/\n/g, '')
+      .replace(/\r\n?/g, '\n')
       .replace(/^\n+|\n+$/g, ''); // 移除开头和结尾的换行
   }, []);
 
@@ -528,4 +528,4 @@ const useCursor = (options?: UseCursorOptions): UseCursorReturn => {
 };
 
 export default useCursor;
-export type { CursorPosition, UseCursorReturn, UseCursorOptions };
+export type { CursorPosition, UseCursorOptions, UseCursorReturn };


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #1965

Related context: #1626

### 💡 Background and Solution

#### Why

Slot-mode paste used the deprecated `document.execCommand('insertText')` API after removing every internal newline from clipboard text. Chrome 149+ can also materialize multiline `contentEditable` insertion as block elements, making the resulting Sender value browser-dependent and, in the reported case, leaving only the first line at submission time.

#### What

- normalize Windows CRLF/CR line endings to LF
- preserve internal line breaks while trimming only leading and trailing blank lines
- insert pasted content through Sender's existing range-based text-node path instead of `execCommand`
- add a regression test that exercises three pasted lines while `execCommand` reports a successful Chrome path

#### How

```ts
const cleanedText = getCleanedText(text);
if (cleanedText) {
  insert([{ type: 'text', value: cleanedText }]);
}
```

This keeps multiline content in one text node, which works with the existing `white-space: pre-wrap` style and avoids browser-generated `<div>` wrappers around pasted lines.

### 🔎 Browser verification

In Chrome, pasting `first line\nsecond line\nthird line` into an empty slot-mode Sender produced the exact same value in both `onChange` and `onSubmit`. No browser console errors were emitted.

### ✅ Validation

```text
SlotTextArea: 22 passed
useCursor:     48 passed
Total:         70 passed
```

- `tsc --noEmit -p packages/x/tsconfig.json`
- Biome check on all three changed files
- `git diff --check`
- real Chrome paste and submit verification

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Preserve multiline clipboard content when pasting into Sender slot mode. |
| 🇨🇳 Chinese | 修复 Sender 词槽模式粘贴多行文本时换行及后续内容丢失的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化文本粘贴行为，保留多行文本的换行格式并统一换行符。
  * 粘贴内容现可稳定插入为纯文本，提升编辑体验。
  * 修复粘贴过程中可能触发不必要命令及警告的问题。

* **Tests**
  * 新增多行文本粘贴场景验证，确保内容插入和粘贴事件回调正常触发。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->