### PR TITLE
fix(sender): delete newlines before slots

### DIFF
--- a/packages/x/components/sender/__tests__/slot.test.tsx
+++ b/packages/x/components/sender/__tests__/slot.test.tsx
@@ -691,6 +691,55 @@ describe('Sender Slot Component', () => {
       setupDOMMocks(customSelectionMock, customRangeMock);
       fireEvent.keyDown(dom, { key: 'Backspace' });
     });
+    it('should remove a newline immediately before a slot', () => {
+      const onChange = jest.fn();
+      const ref = createRef<SenderRef>();
+      const { container } = render(
+        <Sender
+          ref={ref}
+          submitType="shiftEnter"
+          slotConfig={[
+            { type: 'text', value: 'Text before slot' },
+            tagSlotConfig,
+            { type: 'text', value: ' text after slot' },
+          ]}
+          onChange={onChange}
+        />,
+      );
+      const dom = ref.current?.inputElement as HTMLElement;
+      const slotDom = container.querySelector('[data-slot-key="tag1"]') as HTMLElement;
+      const trailingText = Array.from(dom.childNodes).find(
+        (node) => node.nodeType === Node.TEXT_NODE && node.textContent === ' text after slot',
+      ) as Text;
+      const nextLine = document.createElement('div');
+
+      nextLine.append(document.createElement('br'), slotDom, trailingText);
+      dom.append(nextLine);
+      onChange.mockClear();
+
+      setupDOMMocks(
+        {
+          rangeCount: 1,
+          focusOffset: 0,
+          anchorNode: nextLine,
+          anchorOffset: 0,
+          focusNode: nextLine,
+          isCollapsed: true,
+        },
+        {
+          startContainer: nextLine,
+          endContainer: nextLine,
+          startOffset: 0,
+          endOffset: 0,
+          collapsed: true,
+        },
+      );
+
+      expect(fireEvent.keyDown(dom, { key: 'Backspace' })).toBe(false);
+      expect(nextLine).not.toBeInTheDocument();
+      expect(slotDom.parentElement).toBe(dom);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
     it('should handle backspace key in content slot', () => {
       const onSubmit = jest.fn();
       const slotConfig = [contentSlotConfigWithValue];

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -493,6 +493,42 @@ const SlotTextArea = React.forwardRef<SlotTextAreaRef>((_, ref) => {
       return false;
     }
 
+    // Chromium keeps a block wrapper after deleting the leading <br> of a line that starts
+    // with a non-editable slot. Merge that line explicitly so Backspace removes the newline.
+    if (
+      operationType === 'backspace' &&
+      range?.collapsed &&
+      focusOffset === 0 &&
+      anchorNode.nodeType === Node.ELEMENT_NODE
+    ) {
+      const editableDom = editableRef.current;
+      const line = anchorNode as HTMLElement;
+      const lineBreak = line.firstChild;
+      const firstContentNode = lineBreak?.nextSibling;
+      const firstContentInfo =
+        firstContentNode?.nodeType === Node.ELEMENT_NODE
+          ? getNodeInfo(firstContentNode as HTMLElement)
+          : null;
+
+      if (
+        line.parentElement === editableDom &&
+        line.previousSibling &&
+        lineBreak?.nodeName === 'BR' &&
+        firstContentInfo?.slotKey
+      ) {
+        const lineIndex = Array.from(editableDom.childNodes).indexOf(line);
+        e.preventDefault();
+        lineBreak.remove();
+        while (line.firstChild) {
+          editableDom.insertBefore(line.firstChild, line);
+        }
+        line.remove();
+        setCursorPosition(editableDom, editableDom, lineIndex);
+        triggerValueChange(e as unknown as EventType);
+        return true;
+      }
+    }
+
     // 处理文本节点中的slot删除
     if (anchorNode.nodeType === Node.TEXT_NODE && range) {
       const parentElement = anchorNode.parentNode as HTMLElement;


### PR DESCRIPTION
## Why

In Chromium, pressing Enter immediately before a non-editable Sender slot creates a new block that starts with `<br>`. Backspace removes the break node but leaves the block wrapper, so the visual newline cannot be deleted.

Fixes #1889.

## What changed

- Detect a collapsed caret at the start of a slot-led block.
- Remove the leading break and unwrap the block into the editor.
- Preserve the slot DOM and restore the caret immediately before it.
- Add a regression test for Enter then Backspace before a slot.

## Verification

- Sender slot Jest suite: 23 passed.
- TypeScript `--noEmit` check passed.
- Biome and `git diff --check` passed.
- Real Chromium before/after reproduction passed.

## Before / After

**Before:** Backspace removes `<br>`, but the block wrapper keeps the newline.

https://github.com/user-attachments/assets/4e33140f-1326-44bf-bd7b-f8cbc861f351

**After:** Backspace merges the line while preserving the slot and caret position.

https://github.com/user-attachments/assets/98f4cbb6-5fd1-4258-8266-6f6dfe125787

Changelog: Fix Sender slot mode being unable to delete a newline immediately before a slot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复编辑器中退格删除操作的问题：光标位于不可编辑插槽前的换行处时，可正确移除换行并合并内容。
  * 优化插槽内容删除后的光标位置与内容变更处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->