### PR TITLE
fix(sender): keep inline custom inputs editable

### DIFF
--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -1,7 +1,9 @@
+import { Input } from 'antd';
 import React from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
+import type { SenderRef } from '../index';
 import Sender from '../index';
 
 const mockRecognition = {
@@ -206,6 +208,49 @@ describe('Sender Component', () => {
   it('readOnly', () => {
     const { container } = render(<Sender readOnly />);
     expect(container.querySelector('textarea')).toHaveAttribute('readonly');
+  });
+
+  it('keeps an inline custom controlled input focused and exposes its native element', () => {
+    const ref = React.createRef<SenderRef>();
+
+    const CustomSender = () => {
+      const [value, setValue] = React.useState('');
+      return (
+        <Sender
+          ref={ref}
+          value={value}
+          onChange={setValue}
+          components={{
+            input: ({ autoSize: _autoSize, ...inputProps }) => (
+              <Input
+                {...(inputProps as React.ComponentProps<typeof Input>)}
+                placeholder="Custom input"
+              />
+            ),
+          }}
+        />
+      );
+    };
+
+    const { getByPlaceholderText } = render(<CustomSender />);
+
+    let input = getByPlaceholderText('Custom input') as HTMLInputElement;
+    expect(ref.current?.inputElement).toBe(input);
+    input.focus();
+    fireEvent.change(input, { target: { value: 'a' } });
+
+    input = getByPlaceholderText('Custom input') as HTMLInputElement;
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue('a');
+    expect(ref.current?.inputElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: 'ab' } });
+    input = getByPlaceholderText('Custom input') as HTMLInputElement;
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue('ab');
+
+    ref.current?.insert('c', 'end');
+    expect(getByPlaceholderText('Custom input')).toHaveValue('abc');
   });
   describe('footer', () => {
     it('footer width function', () => {

--- a/packages/x/components/sender/components/TextArea.tsx
+++ b/packages/x/components/sender/components/TextArea.tsx
@@ -1,6 +1,6 @@
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import getValue from '@rc-component/util/lib/utils/get';
-import type { InputRef as AntdInputRef, InputRef } from 'antd';
+import type { InputRef } from 'antd';
 import { Input } from 'antd';
 import { clsx } from 'clsx';
 import React from 'react';
@@ -23,6 +23,32 @@ export interface TextAreaRef {
   clear: () => void;
   getValue: () => { value: string; slotConfig: any[]; skill?: SkillType };
 }
+
+interface InnerInputRef {
+  focus: InputRef['focus'];
+  blur: InputRef['blur'];
+  input?: HTMLInputElement | null;
+  resizableTextArea?: {
+    textArea: HTMLTextAreaElement;
+  };
+  nativeElement: HTMLElement | null;
+}
+
+const getNativeInputElement = (
+  inputRef: InnerInputRef | null,
+): HTMLInputElement | HTMLTextAreaElement | null => {
+  const nativeElement = inputRef?.resizableTextArea?.textArea || inputRef?.input;
+  if (nativeElement) {
+    return nativeElement;
+  }
+
+  const fallbackElement = inputRef?.nativeElement;
+  if (fallbackElement?.tagName === 'INPUT' || fallbackElement?.tagName === 'TEXTAREA') {
+    return fallbackElement as HTMLInputElement | HTMLTextAreaElement;
+  }
+
+  return null;
+};
 
 const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
   const {
@@ -47,17 +73,46 @@ const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
     ...restProps
   } = React.useContext(SenderContext);
 
-  const inputRef = React.useRef<AntdInputRef>(null);
+  const inputRef = React.useRef<InnerInputRef>(null);
+  const restoreSelectionRef = React.useRef<{
+    start: number;
+    end: number;
+    direction?: 'forward' | 'backward' | 'none';
+  } | null>(null);
+
+  React.useLayoutEffect(() => {
+    const selection = restoreSelectionRef.current;
+    if (!selection) {
+      return;
+    }
+
+    const inputElement = getNativeInputElement(inputRef.current);
+    if (inputElement) {
+      inputElement.focus({ preventScroll: true });
+      inputElement.setSelectionRange(selection.start, selection.end, selection.direction);
+    }
+
+    const timer = window.setTimeout(() => {
+      if (restoreSelectionRef.current === selection) {
+        restoreSelectionRef.current = null;
+      }
+    });
+
+    return () => window.clearTimeout(timer);
+  });
 
   const insert: TextAreaRef['insert'] = (insertValue: string, positions = 'cursor') => {
-    const textArea = (inputRef.current as any)?.resizableTextArea?.textArea;
+    const textArea = getNativeInputElement(inputRef.current);
+    if (!textArea) {
+      return;
+    }
     // 获取当前文本内容
     const currentText = textArea.value;
     let startPos = currentText.length;
     let endPos = currentText.length;
     if (positions === 'cursor') {
-      startPos = textArea?.selectionStart;
-      endPos = textArea?.selectionEnd;
+      startPos = textArea.selectionStart ?? currentText.length;
+      endPos = textArea.selectionEnd ?? currentText.length;
     }
     if (positions === 'start') {
       startPos = 0;
@@ -73,6 +128,11 @@ const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
     // 设置新的光标位置
     textArea.selectionStart = startPos + insertValue.length;
     textArea.selectionEnd = startPos + insertValue.length;
+    restoreSelectionRef.current = {
+      start: textArea.selectionStart,
+      end: textArea.selectionEnd,
+      direction: textArea.selectionDirection || undefined,
+    };
 
     // 重新聚焦到textarea
     textArea.focus();
@@ -90,9 +150,9 @@ const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
 
   React.useImperativeHandle(ref, () => {
     return {
-      nativeElement: (inputRef.current as any)?.resizableTextArea?.textArea as HTMLTextAreaElement,
-      focus: inputRef.current?.focus!,
-      blur: inputRef.current?.blur!,
+      nativeElement: getNativeInputElement(inputRef.current),
+      focus: (options) => inputRef.current?.focus?.(options),
+      blur: () => inputRef.current?.blur?.(),
       insert,
       clear,
       getValue,
@@ -160,10 +220,14 @@ const TextArea = React.forwardRef<TextAreaRef>((_, ref) => {
   };
 
   const mergeOnChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    onChange?.(
-      (event.target as HTMLTextAreaElement).value,
-      event as React.ChangeEvent<HTMLTextAreaElement>,
-    );
+    const target = event.target as HTMLInputElement | HTMLTextAreaElement;
+    restoreSelectionRef.current = {
+      start: target.selectionStart ?? target.value.length,
+      end: target.selectionEnd ?? target.value.length,
+      direction: target.selectionDirection || undefined,
+    };
+
+    onChange?.(target.value, event as React.ChangeEvent<HTMLTextAreaElement>);
   };
 
   return (


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #1944

### 💡 Background and Solution

#### Why

A controlled Sender re-renders its parent after every `onChange`. When `components.input` is declared inline, that render creates a new component function, so React replaces the underlying input node and focus is lost after the first character.

The previous imperative ref implementation also assumed an antd TextArea ref (`resizableTextArea.textArea`). A custom antd Input uses `ref.input`, leaving `inputElement` and `insert()` unavailable.

#### What

- resolve native elements from antd Input, antd TextArea, and native-element ref shapes
- retain the cursor selection across controlled custom-input replacement and restore it synchronously before paint
- support `focus`, `blur`, `inputElement`, and `insert()` for custom single-line Input components
- add a regression test using the reported inline, controlled `components.input` pattern

#### How

The change records the input selection before forwarding `onChange`. A layout effect restores focus and selection to the newly mounted native control. The pending selection survives Sender's internal update and the parent controlled update, then clears after the render cycle.

Native input resolution is shared by the imperative methods, so custom Input and the default TextArea follow the same code path.

### 🔎 Browser verification

Before the fix, entering `abc` in Chrome stopped at `a` and moved focus to `BODY`. After the fix, the controlled value becomes `abc` and the custom Input remains the active element.

### ✅ Validation

```text
Test Suites: 1 passed, 1 total
Tests:       25 passed, 25 total
Snapshots:   2 passed, 2 total
```

- `tsc --noEmit -p packages/x/tsconfig.json`
- Biome check on both changed files
- `git diff --check`
- real Chrome controlled-input focus and value verification

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Keep inline custom Sender inputs editable during controlled value updates. |
| 🇨🇳 Chinese | 修复 Sender 受控更新时内联自定义输入框输入一个字符后失焦的问题。 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进自定义输入框的文本插入体验，插入内容后可保持输入焦点。
  - 输入内容变化或插入文本后，光标位置能够正确恢复。
  - 提升输入框引用对原生输入元素的访问稳定性，确保文本插入功能可靠运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🎬 Before / After browser recording

The same controlled inline custom Input was used to type abc at the same speed and viewport. Each GIF preview links to the original MP4.

### Before — input stops at a and focus moves to BODY

[![Before: custom input loses focus after the first character](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-1944/before.gif)](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-1944/before.mp4)

[Open the original before MP4](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-1944/before.mp4)

### After — value reaches abc and focus remains on INPUT

[![After: custom input remains focused while typing all characters](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-1944/after.gif)](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-1944/after.mp4)

[Open the original after MP4](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-2030-2032/issue-1944/after.mp4)
