### PR TITLE
fix(mermaid): remove zoom cap and export full diagrams

### DIFF
--- a/packages/x/components/mermaid/Mermaid.tsx
+++ b/packages/x/components/mermaid/Mermaid.tsx
@@ -143,7 +143,7 @@ const Mermaid: React.FC<MermaidProps> = React.memo((props) => {
       lastTime = now;
 
       const delta = e.deltaY > 0 ? -0.1 : 0.1;
-      setScale((prev) => Math.max(0.5, Math.min(3, prev + delta)));
+      setScale((prev) => Math.max(0.5, prev + delta));
     };
 
     container.addEventListener('wheel', wheelHandler, { passive: false });
@@ -206,12 +206,30 @@ const Mermaid: React.FC<MermaidProps> = React.memo((props) => {
     const svgElement = containerRef.current?.querySelector('svg');
     if (!svgElement) return;
 
-    const svgString = new XMLSerializer().serializeToString(svgElement);
+    const exportSvg = svgElement.cloneNode(true) as SVGSVGElement;
+    exportSvg.style.removeProperty('transform');
+    exportSvg.style.removeProperty('transform-origin');
+    exportSvg.style.removeProperty('transition');
+    exportSvg.style.removeProperty('cursor');
+
+    const viewBox = svgElement.viewBox.baseVal;
+    let width = viewBox.width || svgElement.width.baseVal.value;
+    let height = viewBox.height || svgElement.height.baseVal.value;
+    if (!width || !height) {
+      const bounds = svgElement.getBoundingClientRect();
+      width ||= bounds.width / scale;
+      height ||= bounds.height / scale;
+    }
+    if (!width || !height) return;
+
+    exportSvg.setAttribute('width', `${width}`);
+    exportSvg.setAttribute('height', `${height}`);
+
+    const svgString = new XMLSerializer().serializeToString(exportSvg);
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const { width, height } = svgElement.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
 
     canvas.width = width * dpr;
@@ -232,7 +250,7 @@ const Mermaid: React.FC<MermaidProps> = React.memo((props) => {
   };
 
   const handleZoomIn = () => {
-    setScale((prev) => Math.min(prev + 0.2, 3));
+    setScale((prev) => prev + 0.2);
   };
 
   const handleZoomOut = () => {

--- a/packages/x/components/mermaid/__tests__/index.test.tsx
+++ b/packages/x/components/mermaid/__tests__/index.test.tsx
@@ -491,7 +491,7 @@ describe('Mermaid Component', () => {
       const { container } = render(<Mermaid>{mermaidContent}</Mermaid>);
 
       await waitFor(() => {
-        expect(mockRender).toHaveBeenCalled();
+        expect(container.querySelector('.ant-mermaid-graph svg')).toBeInTheDocument();
       });
 
       // 验证组件渲染后包含 SVG 元素
@@ -509,10 +509,10 @@ describe('Mermaid Component', () => {
     });
 
     it('should update transform styles when scale changes', async () => {
-      render(<Mermaid>{mermaidContent}</Mermaid>);
+      const { container } = render(<Mermaid>{mermaidContent}</Mermaid>);
 
       await waitFor(() => {
-        expect(mockRender).toHaveBeenCalled();
+        expect(container.querySelector('.ant-mermaid-graph svg')).toBeInTheDocument();
       });
 
       // 验证缩放功能正常工作
@@ -524,6 +524,16 @@ describe('Mermaid Component', () => {
 
       // 点击缩小按钮应该触发缩放
       expect(() => fireEvent.click(zoomOutButton)).not.toThrow();
+
+      // 放大不应被旧的 3 倍上限截断
+      for (let i = 0; i < 11; i++) {
+        fireEvent.click(zoomInButton);
+      }
+      await waitFor(() => {
+        const svg = container.querySelector('.ant-mermaid-graph svg') as SVGSVGElement | null;
+        const currentScale = Number(svg?.style.transform.match(/scale\(([^)]+)\)/)?.[1]);
+        expect(currentScale).toBeGreaterThan(3);
+      });
     });
 
     it('should update transform styles when position changes during drag', async () => {
@@ -697,10 +707,9 @@ describe('Mermaid Component', () => {
 
   describe('Download Functionality', () => {
     it('should handle download correctly', async () => {
-      // Mock DOM APIs
-      const mockSvgElement = {
-        getBoundingClientRect: jest.fn().mockReturnValue({ width: 200, height: 150 }),
-      };
+      mockRender.mockResolvedValueOnce({
+        svg: '<svg viewBox="0 0 640 480"><rect width="640" height="480" /></svg>',
+      });
 
       // Mock XMLSerializer
       const mockSerializeToString = jest.fn().mockReturnValue('<svg>test</svg>');
@@ -754,30 +763,35 @@ describe('Mermaid Component', () => {
       const originalDevicePixelRatio = window.devicePixelRatio;
       window.devicePixelRatio = 2;
 
-      // Mock containerRef and querySelector
-      const mockQuerySelector = jest.fn().mockReturnValue(mockSvgElement);
+      const { container } = render(<Mermaid>{mermaidContent}</Mermaid>);
 
-      render(<Mermaid>{mermaidContent}</Mermaid>);
-
-      // Override the containerRef to return our mock
-      const container = document.querySelector('.ant-mermaid-graph');
-      if (container) {
-        container.querySelector = mockQuerySelector;
-      }
+      await waitFor(() => {
+        expect(container.querySelector('.ant-mermaid-graph svg')).toBeInTheDocument();
+      });
+      const svgElement = container.querySelector('.ant-mermaid-graph svg') as SVGSVGElement;
+      svgElement.style.transform = 'scale(3) translate(20px, 10px)';
+      const getBoundingClientRectSpy = jest
+        .spyOn(svgElement, 'getBoundingClientRect')
+        .mockReturnValue({ width: 1920, height: 1440 } as DOMRect);
 
       const downloadButton = screen.getByLabelText('download');
       fireEvent.click(downloadButton);
 
       // Wait for async operations
       await waitFor(() => {
-        expect(mockQuerySelector).toHaveBeenCalledWith('svg');
-        expect(mockSerializeToString).toHaveBeenCalledWith(mockSvgElement);
-        expect(mockCanvas.width).toBe(400); // 200 * 2 (dpr)
-        expect(mockCanvas.height).toBe(300); // 150 * 2 (dpr)
+        expect(mockSerializeToString).toHaveBeenCalled();
+        const serializedSvg = mockSerializeToString.mock.calls[0][0] as SVGSVGElement;
+        expect(serializedSvg).not.toBe(svgElement);
+        expect(serializedSvg.style.transform).toBe('');
+        expect(serializedSvg.getAttribute('width')).toBe('640');
+        expect(serializedSvg.getAttribute('height')).toBe('480');
+        expect(getBoundingClientRectSpy).not.toHaveBeenCalled();
+        expect(mockCanvas.width).toBe(1280); // 640 * 2 (dpr)
+        expect(mockCanvas.height).toBe(960); // 480 * 2 (dpr)
         // @ts-ignore
-        expect(mockCanvas.style.width).toBe('200px');
+        expect(mockCanvas.style.width).toBe('640px');
         // @ts-ignore
-        expect(mockCanvas.style.height).toBe('150px');
+        expect(mockCanvas.style.height).toBe('480px');
 
         // Simulate image load
         if (mockImage.onload) {
@@ -785,7 +799,7 @@ describe('Mermaid Component', () => {
           mockImage.onload();
         }
 
-        expect(mockDrawImage).toHaveBeenCalledWith(mockImage, 0, 0, 200, 150);
+        expect(mockDrawImage).toHaveBeenCalledWith(mockImage, 0, 0, 640, 480);
         expect(mockToDataURL).toHaveBeenCalledWith('image/png', 1);
       });
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #1875

### 💡 Background and Solution

Large Mermaid diagrams had two related problems: zooming stopped at 3×, and PNG export measured the transformed DOM rectangle, so the downloaded result changed with the current zoom/drag state and could be clipped or low-resolution.

- Remove the 3× upper bound from wheel and button zoom while preserving the 0.5× minimum.
- Clone the rendered SVG for export and strip interactive transform/transition styles.
- Size the PNG from the SVG viewBox or intrinsic dimensions; only fall back to an unscaled DOM rectangle when neither is available.
- Add regression coverage for zooming beyond 3× and exporting a transformed SVG at its full intrinsic size.

### 🎥 Before / After

**Before** — zoom is capped at 3.0× and export dimensions change with the current zoom state.

https://github.com/user-attachments/assets/c7d9578b-b88b-46e4-a4cf-3b30c7e66dfa

**After** — zoom reaches 3.6× and the complete export keeps the same intrinsic dimensions.

https://github.com/user-attachments/assets/139d79d0-6703-4dfe-87b2-e8bea723a8fd

Observed in Chromium with the same 15-node diagram:

- Before: zoom stopped at 3.0×; export changed from 1028×25 to 3084×75.
- After: zoom reached 3.6×; export remained a complete 2845×70 PNG before and after zooming.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Mermaid diagrams can zoom beyond 3× and download as complete, zoom-independent PNGs. |
| 🇨🇳 Chinese | Mermaid 流程图支持超过 3 倍缩放，并可下载不受当前缩放状态影响的完整 PNG。 |

### ✅ Verification

- Mermaid Jest suite: 70/70 passed
- TypeScript: `tsc --noEmit -p packages/x/tsconfig.json`
- Biome: changed files passed
- Real Chromium: zoom, export dimensions, and downloaded PNG contents verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Mermaid 图表支持持续放大，滚轮和放大按钮不再受原有缩放上限限制。
  * 下载 PNG 时将根据图表原始尺寸生成图片，并适配设备像素比，提升清晰度。
* **问题修复**
  * 修复图表放大或平移后下载 PNG 可能出现尺寸异常、变换偏移的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->