### PR TITLE
fix(sender): preserve slots for text selection deletion

### DIFF
--- a/packages/x/components/sender/__tests__/slot.test.tsx
+++ b/packages/x/components/sender/__tests__/slot.test.tsx
@@ -691,6 +691,49 @@ describe('Sender Slot Component', () => {
       setupDOMMocks(customSelectionMock, customRangeMock);
       fireEvent.keyDown(dom, { key: 'Backspace' });
     });
+    it('should preserve a slot while deleting a non-collapsed text selection', () => {
+      const onChange = jest.fn();
+      const ref = createRef<SenderRef>();
+      const { container } = render(
+        <Sender
+          ref={ref}
+          slotConfig={[tagSlotConfig, { type: 'text', value: 'Selected text' }]}
+          onChange={onChange}
+        />,
+      );
+      const dom = ref.current?.inputElement as HTMLElement;
+      const slotDom = container.querySelector('[data-slot-key="tag1"]') as HTMLElement;
+      const textDom = Array.from(dom.childNodes).find(
+        (node) => node.nodeType === Node.TEXT_NODE && node.textContent === 'Selected text',
+      );
+
+      expect(slotDom).toBeInTheDocument();
+      expect(textDom).toBeTruthy();
+      onChange.mockClear();
+
+      setupDOMMocks(
+        {
+          rangeCount: 1,
+          focusOffset: 0,
+          anchorNode: textDom,
+          anchorOffset: textDom?.textContent?.length,
+          focusNode: textDom,
+          isCollapsed: false,
+        },
+        {
+          startContainer: textDom as HTMLElement,
+          endContainer: textDom as HTMLElement,
+          startOffset: 0,
+          endOffset: textDom?.textContent?.length,
+          collapsed: false,
+          toString: jest.fn(() => 'Selected text'),
+        },
+      );
+
+      expect(fireEvent.keyDown(dom, { key: 'Backspace' })).toBe(true);
+      expect(slotDom).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
     it('should handle backspace key in content slot', () => {
       const onSubmit = jest.fn();
       const slotConfig = [contentSlotConfigWithValue];

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -510,8 +510,9 @@ const SlotTextArea = React.forwardRef<SlotTextAreaRef>((_, ref) => {
       }
     }
 
-    // 处理退格键删除前一个元素
-    if (operationType === 'backspace' && focusOffset === 0) {
+    // Only remove the preceding slot for a collapsed caret. When text is selected,
+    // the browser must handle the selection first, even if its focus edge touches a slot.
+    if (operationType === 'backspace' && range?.collapsed && focusOffset === 0) {
       const previousSibling = anchorNode.previousSibling;
       if (previousSibling) {
         const nodeInfo = getNodeInfo(previousSibling as HTMLElement);


### PR DESCRIPTION
## Why

In Sender slot mode, Backspace treated a non-collapsed text selection as a caret at offset zero. When the selection edge touched a slot, Sender removed the slot and prevented the browser from deleting the selected text.

Fixes #1906.

## What changed

- Restrict preceding-slot deletion to collapsed caret ranges.
- Let the browser handle normal non-collapsed text selection deletion.
- Add a regression test for a backwards text selection whose edge touches a slot.

## Verification

- Sender slot Jest suite: 23 passed.
- TypeScript `--noEmit` check passed.
- Biome and `git diff --check` passed.
- Real Chromium before/after reproduction passed.

## Before / After

**Before:** Backspace removes the adjacent slot while the selected text remains.

https://github.com/user-attachments/assets/e815bfee-69c2-4e10-8743-97c6b0a4a39c

**After:** Backspace deletes the selected text while preserving the slot.

https://github.com/user-attachments/assets/13d732ef-9139-4c85-a8c8-249401565391

Changelog: Fix Sender slot mode deleting the adjacent slot before a selected text range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复在文本选区上按下 Backspace 时，误删除相邻标签或技能项的问题。
  * 现在，删除已有文本选区时会优先处理选区内容，并保留相邻的标签槽位。
  * 仅当光标未选中文本时，Backspace 才会删除光标前的相邻项目。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->