### PR TITLE
test: update snapshots for latest Ant Design

### DIFF
--- a/packages/x/components/actions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/packages/x/components/actions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -825,7 +825,7 @@ exports[`renders components/actions/demo/sub.tsx extend context correctly 1`] = 
         <li
           aria-describedby="test-id"
           class="ant-dropdown-menu-item"
-          data-menu-id="rc-menu-uuid-share"
+          data-menu-id="rc-menu-uuid-test-id-share"
           role="menuitem"
           tabindex="-1"
         >
@@ -875,7 +875,7 @@ exports[`renders components/actions/demo/sub.tsx extend context correctly 1`] = 
         <li
           aria-describedby="test-id"
           class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-          data-menu-id="rc-menu-uuid-import"
+          data-menu-id="rc-menu-uuid-test-id-import"
           role="menuitem"
           tabindex="-1"
         >
@@ -906,7 +906,7 @@ exports[`renders components/actions/demo/sub.tsx extend context correctly 1`] = 
         <li
           aria-describedby="test-id"
           class="ant-dropdown-menu-item ant-dropdown-menu-item-danger"
-          data-menu-id="rc-menu-uuid-delete"
+          data-menu-id="rc-menu-uuid-test-id-delete"
           role="menuitem"
           tabindex="-1"
         >

--- a/packages/x/components/attachments/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/packages/x/components/attachments/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2680,7 +2680,7 @@ exports[`renders components/attachments/demo/select-files.tsx extend context cor
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                  data-menu-id="rc-menu-uuid-image"
+                  data-menu-id="rc-menu-uuid-test-id-image"
                   role="menuitem"
                   tabindex="-1"
                 >
@@ -2736,7 +2736,7 @@ exports[`renders components/attachments/demo/select-files.tsx extend context cor
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                  data-menu-id="rc-menu-uuid-docs"
+                  data-menu-id="rc-menu-uuid-test-id-docs"
                   role="menuitem"
                   tabindex="-1"
                 >

--- a/packages/x/components/conversations/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/packages/x/components/conversations/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1081,7 +1081,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Rename"
+            data-menu-id="rc-menu-uuid-test-id-Rename"
             role="menuitem"
             tabindex="-1"
           >
@@ -1131,7 +1131,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Share"
+            data-menu-id="rc-menu-uuid-test-id-Share"
             role="menuitem"
             tabindex="-1"
           >
@@ -1186,7 +1186,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
             aria-describedby="test-id"
             aria-disabled="true"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-disabled"
-            data-menu-id="rc-menu-uuid-Archive"
+            data-menu-id="rc-menu-uuid-test-id-Archive"
             role="menuitem"
           >
             <span
@@ -1235,7 +1235,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-danger"
-            data-menu-id="rc-menu-uuid-deleteChat"
+            data-menu-id="rc-menu-uuid-test-id-deleteChat"
             role="menuitem"
             tabindex="-1"
           >
@@ -1383,7 +1383,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Rename"
+            data-menu-id="rc-menu-uuid-test-id-Rename"
             role="menuitem"
             tabindex="-1"
           >
@@ -1433,7 +1433,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Share"
+            data-menu-id="rc-menu-uuid-test-id-Share"
             role="menuitem"
             tabindex="-1"
           >
@@ -1488,7 +1488,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
             aria-describedby="test-id"
             aria-disabled="true"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-disabled"
-            data-menu-id="rc-menu-uuid-Archive"
+            data-menu-id="rc-menu-uuid-test-id-Archive"
             role="menuitem"
           >
             <span
@@ -1537,7 +1537,7 @@ exports[`renders components/conversations/demo/menu-trigger.tsx extend context c
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-danger"
-            data-menu-id="rc-menu-uuid-deleteChat"
+            data-menu-id="rc-menu-uuid-test-id-deleteChat"
             role="menuitem"
             tabindex="-1"
           >
@@ -2183,7 +2183,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Rename"
+            data-menu-id="rc-menu-uuid-test-id-Rename"
             role="menuitem"
             tabindex="-1"
           >
@@ -2233,7 +2233,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Share"
+            data-menu-id="rc-menu-uuid-test-id-Share"
             role="menuitem"
             tabindex="-1"
           >
@@ -2288,7 +2288,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
             aria-describedby="test-id"
             aria-disabled="true"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-disabled"
-            data-menu-id="rc-menu-uuid-Archive"
+            data-menu-id="rc-menu-uuid-test-id-Archive"
             role="menuitem"
           >
             <span
@@ -2337,7 +2337,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-danger"
-            data-menu-id="rc-menu-uuid-deleteChat"
+            data-menu-id="rc-menu-uuid-test-id-deleteChat"
             role="menuitem"
             tabindex="-1"
           >
@@ -2435,7 +2435,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Rename"
+            data-menu-id="rc-menu-uuid-test-id-Rename"
             role="menuitem"
             tabindex="-1"
           >
@@ -2485,7 +2485,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Share"
+            data-menu-id="rc-menu-uuid-test-id-Share"
             role="menuitem"
             tabindex="-1"
           >
@@ -2540,7 +2540,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
             aria-describedby="test-id"
             aria-disabled="true"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-disabled"
-            data-menu-id="rc-menu-uuid-Archive"
+            data-menu-id="rc-menu-uuid-test-id-Archive"
             role="menuitem"
           >
             <span
@@ -2589,7 +2589,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-danger"
-            data-menu-id="rc-menu-uuid-deleteChat"
+            data-menu-id="rc-menu-uuid-test-id-deleteChat"
             role="menuitem"
             tabindex="-1"
           >
@@ -2687,7 +2687,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Rename"
+            data-menu-id="rc-menu-uuid-test-id-Rename"
             role="menuitem"
             tabindex="-1"
           >
@@ -2737,7 +2737,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item"
-            data-menu-id="rc-menu-uuid-Share"
+            data-menu-id="rc-menu-uuid-test-id-Share"
             role="menuitem"
             tabindex="-1"
           >
@@ -2792,7 +2792,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
             aria-describedby="test-id"
             aria-disabled="true"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-disabled"
-            data-menu-id="rc-menu-uuid-Archive"
+            data-menu-id="rc-menu-uuid-test-id-Archive"
             role="menuitem"
           >
             <span
@@ -2841,7 +2841,7 @@ exports[`renders components/conversations/demo/with-menu.tsx extend context corr
           <li
             aria-describedby="test-id"
             class="ant-dropdown-menu-item ant-dropdown-menu-item-danger"
-            data-menu-id="rc-menu-uuid-deleteChat"
+            data-menu-id="rc-menu-uuid-test-id-deleteChat"
             role="menuitem"
             tabindex="-1"
           >

--- a/packages/x/components/sender/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/packages/x/components/sender/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -124,7 +124,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Campus"
+                data-menu-id="rc-menu-uuid-test-id-Campus"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -155,7 +155,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Travel"
+                data-menu-id="rc-menu-uuid-test-id-Travel"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -186,7 +186,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Reading"
+                data-menu-id="rc-menu-uuid-test-id-Reading"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -380,7 +380,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item"
-                data-menu-id="rc-menu-uuid-deep_search"
+                data-menu-id="rc-menu-uuid-test-id-deep_search"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -430,7 +430,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item"
-                data-menu-id="rc-menu-uuid-ai_code"
+                data-menu-id="rc-menu-uuid-test-id-ai_code"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -480,7 +480,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-selected"
-                data-menu-id="rc-menu-uuid-ai_writing"
+                data-menu-id="rc-menu-uuid-test-id-ai_writing"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -583,7 +583,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item"
-                data-menu-id="rc-menu-uuid-file_image"
+                data-menu-id="rc-menu-uuid-test-id-file_image"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -829,7 +829,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-校园"
+                data-menu-id="rc-menu-uuid-test-id-校园"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -860,7 +860,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-旅行"
+                data-menu-id="rc-menu-uuid-test-id-旅行"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -891,7 +891,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-阅读"
+                data-menu-id="rc-menu-uuid-test-id-阅读"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -1087,7 +1087,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item"
-                data-menu-id="rc-menu-uuid-deep_search"
+                data-menu-id="rc-menu-uuid-test-id-deep_search"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -1137,7 +1137,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item"
-                data-menu-id="rc-menu-uuid-ai_code"
+                data-menu-id="rc-menu-uuid-test-id-ai_code"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -1187,7 +1187,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-selected"
-                data-menu-id="rc-menu-uuid-ai_writing"
+                data-menu-id="rc-menu-uuid-test-id-ai_writing"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -1290,7 +1290,7 @@ exports[`renders components/sender/demo/agent.tsx extend context correctly 1`] =
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item"
-                data-menu-id="rc-menu-uuid-file_image"
+                data-menu-id="rc-menu-uuid-test-id-file_image"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -1847,7 +1847,7 @@ exports[`renders components/sender/demo/disable-ctrl-slot.tsx extend context cor
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-AI"
+                data-menu-id="rc-menu-uuid-test-id-AI"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -1878,7 +1878,7 @@ exports[`renders components/sender/demo/disable-ctrl-slot.tsx extend context cor
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Technology"
+                data-menu-id="rc-menu-uuid-test-id-Technology"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -1909,7 +1909,7 @@ exports[`renders components/sender/demo/disable-ctrl-slot.tsx extend context cor
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Entertainment"
+                data-menu-id="rc-menu-uuid-test-id-Entertainment"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3434,7 +3434,7 @@ exports[`renders components/sender/demo/slot-filling.tsx extend context correctl
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-selected ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-airplane"
+                data-menu-id="rc-menu-uuid-test-id-airplane"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3465,7 +3465,7 @@ exports[`renders components/sender/demo/slot-filling.tsx extend context correctl
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-high-speed rail"
+                data-menu-id="rc-menu-uuid-test-id-high-speed rail"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3496,7 +3496,7 @@ exports[`renders components/sender/demo/slot-filling.tsx extend context correctl
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-cruise ship"
+                data-menu-id="rc-menu-uuid-test-id-cruise ship"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3538,7 +3538,7 @@ exports[`renders components/sender/demo/slot-filling.tsx extend context correctl
           data-slot-key="priceRange"
         >
           <div
-            style="width: 200px; display: inline-block; align-items: center;"
+            style="width: 200px; padding-inline: 20px; display: inline-block; align-items: center;"
           >
             <div
               class="ant-slider css-var-_r_1t_ ant-slider-horizontal"
@@ -3807,7 +3807,7 @@ exports[`renders components/sender/demo/slot-format-result.tsx extend context co
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-selected ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-English"
+                data-menu-id="rc-menu-uuid-test-id-English"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3838,7 +3838,7 @@ exports[`renders components/sender/demo/slot-format-result.tsx extend context co
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Chinese"
+                data-menu-id="rc-menu-uuid-test-id-Chinese"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3869,7 +3869,7 @@ exports[`renders components/sender/demo/slot-format-result.tsx extend context co
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Japanese"
+                data-menu-id="rc-menu-uuid-test-id-Japanese"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3956,7 +3956,7 @@ exports[`renders components/sender/demo/slot-format-result.tsx extend context co
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-English"
+                data-menu-id="rc-menu-uuid-test-id-English"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -3987,7 +3987,7 @@ exports[`renders components/sender/demo/slot-format-result.tsx extend context co
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-selected ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Chinese"
+                data-menu-id="rc-menu-uuid-test-id-Chinese"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -4018,7 +4018,7 @@ exports[`renders components/sender/demo/slot-format-result.tsx extend context co
               <li
                 aria-describedby="test-id"
                 class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                data-menu-id="rc-menu-uuid-Japanese"
+                data-menu-id="rc-menu-uuid-test-id-Japanese"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -4181,7 +4181,7 @@ exports[`renders components/sender/demo/slot-with-suggestion.tsx extend context 
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                  data-menu-id="rc-menu-uuid-AI"
+                  data-menu-id="rc-menu-uuid-test-id-AI"
                   role="menuitem"
                   tabindex="-1"
                 >
@@ -4212,7 +4212,7 @@ exports[`renders components/sender/demo/slot-with-suggestion.tsx extend context 
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                  data-menu-id="rc-menu-uuid-Technology"
+                  data-menu-id="rc-menu-uuid-test-id-Technology"
                   role="menuitem"
                   tabindex="-1"
                 >
@@ -4243,7 +4243,7 @@ exports[`renders components/sender/demo/slot-with-suggestion.tsx extend context 
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
-                  data-menu-id="rc-menu-uuid-Entertainment"
+                  data-menu-id="rc-menu-uuid-test-id-Entertainment"
                   role="menuitem"
                   tabindex="-1"
                 >
@@ -4416,7 +4416,7 @@ exports[`renders components/sender/demo/slot-with-suggestion.tsx extend context 
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item ant-dropdown-menu-item-selected"
-                  data-menu-id="rc-menu-uuid-deep_search"
+                  data-menu-id="rc-menu-uuid-test-id-deep_search"
                   role="menuitem"
                   tabindex="-1"
                 >
@@ -4466,7 +4466,7 @@ exports[`renders components/sender/demo/slot-with-suggestion.tsx extend context 
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item"
-                  data-menu-id="rc-menu-uuid-ai_code"
+                  data-menu-id="rc-menu-uuid-test-id-ai_code"
                   role="menuitem"
                   tabindex="-1"
                 >
@@ -4516,7 +4516,7 @@ exports[`renders components/sender/demo/slot-with-suggestion.tsx extend context 
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item"
-                  data-menu-id="rc-menu-uuid-ai_writing"
+                  data-menu-id="rc-menu-uuid-test-id-ai_writing"
                   role="menuitem"
                   tabindex="-1"
                 >
@@ -4619,7 +4619,7 @@ exports[`renders components/sender/demo/slot-with-suggestion.tsx extend context 
                 <li
                   aria-describedby="test-id"
                   class="ant-dropdown-menu-item"
-                  data-menu-id="rc-menu-uuid-file_image"
+                  data-menu-id="rc-menu-uuid-test-id-file_image"
                   role="menuitem"
                   tabindex="-1"
                 >

--- a/packages/x/components/suggestion/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/packages/x/components/suggestion/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -836,7 +836,6 @@ Array [
         >
           <div
             class="ant-select-placeholder"
-            style="visibility: visible;"
           >
             可任意输入 / 与 # 多次获取建议
           </div>

--- a/packages/x/components/suggestion/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/x/components/suggestion/__tests__/__snapshots__/demo.test.ts.snap
@@ -185,7 +185,6 @@ exports[`renders components/suggestion/demo/trigger.tsx correctly 1`] = `
       >
         <div
           class="ant-select-placeholder"
-          style="visibility:visible"
         >
           可任意输入 / 与 # 多次获取建议
         </div>


### PR DESCRIPTION
### 修改内容

- 基于 CI 使用的最新依赖重新生成完整组件测试快照
- 更新 Actions、Attachments、Conversations、Sender 中 antd 菜单标识的变化
- 更新 Suggestion 中 Select placeholder 内联样式的变化
- 更新 Sender 中 Slider 新增的 `padding-inline` 样式

### 背景

`main` 分支 CI 安装到 `antd@6.6.3` 后，已有快照仍对应旧版依赖的渲染结果，导致快照测试失败。该修改与 Folder 功能修复独立。

### 验证

- 使用与 CI 一致的依赖安装方式：`ut install --ignore-scripts`
- 本地依赖：`antd@6.6.3`、`@ant-design/icons@6.3.4`
- `npm test --workspace packages/x -- --runInBand`：71 个测试套件通过，1074 个测试通过，313 个快照通过
- `git diff --check` 通过