### PR TITLE
fix(Folder): align switcher hover background

### DIFF
--- a/packages/x/components/folder/style/index.tsx
+++ b/packages/x/components/folder/style/index.tsx
@@ -38,6 +38,8 @@ const genFolderStyle: GenerateStyle<FolderToken> = (token) => {
         '&:before': {
           width: '10px',
           height: '10px',
+          top: '50%',
+          transform: 'translateY(-50%)',
         },
       },
       [`${antCls}-tree-node-content-wrapper`]: {


### PR DESCRIPTION
### 修复内容

- 将 Folder 展开按钮的 hover 背景在 switcher 容器内垂直居中
- 修复 hover 背景与展开图标位置不一致的问题

### 验证

- `antd doctor --format json`
- `antd lint packages/x/components/folder/style/index.tsx --format json`
- `npm run lint:style --workspace packages/x`
- `npm run tsc --workspace packages/x`
- Folder 相关单测（134 项）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 调整文件夹树切换图标的垂直对齐方式，使其在切换器中居中显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->