### PR TITLE
fix(conversations): avoid rerendering all items on selection

### DIFF
--- a/packages/x/components/conversations/Item.tsx
+++ b/packages/x/components/conversations/Item.tsx
@@ -9,20 +9,26 @@ import type { DirectionType } from '../_util/type';
 import type { ConversationsProps } from '.';
 import type { ConversationItemType } from './interface';
 
+export type ConversationsItemMenu = MenuProps & {
+  trigger?:
+    | React.ReactNode
+    | ((
+        conversation: ConversationItemType,
+        info: { originNode: React.ReactNode },
+      ) => React.ReactNode);
+  getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
+};
+
 export interface ConversationsItemProps
   extends Omit<React.HTMLAttributes<HTMLLIElement>, 'onClick'> {
   info: ConversationItemType;
   prefixCls?: string;
   direction?: DirectionType;
-  menu?: MenuProps & {
-    trigger?:
-      | React.ReactNode
-      | ((
-          conversation: ConversationItemType,
-          info: { originNode: React.ReactNode },
-        ) => React.ReactNode);
-    getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
-  };
+  menu?:
+    | ConversationsItemMenu
+    | ((value: ConversationItemType) => ConversationsItemMenu | undefined);
+  componentStyle?: React.CSSProperties;
+  semanticStyle?: React.CSSProperties;
   active?: boolean;
   onClick?: ConversationsProps['onActiveChange'];
 }
@@ -32,7 +38,19 @@ const stopPropagation: React.MouseEventHandler<HTMLSpanElement> = (e) => {
 };
 
 const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
-  const { prefixCls, info, className, direction, onClick, active, menu, ...restProps } = props;
+  const {
+    prefixCls,
+    info,
+    className,
+    style,
+    componentStyle,
+    semanticStyle,
+    direction,
+    onClick,
+    active,
+    menu,
+    ...restProps
+  } = props;
   const isMobile = useMobile();
 
   const domProps = pickAttrs(restProps, {
@@ -61,7 +79,8 @@ const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
 
   // ============================ Menu ============================
 
-  const { trigger, ...dropdownMenu } = menu || {};
+  const mergedMenu = typeof menu === 'function' ? menu(info) : menu;
+  const { trigger, ...dropdownMenu } = mergedMenu || {};
 
   const getPopupContainer = dropdownMenu?.getPopupContainer;
 
@@ -88,11 +107,12 @@ const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
       title={typeof info.label === 'object' ? undefined : `${info.label}`}
       {...domProps}
       className={mergedCls}
+      style={{ ...componentStyle, ...semanticStyle, ...style }}
       onClick={onInternalClick}
     >
       {info.icon && <div className={`${prefixCls}-icon`}>{info.icon}</div>}
       <Typography.Text className={`${prefixCls}-label`}>{info.label}</Typography.Text>
-      {!disabled && menu && (
+      {!disabled && mergedMenu && (
         <div onClick={stopPropagation}>
           <Dropdown
             menu={dropdownMenu}
@@ -109,4 +129,4 @@ const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
   );
 };
 
-export default ConversationsItem;
+export default React.memo(ConversationsItem);

--- a/packages/x/components/conversations/__tests__/index.test.tsx
+++ b/packages/x/components/conversations/__tests__/index.test.tsx
@@ -158,6 +158,29 @@ describe('Conversations Component', () => {
     const element = container.querySelector('.ant-dropdown-open');
     expect(element).not.toBeInTheDocument();
   });
+
+  it('should only recompute affected items when active selection changes', () => {
+    const largeItems = Array.from({ length: 500 }, (_, index) => ({
+      key: `item-${index}`,
+      label: `Conversation ${index}`,
+    }));
+    const itemMenu = jest.fn(() => undefined);
+    const { getByText } = render(
+      <Conversations items={largeItems} menu={itemMenu} defaultActiveKey="item-0" />,
+    );
+
+    const initialMenuCalls = itemMenu.mock.calls.length;
+    expect(initialMenuCalls).toBeGreaterThanOrEqual(500);
+    fireEvent.click(getByText('Conversation 499'));
+
+    // React's development renderer may invoke each affected item more than once,
+    // but the work must stay constant instead of growing with all 500 items.
+    expect(itemMenu.mock.calls.length - initialMenuCalls).toBeLessThanOrEqual(8);
+    expect(getByText('Conversation 499').parentElement).toHaveClass(
+      'ant-conversations-item-active',
+    );
+  });
+
   describe('should handle menu trigger function', () => {
     it('render node', async () => {
       const { findAllByText, container } = render(

--- a/packages/x/components/conversations/index.tsx
+++ b/packages/x/components/conversations/index.tsx
@@ -1,4 +1,4 @@
-import { useControlledState } from '@rc-component/util';
+import { useControlledState, useEvent } from '@rc-component/util';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import { Divider } from 'antd';
 import { clsx } from 'clsx';
@@ -13,7 +13,7 @@ import type { CreationProps } from './Creation';
 import Creation from './Creation';
 import GroupTitle, { GroupTitleContext } from './GroupTitle';
 import useGroupable from './hooks/useGroupable';
-import ConversationsItem, { type ConversationsItemProps } from './Item';
+import ConversationsItem, { type ConversationsItemMenu, type ConversationsItemProps } from './Item';
 import type { ConversationItemType, DividerItemType, GroupableProps, ItemType } from './interface';
 import useStyle from './style';
 
@@ -52,8 +52,8 @@ export interface ConversationsProps extends React.HTMLAttributes<HTMLUListElemen
    * @descEN Operation menu for conversations
    */
   menu?:
-    | ConversationsItemProps['menu']
-    | ((value: ConversationItemType) => ConversationsItemProps['menu']);
+    | ConversationsItemMenu
+    | ((value: ConversationItemType) => ConversationsItemMenu | undefined);
 
   /**
    * @desc 是否支持分组, 开启后默认按 {@link Conversation.group} 字段分组
@@ -117,8 +117,8 @@ const ForwardConversations = React.forwardRef<ConversationsRef, ConversationsPro
       defaultActiveKey,
       onActiveChange,
       menu,
-      styles = {},
-      classNames = {},
+      styles,
+      classNames,
       groupable,
       className,
       style,
@@ -166,7 +166,7 @@ const ForwardConversations = React.forwardRef<ConversationsRef, ConversationsPro
       contextConfig.className,
       contextConfig.classNames.root,
       className,
-      classNames.root,
+      classNames?.root,
       rootClassName,
       hashId,
       cssVarCls,
@@ -176,13 +176,13 @@ const ForwardConversations = React.forwardRef<ConversationsRef, ConversationsPro
     );
 
     // ============================ Events ============================
-    const onConversationItemClick: ConversationsItemProps['onClick'] = (key) => {
+    const onConversationItemClick: ConversationsItemProps['onClick'] = useEvent((key) => {
       setMergedActiveKey(key);
       onActiveChange?.(
         key,
         items?.find((item) => item.key === key),
       );
-    };
+    });
 
     // ============================ Short Key =========================
     const [_, shortcutKeysInfo, subscribe] = useShortcutKeys(
@@ -228,7 +228,14 @@ const ForwardConversations = React.forwardRef<ConversationsRef, ConversationsPro
           );
         }
         const baseConversationInfo = conversationInfo as ConversationItemType;
-        const { label: _, disabled: __, icon: ___, ...restInfo } = baseConversationInfo;
+        const {
+          label: _,
+          disabled: __,
+          icon: ___,
+          className: itemClassName,
+          style: itemStyle,
+          ...restInfo
+        } = baseConversationInfo;
         return (
           <ConversationsItem
             {...restInfo}
@@ -236,17 +243,11 @@ const ForwardConversations = React.forwardRef<ConversationsRef, ConversationsPro
             info={baseConversationInfo}
             prefixCls={prefixCls}
             direction={direction}
-            className={clsx(
-              classNames.item,
-              contextConfig.classNames.item,
-              baseConversationInfo.className,
-            )}
-            style={{
-              ...contextConfig.styles.item,
-              ...styles.item,
-              ...baseConversationInfo.style,
-            }}
-            menu={typeof menu === 'function' ? menu(baseConversationInfo) : menu}
+            className={clsx(classNames?.item, contextConfig.classNames.item, itemClassName)}
+            style={itemStyle}
+            componentStyle={contextConfig.styles.item}
+            semanticStyle={styles?.item}
+            menu={menu}
             active={mergedActiveKey === baseConversationInfo.key}
             onClick={onConversationItemClick}
           />
@@ -269,17 +270,17 @@ const ForwardConversations = React.forwardRef<ConversationsRef, ConversationsPro
           ...contextConfig.style,
           ...style,
           ...contextConfig.styles.root,
-          ...styles.root,
+          ...styles?.root,
         }}
         className={mergedCls}
         ref={containerRef}
       >
         {!!creation && (
           <Creation
-            className={clsx(contextConfig.classNames.creation, classNames.creation)}
+            className={clsx(contextConfig.classNames.creation, classNames?.creation)}
             style={{
               ...contextConfig.styles.creation,
-              ...styles.creation,
+              ...styles?.creation,
             }}
             shortcutKeyInfo={shortcutKeysInfo?.creation}
             prefixCls={`${prefixCls}-creation`}
@@ -300,12 +301,12 @@ const ForwardConversations = React.forwardRef<ConversationsRef, ConversationsPro
                 collapseMotion,
               }}
             >
-              <GroupTitle className={clsx(contextConfig.classNames.group, classNames.group)}>
+              <GroupTitle className={clsx(contextConfig.classNames.group, classNames?.group)}>
                 <ul
                   className={clsx(`${prefixCls}-list`, {
                     [`${prefixCls}-group-collapsible-list`]: groupInfo.collapsible,
                   })}
-                  style={{ ...contextConfig.styles.group, ...styles.group }}
+                  style={{ ...contextConfig.styles.group, ...styles?.group }}
                 >
                   {itemNode}
                 </ul>
@@ -326,6 +327,7 @@ if (process.env.NODE_ENV !== 'production') {
   Conversations.displayName = 'Conversations';
 }
 
-export type { ItemType, ConversationItemType, DividerItemType };
+export type { ConversationItemType, DividerItemType, ItemType };
+
 Conversations.Creation = Creation;
 export default Conversations;

--- a/packages/x/components/suggestion/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/x/components/suggestion/__tests__/__snapshots__/demo.test.ts.snap
@@ -185,7 +185,6 @@ exports[`renders components/suggestion/demo/trigger.tsx correctly 1`] = `
       >
         <div
           class="ant-select-placeholder"
-          style="visibility:visible"
         >
           可任意输入 / 与 # 多次获取建议
         </div>


### PR DESCRIPTION
Fixes #1871

## Background

Changing the active conversation caused every item in a large list to rerender. The parent recomputed merged styles, resolved the menu callback for every row, and passed a new click callback on each selection change. With 500 items, a single click performed work proportional to the full list.

## Changes

- Memoize individual conversation items so unchanged rows can skip selection updates.
- Keep the item click callback stable with `useEvent`.
- Move menu resolution and style merging into the item while preserving the existing style precedence.
- Add a 500-item regression test that asserts selection work remains constant instead of scaling with the list size.

## Performance evidence

Measured in the same React development build and browser session:

- Before: 1,000 item computations per selection; 79–104 ms click-to-paint.
- After: 3–4 item computations per selection; 21–44 ms click-to-paint.

The timing is environment-dependent; the item-computation reduction is deterministic. React development mode invokes render work more than once, which is why two affected rows can report 3–4 computations.

## Recordings

**Before — 1,000 item computations**

[![Before: selection recomputes all 500 items](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-1871/issue-1871/before.gif)](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-1871/issue-1871/before.mp4)

[Open the original MP4](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-1871/issue-1871/before.mp4)

**After — 3–4 item computations**

[![After: selection only recomputes affected items](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-1871/issue-1871/after.gif)](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-1871/issue-1871/after.mp4)

[Open the original MP4](https://raw.githubusercontent.com/advance-hub/x/codex/pr-evidence-1871/issue-1871/after.mp4)

## Verification

- `NODE_OPTIONS=--max-old-space-size=768 ../../node_modules/.bin/jest --config .jest.js components/conversations/__tests__/index.test.tsx --runInBand --no-cache` (24 tests, 2 snapshots)
- `NODE_OPTIONS=--max-old-space-size=1024 ./node_modules/.bin/tsc --noEmit -p packages/x/tsconfig.json`
- `./node_modules/.bin/biome check packages/x/components/conversations/index.tsx packages/x/components/conversations/Item.tsx packages/x/components/conversations/__tests__/index.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 会话菜单支持根据当前会话动态生成。
  - 会话列表项新增组件样式和语义样式配置能力。
  - 新增可复用的会话菜单类型定义。

- **性能优化**
  - 优化会话列表更新机制，切换活动会话时减少不必要的菜单重新计算，提升大规模列表的响应性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->