### PR TITLE
fix(x-markdown): fix CJK bold `**…**` not rendering when adjacent to …

### DIFF
--- a/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
@@ -335,6 +335,25 @@ describe('Parser', () => {
       expect(result).toContain('中间有哨兵');
     });
 
+    // Regression: a pre-existing placeholder-shaped sequence in the source must
+    // not collide with generated placeholders (which start at counter 0).
+    it('does not collide with a pre-existing placeholder-shaped sequence', () => {
+      const parser = new Parser();
+      // \uE000X_MD_EB_0\uE001 is the exact shape of the first generated key.
+      const input = '\uE000X_MD_EB_0\uE001\uE002';
+      const result = parser.parse(input);
+      expect(result).toContain('\uE000X_MD_EB_0\uE001');
+      expect(result).toContain('\uE002');
+    });
+
+    it('does not collide when multiple U+E002 are protected', () => {
+      const parser = new Parser();
+      const input = 'a\uE000X_MD_EB_0\uE001b\uE002c\uE002d';
+      const result = parser.parse(input);
+      expect(result).toContain('a\uE000X_MD_EB_0\uE001b');
+      expect(result).toContain('c\uE002d');
+    });
+
     // Regression: triple-emphasis delimiters (*** / ___) must not be split —
     // relaxEmphasis should not insert a sentinel inside them.
     it('does not insert boundary inside triple *** delimiter', () => {

--- a/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
@@ -232,4 +232,95 @@ describe('Parser', () => {
       expect(escapeHtml('test<script>', undefined)).toBe('test&lt;script&gt;');
     });
   });
+
+  // Regression for CJK-friendly strong emphasis (#2038). marked's CommonMark
+  // flanking rule keeps `**` literal when next to punctuation, which breaks
+  // common Chinese/Japanese output like 写作**"加粗"**表示.
+  describe('CJK-friendly strong emphasis', () => {
+    it('renders bold when ** is immediately followed by ASCII double quotes', () => {
+      const parser = new Parser();
+      const result = parser.parse('写作**"加粗"**表示');
+      expect(result).toContain('<strong>&quot;加粗&quot;</strong>');
+      expect(result).not.toContain('**');
+    });
+
+    it('renders bold when ** is immediately followed by fullwidth double quotes', () => {
+      const parser = new Parser();
+      const result = parser.parse('写作**“加粗”**表示');
+      expect(result).toContain('<strong>“加粗”</strong>');
+      expect(result).not.toContain('**');
+    });
+
+    it('renders bold when ** is immediately followed by fullwidth single quotes', () => {
+      const parser = new Parser();
+      const result = parser.parse('写作**‘加粗’**表示');
+      expect(result).toContain('<strong>‘加粗’</strong>');
+    });
+
+    it('renders bold when ** wraps a fullwidth-parenthesized term', () => {
+      const parser = new Parser();
+      const result = parser.parse('写作**（加粗）**表示');
+      expect(result).toContain('<strong>（加粗）</strong>');
+    });
+
+    it('renders bold when ** wraps an ASCII-parenthesized term', () => {
+      const parser = new Parser();
+      const result = parser.parse('写作**(加粗)**表示');
+      expect(result).toContain('<strong>(加粗)</strong>');
+    });
+
+    it('renders bold for Japanese and Korean adjacent to quotes', () => {
+      const parser = new Parser();
+      expect(parser.parse('これは**“太字”**です')).toContain('<strong>“太字”</strong>');
+      expect(parser.parse('이것은**“굵게”**입니다')).toContain('<strong>“굵게”</strong>');
+    });
+
+    it('keeps plain CJK bold working (no regression)', () => {
+      const parser = new Parser();
+      expect(parser.parse('这是**加粗**测试')).toContain('<strong>加粗</strong>');
+    });
+
+    it('keeps plain ASCII bold and intraword bold working (no regression)', () => {
+      const parser = new Parser();
+      expect(parser.parse('plain **bold** text')).toContain('<strong>bold</strong>');
+      expect(parser.parse('foo**bar**baz')).toContain('<strong>bar</strong>');
+    });
+
+    it('keeps nested em inside strong working (no regression)', () => {
+      const parser = new Parser();
+      expect(parser.parse('**bold *italic* inside**')).toContain('<strong>bold <em>italic</em> inside</strong>');
+    });
+
+    it('does not leak the boundary sentinel into the output', () => {
+      const parser = new Parser();
+      const result = parser.parse('写作**“加粗”**表示');
+      // PUA sentinel used internally must be stripped before returning.
+      expect(result).not.toMatch(/\uE000|\uE001|\uE002/);
+    });
+
+    it('keeps ** literal inside fenced code (no regression)', () => {
+      const parser = new Parser();
+      const result = parser.parse('```\n**not bold**\n```');
+      expect(result).not.toContain('<strong>');
+      expect(result).toContain('**not bold**');
+    });
+
+    it('keeps ** literal inside inline code (no regression)', () => {
+      const parser = new Parser();
+      const result = parser.parse('`src/**/*.ts`');
+      expect(result).not.toContain('<strong>');
+      expect(result).toContain('src/**/*.ts');
+    });
+
+    it('produces balanced <strong> across all streaming prefixes', () => {
+      const parser = new Parser();
+      const sentence = '写作**“加粗”**表示。';
+      for (let i = 1; i <= sentence.length; i++) {
+        const result = parser.parse(sentence.slice(0, i));
+        const open = (result.match(/<strong>/g) || []).length;
+        const close = (result.match(/<\/strong>/g) || []).length;
+        expect(open).toBe(close);
+      }
+    });
+  });
 });

--- a/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/Parser.test.ts
@@ -240,7 +240,7 @@ describe('Parser', () => {
     it('renders bold when ** is immediately followed by ASCII double quotes', () => {
       const parser = new Parser();
       const result = parser.parse('写作**"加粗"**表示');
-      expect(result).toContain('<strong>&quot;加粗&quot;</strong>');
+      expect(result).toContain('<strong>"加粗"</strong>');
       expect(result).not.toContain('**');
     });
 
@@ -321,6 +321,40 @@ describe('Parser', () => {
         const close = (result.match(/<\/strong>/g) || []).length;
         expect(open).toBe(close);
       }
+    });
+
+    // Regression: user-supplied U+E002 in input must survive parsing — only
+    // sentinels inserted by relaxEmphasis should be stripped.
+    it('preserves user-supplied U+E002 characters in the output', () => {
+      const parser = new Parser();
+      const input = '普通文字\uE002中间有哨兵';
+      const result = parser.parse(input);
+      expect(result).toContain('\uE002');
+      // Content other than the sentinel must not be lost either.
+      expect(result).toContain('普通文字');
+      expect(result).toContain('中间有哨兵');
+    });
+
+    // Regression: triple-emphasis delimiters (*** / ___) must not be split —
+    // relaxEmphasis should not insert a sentinel inside them.
+    it('does not insert boundary inside triple *** delimiter', () => {
+      const parser = new Parser();
+      const result = parser.parse('***"加粗"***');
+      // marked should produce bold+italic, same as without preprocessing.
+      expect(result).toContain('<strong>');
+      expect(result).toContain('<em>');
+    });
+
+    it('does not insert boundary inside triple ___ delimiter', () => {
+      const parser = new Parser();
+      const result = parser.parse('___"加粗"___');
+      expect(result).toContain('<strong>');
+      expect(result).toContain('<em>');
+    });
+
+    it('keeps plain triple emphasis working (no regression)', () => {
+      const parser = new Parser();
+      expect(parser.parse('***bold***')).toContain('<em><strong>bold</strong></em>');
     });
   });
 });

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -428,8 +428,17 @@ class Parser {
     }
     const placeholders = new Map<string, string>();
     let counter = 0;
+    const nextPlaceholder = () => {
+      // Skip keys that already exist in the source, otherwise a pre-existing
+      // placeholder-shaped sequence would collide and get rewritten on restore.
+      let placeholder = `${EMPH_USER_PLACEHOLDER_PREFIX}${counter++}${EMPH_USER_PLACEHOLDER_SUFFIX}`;
+      while (content.includes(placeholder)) {
+        placeholder = `${EMPH_USER_PLACEHOLDER_PREFIX}${counter++}${EMPH_USER_PLACEHOLDER_SUFFIX}`;
+      }
+      return placeholder;
+    };
     const protectedContent = content.replace(EMPH_BOUNDARY_REGEX, (match) => {
-      const placeholder = `${EMPH_USER_PLACEHOLDER_PREFIX}${counter++}${EMPH_USER_PLACEHOLDER_SUFFIX}`;
+      const placeholder = nextPlaceholder();
       placeholders.set(placeholder, match);
       return placeholder;
     });

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -59,6 +59,11 @@ const PLACEHOLDER_PREFIX = '\uE000X_MD_NL_';
 const PLACEHOLDER_SUFFIX = '\uE001';
 const PLACEHOLDER_REGEX = /\uE000X_MD_NL_\d+\uE001/g;
 
+// PUA sentinel between `**`/`__` and adjacent punctuation — relaxes marked's
+// strict CommonMark flanking rule for CJK bold. Stripped from the final HTML.
+const EMPH_BOUNDARY = '\uE002';
+const EMPH_BOUNDARY_REGEX = /\uE002/g;
+
 // Type for tokens that can be marked for tail injection
 type MarkableToken = Token & { [TAIL_MARKER]?: boolean };
 
@@ -300,6 +305,32 @@ class Parser {
   }
 
   /**
+   * Relax CommonMark's strong-emphasis flanking rule around punctuation so that
+   * CJK bold patterns like `写作**"加粗"**表示` render as `<strong>` instead of
+   * staying literal (mirrors what `remark-cjk-friendly` does for remark).
+   *
+   * Scope: fully fixes `**`. Fixes `__` when not directly inside a word run
+   * (marked's intraword rule for `_` cannot be bypassed by boundary insertion,
+   * so `写作__"加粗"__表示` stays literal — same behavior as before the fix,
+   * no regression; prefer `**` for CJK bold).
+   */
+  private relaxEmphasis(content: string): string {
+    // Match marked's own `((?!\*)punct)` exclusion — don't split `***` / `___`.
+    const punct = '(?:(?![*_])[\\p{P}\\p{S}])';
+    const delim = '(\\*\\*|__)';
+
+    let out = content.replace(
+      new RegExp(`${delim}(?=${punct})`, 'gu'),
+      `$1${EMPH_BOUNDARY}`,
+    );
+    out = out.replace(
+      new RegExp(`(${punct})${delim}`, 'gu'),
+      `$1${EMPH_BOUNDARY}$2`,
+    );
+    return out;
+  }
+
+  /**
    * Find the last non-empty token in the token tree (reverse search)
    */
   private findLastNonEmptyToken(tokens: Token[]): Token | null {
@@ -354,20 +385,30 @@ class Parser {
   }
 
   public parse(content: string, parseOptions?: ParseOptions) {
-    // Set tail injection flag
     this.injectTail = parseOptions?.injectTail ?? false;
 
-    // Protect custom tags if needed
+    // Relax strong-emphasis flanking around punctuation (CJK-friendly bold).
+    // Runs before custom-tag protection so inline markdown inside custom tags
+    // also benefits; sentinel is stripped after parse.
+    const relaxed = this.relaxEmphasis(content);
+
     if (this.options.protectCustomTagNewlines || this.options.disableCustomTagBlockMarkdown) {
       const { protected: protectedContent, placeholders } = this.protectCustomTags(
-        content,
+        relaxed,
         !!this.options.disableCustomTagBlockMarkdown,
       );
       const parsed = this.markdownInstance.parse(protectedContent) as string;
-      return this.restorePlaceholders(parsed, placeholders);
+      return this.stripEmphasisBoundary(this.restorePlaceholders(parsed, placeholders));
     }
 
-    return this.markdownInstance.parse(content) as string;
+    return this.stripEmphasisBoundary(this.markdownInstance.parse(relaxed) as string);
+  }
+
+  private stripEmphasisBoundary(html: string): string {
+    if (!html.includes(EMPH_BOUNDARY)) {
+      return html;
+    }
+    return html.replace(EMPH_BOUNDARY_REGEX, '');
   }
 }
 

--- a/packages/x-markdown/src/XMarkdown/core/Parser.ts
+++ b/packages/x-markdown/src/XMarkdown/core/Parser.ts
@@ -63,6 +63,11 @@ const PLACEHOLDER_REGEX = /\uE000X_MD_NL_\d+\uE001/g;
 // strict CommonMark flanking rule for CJK bold. Stripped from the final HTML.
 const EMPH_BOUNDARY = '\uE002';
 const EMPH_BOUNDARY_REGEX = /\uE002/g;
+// Placeholder to protect user-supplied U+E002 before preprocessing so that
+// stripEmphasisBoundary only removes sentinels we inserted, never user content.
+const EMPH_USER_PLACEHOLDER_PREFIX = '\uE000X_MD_EB_';
+const EMPH_USER_PLACEHOLDER_SUFFIX = '\uE001';
+const EMPH_USER_PLACEHOLDER_REGEX = /\uE000X_MD_EB_\d+\uE001/g;
 
 // Type for tokens that can be marked for tail injection
 type MarkableToken = Token & { [TAIL_MARKER]?: boolean };
@@ -316,15 +321,19 @@ class Parser {
    */
   private relaxEmphasis(content: string): string {
     // Match marked's own `((?!\*)punct)` exclusion — don't split `***` / `___`.
+    // Negative lookbehind/lookahead prevent matching `**` inside `***` or `__`
+    // inside `___`, which would corrupt triple-emphasis delimiters.
+    const notDelim = '(?<![*_])';
+    const notDelimAfter = '(?![*_])';
     const punct = '(?:(?![*_])[\\p{P}\\p{S}])';
-    const delim = '(\\*\\*|__)';
+    const delim = `(\\*\\*|__)`;
 
     let out = content.replace(
-      new RegExp(`${delim}(?=${punct})`, 'gu'),
+      new RegExp(`${notDelim}${delim}(?=${punct})`, 'gu'),
       `$1${EMPH_BOUNDARY}`,
     );
     out = out.replace(
-      new RegExp(`(${punct})${delim}`, 'gu'),
+      new RegExp(`(${punct})${delim}${notDelimAfter}`, 'gu'),
       `$1${EMPH_BOUNDARY}$2`,
     );
     return out;
@@ -387,21 +396,51 @@ class Parser {
   public parse(content: string, parseOptions?: ParseOptions) {
     this.injectTail = parseOptions?.injectTail ?? false;
 
+    // Protect any user-supplied U+E002 before inserting our own sentinels,
+    // so stripEmphasisBoundary never removes user content.
+    const { protected: protectedInput, placeholders } = this.protectEmphasisBoundary(content);
     // Relax strong-emphasis flanking around punctuation (CJK-friendly bold).
     // Runs before custom-tag protection so inline markdown inside custom tags
     // also benefits; sentinel is stripped after parse.
-    const relaxed = this.relaxEmphasis(content);
+    const relaxed = this.relaxEmphasis(protectedInput);
 
     if (this.options.protectCustomTagNewlines || this.options.disableCustomTagBlockMarkdown) {
-      const { protected: protectedContent, placeholders } = this.protectCustomTags(
+      const { protected: protectedContent, placeholders: tagPlaceholders } = this.protectCustomTags(
         relaxed,
         !!this.options.disableCustomTagBlockMarkdown,
       );
       const parsed = this.markdownInstance.parse(protectedContent) as string;
-      return this.stripEmphasisBoundary(this.restorePlaceholders(parsed, placeholders));
+      return this.restoreEmphasisBoundary(
+        this.stripEmphasisBoundary(this.restorePlaceholders(parsed, tagPlaceholders)),
+        placeholders,
+      );
     }
 
-    return this.stripEmphasisBoundary(this.markdownInstance.parse(relaxed) as string);
+    return this.restoreEmphasisBoundary(
+      this.stripEmphasisBoundary(this.markdownInstance.parse(relaxed) as string),
+      placeholders,
+    );
+  }
+
+  private protectEmphasisBoundary(content: string): { protected: string; placeholders: Map<string, string> } {
+    if (!content.includes(EMPH_BOUNDARY)) {
+      return { protected: content, placeholders: new Map() };
+    }
+    const placeholders = new Map<string, string>();
+    let counter = 0;
+    const protectedContent = content.replace(EMPH_BOUNDARY_REGEX, (match) => {
+      const placeholder = `${EMPH_USER_PLACEHOLDER_PREFIX}${counter++}${EMPH_USER_PLACEHOLDER_SUFFIX}`;
+      placeholders.set(placeholder, match);
+      return placeholder;
+    });
+    return { protected: protectedContent, placeholders };
+  }
+
+  private restoreEmphasisBoundary(html: string, placeholders: Map<string, string>): string {
+    if (placeholders.size === 0) {
+      return html;
+    }
+    return html.replace(EMPH_USER_PLACEHOLDER_REGEX, (match) => placeholders.get(match) ?? match);
   }
 
   private stripEmphasisBoundary(html: string): string {


### PR DESCRIPTION
closes #2038

marked 严格遵循 CommonMark flanking 规则，当 `**` / `__` 紧邻标点（引号、括号等）时保持字面渲染，导致中文/日文/韩文环境下大量常见输出无法加粗：如  写作**"加粗"**表示

## 🔧 实现 / Implementation

在 [`Parser.relaxEmphasis`](./packages/x-markdown/src/XMarkdown/core/Parser.ts) 中预处理：
1. **开侧**：`**`/`__` 紧邻标点 → 分隔符后插入 PUA 哨兵 `\uE002`
2. **闭侧**：标点紧邻 `**`/`__` → 标点与分隔符之间插入同一哨兵
3. `marked` 解析时把哨兵当作"非标点、非空白"处理，flanking 判定通过 → 正常生成 `<strong>`
4. 解析后调用 `stripEmphasisBoundary` 统一剥离所有哨兵



### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://x.ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix CJK bold `**…**` not rendering when adjacent to punctuation      |
| 🇨🇳 Chinese |      修复 CJK 下 **加粗** 紧邻标点无法正确渲染的问题      |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 改进中文、日文和韩文文本中的粗体强调解析，支持与中英文标点、全角引号及括号相邻的场景。
  * 优化普通粗体、嵌套强调、围栏代码、行内代码及流式内容的解析。
  * 优化三重强调分隔符处理，避免粗体或斜体标记被错误拆分。
  * 保留用户输入中的特殊字符，并避免与解析标记冲突导致内容被错误替换。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->